### PR TITLE
Tolerate tag version equal to the in-repo version when stamping

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,10 +190,10 @@ jobs:
           V="${TAG#v}"
           grep -q 'export const VERSION = "' packages/core/src/index.ts
           sed -i "s/export const VERSION = \"[^\"]*\"/export const VERSION = \"$V\"/" packages/core/src/index.ts
-          (cd packages/skills && npm version --no-git-tag-version "$V")
-          (cd packages/core && npm version --no-git-tag-version "$V")
-          (cd packages/server && npm version --no-git-tag-version "$V")
-          (cd packages/cli && npm version --no-git-tag-version "$V")
+          (cd packages/skills && npm version --no-git-tag-version --allow-same-version "$V")
+          (cd packages/core && npm version --no-git-tag-version --allow-same-version "$V")
+          (cd packages/server && npm version --no-git-tag-version --allow-same-version "$V")
+          (cd packages/cli && npm version --no-git-tag-version --allow-same-version "$V")
 
       # Dependency order: cli bundles core's dist (tsup noExternal), server/web need core's types;
       # web is built here only to be copied into the server package below.


### PR DESCRIPTION
The publish-npm job's Stamp step runs `npm version <tag-version>`, which exits 1 with **Version not changed** when the tag equals the in-repo version — exactly what happened on `v0.0.1` (first release; repo dev version and tag coincide). Add `--allow-same-version` so stamping becomes a no-op in that case and the run proceeds to the idempotent publish loop.

The four packages are already live on npm at 0.0.1 (bootstrap-published); after this merges, a `workflow_dispatch` of Release with tag `v0.0.1` will go green via the idempotent skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ihk8iQuo3kv2aPjAYEPuR