### PR TITLE
[fix(web)] localize copied task-stats line instead of hardcoded Chinese

### DIFF
--- a/packages/web/src/features/chat/task-stats-line.tsx
+++ b/packages/web/src/features/chat/task-stats-line.tsx
@@ -78,6 +78,8 @@ export function TaskStatsLine({
             input: S.chat.statInput,
             cached: S.chat.statCached,
             output: S.chat.statOutput,
+            parenOpen: S.chat.statParenOpen,
+            parenClose: S.chat.statParenClose,
           });
     void navigator.clipboard?.writeText(text).then(() => {
       setCopied(true);

--- a/packages/web/src/features/chat/task-stats-line.tsx
+++ b/packages/web/src/features/chat/task-stats-line.tsx
@@ -71,7 +71,14 @@ export function TaskStatsLine({
 
   const copy = () => {
     const text =
-      assistantText?.trim() || stats === null ? (assistantText ?? "") : formatTaskStats(stats);
+      assistantText?.trim() || stats === null
+        ? (assistantText ?? "")
+        : formatTaskStats(stats, {
+            stats: S.chat.statsLabel,
+            input: S.chat.statInput,
+            cached: S.chat.statCached,
+            output: S.chat.statOutput,
+          });
     void navigator.clipboard?.writeText(text).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);

--- a/packages/web/src/lib/omni/task-stats.ts
+++ b/packages/web/src/lib/omni/task-stats.ts
@@ -297,18 +297,23 @@ export interface TaskStatsLabels {
   cached: string;
   /** Output-tokens label, e.g. "Output tokens" / "输出 tokens". */
   output: string;
+  /** Opening wrapper before the cached amount — keeps per-locale typography (e.g. " (" / "（"). */
+  parenOpen: string;
+  /** Closing wrapper after the cached amount (e.g. ")" / "）"). */
+  parenClose: string;
 }
 
 /**
  * Stats row text (copy fallback / used when there's no body text): same basis as the stats row —
  * this round's usage "input tokens (including cached amount) · output tokens · output TPS", e.g.
- * `[Stats] Input tokens 4k (cached 3k) · Output tokens 1.2k · 42.5 tok/s`. Labels come from the
- * caller's active locale dictionary so the copied text matches the UI language.
+ * `[Stats] Input tokens 4k (cached 3k) · Output tokens 1.2k · 42.5 tok/s`. Labels (including the
+ * parenthesis wrappers) come from the caller's active locale dictionary, so the copied text keeps
+ * per-locale typography — ASCII `(…)` in English, fullwidth `（…）` in Chinese.
  */
 export function formatTaskStats(s: TaskStats, labels: TaskStatsLabels): string {
   const b = s.tokensByBucket;
   return (
-    `[${labels.stats}] ${labels.input} ${humanizeTokens(b.cacheRead + b.cacheWrite)} (${labels.cached} ${humanizeTokens(b.cacheRead)})` +
+    `[${labels.stats}] ${labels.input} ${humanizeTokens(b.cacheRead + b.cacheWrite)}${labels.parenOpen}${labels.cached} ${humanizeTokens(b.cacheRead)}${labels.parenClose}` +
     ` · ${labels.output} ${humanizeTokens(b.output)}` +
     ` · ${formatTps(s.outputTps)}`
   );

--- a/packages/web/src/lib/omni/task-stats.ts
+++ b/packages/web/src/lib/omni/task-stats.ts
@@ -287,17 +287,29 @@ export function endTask(t: TaskStatsTracker, elapsedMs: number): TaskStats | nul
   return stats;
 }
 
+/** Localized labels for {@link formatTaskStats} (supplied by the view layer's active dictionary). */
+export interface TaskStatsLabels {
+  /** Row prefix, e.g. "Stats" / "统计信息". */
+  stats: string;
+  /** Input-tokens label, e.g. "Input tokens" / "输入 tokens". */
+  input: string;
+  /** Cached-amount label, e.g. "cached" / "已缓存". */
+  cached: string;
+  /** Output-tokens label, e.g. "Output tokens" / "输出 tokens". */
+  output: string;
+}
+
 /**
  * Stats row text (copy fallback / used when there's no body text): same basis as the stats row —
  * this round's usage "input tokens (including cached amount) · output tokens · output TPS", e.g.
- * `[统计信息] 输入 tokens 4k（已缓存 3k） · 输出 tokens 1.2k · 42.5 tok/s`; label can be overridden
- * per UI locale.
+ * `[Stats] Input tokens 4k (cached 3k) · Output tokens 1.2k · 42.5 tok/s`. Labels come from the
+ * caller's active locale dictionary so the copied text matches the UI language.
  */
-export function formatTaskStats(s: TaskStats, label = "统计信息"): string {
+export function formatTaskStats(s: TaskStats, labels: TaskStatsLabels): string {
   const b = s.tokensByBucket;
   return (
-    `[${label}] 输入 tokens ${humanizeTokens(b.cacheRead + b.cacheWrite)}（已缓存 ${humanizeTokens(b.cacheRead)}）` +
-    ` · 输出 tokens ${humanizeTokens(b.output)}` +
+    `[${labels.stats}] ${labels.input} ${humanizeTokens(b.cacheRead + b.cacheWrite)} (${labels.cached} ${humanizeTokens(b.cacheRead)})` +
+    ` · ${labels.output} ${humanizeTokens(b.output)}` +
     ` · ${formatTps(s.outputTps)}`
   );
 }

--- a/packages/web/src/lib/strings-en.ts
+++ b/packages/web/src/lib/strings-en.ts
@@ -531,6 +531,9 @@ export const en: Strings = {
     statCached: "cached",
     statOutput: "Output tokens",
     statTps: "Output TPS",
+    /** Copied-stats-line parenthesis wrappers around the cached amount (ASCII with a leading space for en). */
+    statParenOpen: " (",
+    statParenClose: ")",
     noSessions: "No Sessions yet",
     emptyStream: "Send a message to start the conversation",
     historyLoadFailed: "Failed to load history",

--- a/packages/web/src/lib/strings-en.ts
+++ b/packages/web/src/lib/strings-en.ts
@@ -528,6 +528,7 @@ export const en: Strings = {
     statCost: "Cost",
     statElapsed: "Elapsed",
     statInput: "Input tokens",
+    statCached: "cached",
     statOutput: "Output tokens",
     statTps: "Output TPS",
     noSessions: "No Sessions yet",

--- a/packages/web/src/lib/strings.ts
+++ b/packages/web/src/lib/strings.ts
@@ -506,6 +506,7 @@ export const zh = {
     statCost: "成本",
     statElapsed: "用时",
     statInput: "输入 tokens",
+    statCached: "已缓存",
     statOutput: "输出 tokens",
     statTps: "输出 TPS",
     noSessions: "还没有 Session",

--- a/packages/web/src/lib/strings.ts
+++ b/packages/web/src/lib/strings.ts
@@ -509,6 +509,9 @@ export const zh = {
     statCached: "已缓存",
     statOutput: "输出 tokens",
     statTps: "输出 TPS",
+    /** Copied-stats-line parenthesis wrappers around the cached amount (fullwidth for zh typography). */
+    statParenOpen: "（",
+    statParenClose: "）",
     noSessions: "还没有 Session",
     emptyStream: "发送一条消息开始对话",
     historyLoadFailed: "历史消息加载失败",

--- a/packages/web/test/task-stats.test.ts
+++ b/packages/web/test/task-stats.test.ts
@@ -200,12 +200,16 @@ describe("formatTaskStats", () => {
     input: "Input tokens",
     cached: "cached",
     output: "Output tokens",
+    parenOpen: " (",
+    parenClose: ")",
   };
   const ZH_LABELS = {
     stats: "统计信息",
     input: "输入 tokens",
     cached: "已缓存",
     output: "输出 tokens",
+    parenOpen: "（",
+    parenClose: "）",
   };
 
   it("the convention is this round's usage \"input (cached) · output · output TPS\", taking this Task's three-bucket usage + this Task's TPS", () => {
@@ -259,6 +263,6 @@ describe("formatTaskStats", () => {
         },
         ZH_LABELS,
       ),
-    ).toBe("[统计信息] 输入 tokens 4k (已缓存 3k) · 输出 tokens 1.2k · 42.5 tok/s");
+    ).toBe("[统计信息] 输入 tokens 4k（已缓存 3k） · 输出 tokens 1.2k · 42.5 tok/s");
   });
 });

--- a/packages/web/test/task-stats.test.ts
+++ b/packages/web/test/task-stats.test.ts
@@ -195,33 +195,70 @@ describe("TaskStatsTracker", () => {
 });
 
 describe("formatTaskStats", () => {
-  it("the convention is this round's usage \"输入（已缓存）· 输出 · 输出 TPS\", taking this Task's three-bucket usage + this Task's TPS", () => {
+  const EN_LABELS = {
+    stats: "Stats",
+    input: "Input tokens",
+    cached: "cached",
+    output: "Output tokens",
+  };
+  const ZH_LABELS = {
+    stats: "统计信息",
+    input: "输入 tokens",
+    cached: "已缓存",
+    output: "输出 tokens",
+  };
+
+  it("the convention is this round's usage \"input (cached) · output · output TPS\", taking this Task's three-bucket usage + this Task's TPS", () => {
     expect(
-      formatTaskStats({
-        context: 40000, // context usage isn't in the stats row (shown by the input-box ring instead)
-        contextDelta: 1000,
-        tokens: 60000,
-        tokensDelta: 1200,
-        elapsedMs: 5100,
-        elapsedDeltaMs: 2300,
-        tokensByBucket: { cacheRead: 3000, cacheWrite: 1000, output: 1200 },
-        outputTps: 42.5,
-      }),
-    ).toBe("[统计信息] 输入 tokens 4k（已缓存 3k） · 输出 tokens 1.2k · 42.5 tok/s");
+      formatTaskStats(
+        {
+          context: 40000, // context usage isn't in the stats row (shown by the input-box ring instead)
+          contextDelta: 1000,
+          tokens: 60000,
+          tokensDelta: 1200,
+          elapsedMs: 5100,
+          elapsedDeltaMs: 2300,
+          tokensByBucket: { cacheRead: 3000, cacheWrite: 1000, output: 1200 },
+          outputTps: 42.5,
+        },
+        EN_LABELS,
+      ),
+    ).toBe("[Stats] Input tokens 4k (cached 3k) · Output tokens 1.2k · 42.5 tok/s");
   });
 
   it("TPS shows — without LLM timing", () => {
     expect(
-      formatTaskStats({
-        context: 500,
-        contextDelta: 0,
-        tokens: 500,
-        tokensDelta: 500,
-        elapsedMs: 900,
-        elapsedDeltaMs: 900,
-        tokensByBucket: { cacheRead: 500, cacheWrite: 0, output: 0 },
-        outputTps: null,
-      }),
-    ).toBe("[统计信息] 输入 tokens 500（已缓存 500） · 输出 tokens 0 · —");
+      formatTaskStats(
+        {
+          context: 500,
+          contextDelta: 0,
+          tokens: 500,
+          tokensDelta: 500,
+          elapsedMs: 900,
+          elapsedDeltaMs: 900,
+          tokensByBucket: { cacheRead: 500, cacheWrite: 0, output: 0 },
+          outputTps: null,
+        },
+        EN_LABELS,
+      ),
+    ).toBe("[Stats] Input tokens 500 (cached 500) · Output tokens 0 · —");
+  });
+
+  it("renders with the supplied locale labels (zh)", () => {
+    expect(
+      formatTaskStats(
+        {
+          context: 40000,
+          contextDelta: 1000,
+          tokens: 60000,
+          tokensDelta: 1200,
+          elapsedMs: 5100,
+          elapsedDeltaMs: 2300,
+          tokensByBucket: { cacheRead: 3000, cacheWrite: 1000, output: 1200 },
+          outputTps: 42.5,
+        },
+        ZH_LABELS,
+      ),
+    ).toBe("[统计信息] 输入 tokens 4k (已缓存 3k) · 输出 tokens 1.2k · 42.5 tok/s");
   });
 });


### PR DESCRIPTION
## Summary
  - `formatTaskStats` hardcoded its entire output in Chinese (`统计信息`, `输入 tokens`, `已缓存`, `输出 tokens`), and its only caller in
  `task-stats-line.tsx` passed no label — so after the repo switched to English as the working language (#5), English users still got Chinese text whenever they copied a reply's stats line.
  - The function now takes a `labels` object supplied by the active locale dictionary, keeping it a pure, locale-agnostic formatter.
  - Adds a `statCached` string to both the `zh` and `en` dictionaries; the existing `statsLabel` / `statInput` / `statOutput` keys are reused.

## Test plan
  - [x] `pnpm --filter @prismshadow/penguin-web typecheck`
  - [x] `pnpm --filter @prismshadow/penguin-web test` (288 passed, includes
  updated `task-stats.test.ts` with en + zh label cases)
  - [x] `pnpm exec prettier --check` on changed files
