### PR TITLE
fix(server): validate positiveIntParam and optionalDateParam inputs

### DIFF
--- a/packages/server/src/http/validate.ts
+++ b/packages/server/src/http/validate.ts
@@ -166,8 +166,20 @@ export function optionalNumber(
 /** Validate a yyyy-mm-dd query parameter (defaults to undefined). */
 export function optionalDateParam(value: string | undefined, label: string): string | undefined {
   if (value === undefined || value === "") return undefined;
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
-    throw badRequest(`${label} must be in YYYY-MM-DD format.`);
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  // The shape check alone accepts impossible dates (2026-13-40, 2026-02-30); verify it's a real
+  // calendar day by round-tripping through UTC (which never rolls over into an adjacent month).
+  if (m) {
+    const [, y, mo, d] = m;
+    const dt = new Date(`${value}T00:00:00Z`);
+    if (
+      !Number.isNaN(dt.getTime()) &&
+      dt.getUTCFullYear() === Number(y) &&
+      dt.getUTCMonth() + 1 === Number(mo) &&
+      dt.getUTCDate() === Number(d)
+    ) {
+      return value;
+    }
   }
-  return value;
+  throw badRequest(`${label} must be a valid date in YYYY-MM-DD format.`);
 }

--- a/packages/server/src/http/validate.ts
+++ b/packages/server/src/http/validate.ts
@@ -42,7 +42,10 @@ export function requireValidId(c: Context, name: string): string {
 
 /** Parse a positive-integer path parameter (e.g. Trace file index). */
 export function positiveIntParam(c: Context, name: string): number {
-  const v = Number.parseInt(pathParam(c, name), 10);
+  // Match digits only: Number.parseInt would accept trailing garbage ("12abc" -> 12).
+  const raw = pathParam(c, name);
+  if (!/^\d+$/.test(raw)) throw badRequest(`${name} must be a positive integer.`);
+  const v = Number.parseInt(raw, 10);
   if (!Number.isInteger(v) || v < 1) throw badRequest(`${name} must be a positive integer.`);
   return v;
 }

--- a/packages/server/src/http/validate.ts
+++ b/packages/server/src/http/validate.ts
@@ -46,7 +46,9 @@ export function positiveIntParam(c: Context, name: string): number {
   const raw = pathParam(c, name);
   if (!/^\d+$/.test(raw)) throw badRequest(`${name} must be a positive integer.`);
   const v = Number.parseInt(raw, 10);
-  if (!Number.isInteger(v) || v < 1) throw badRequest(`${name} must be a positive integer.`);
+  // isSafeInteger (not isInteger) also rejects overlong indices like "99999999999999999999"
+  // that would otherwise parse to an imprecise float (1e20).
+  if (!Number.isSafeInteger(v) || v < 1) throw badRequest(`${name} must be a positive integer.`);
   return v;
 }
 

--- a/packages/server/test/validate.test.ts
+++ b/packages/server/test/validate.test.ts
@@ -1,10 +1,10 @@
 /**
- * Request-validation helper unit tests: positiveIntParam rejects trailing garbage that
- * Number.parseInt would otherwise accept.
+ * Request-validation helper unit tests: positiveIntParam rejects trailing garbage, and
+ * optionalDateParam rejects impossible calendar dates (shape-only checks let these through).
  */
 import { describe, expect, it } from "vitest";
 import type { Context } from "hono";
-import { positiveIntParam } from "../src/http/validate.js";
+import { optionalDateParam, positiveIntParam } from "../src/http/validate.js";
 import { HttpError } from "../src/http/errors.js";
 
 /** Minimal Context stub exposing a single path parameter. */
@@ -29,5 +29,29 @@ describe("positiveIntParam", () => {
 
   it("rejects zero (must be >= 1)", () => {
     expect(() => positiveIntParam(ctxWithParam("idx", "0"), "idx")).toThrow(HttpError);
+  });
+});
+
+describe("optionalDateParam", () => {
+  it("returns undefined for missing or empty input", () => {
+    expect(optionalDateParam(undefined, "from")).toBeUndefined();
+    expect(optionalDateParam("", "from")).toBeUndefined();
+  });
+
+  it("accepts a real calendar date", () => {
+    expect(optionalDateParam("2026-07-20", "from")).toBe("2026-07-20");
+    expect(optionalDateParam("2024-02-29", "from")).toBe("2024-02-29"); // leap day
+  });
+
+  it("rejects malformed shapes", () => {
+    for (const bad of ["2026/07/20", "20260720", "2026-7-20", "not-a-date"]) {
+      expect(() => optionalDateParam(bad, "from")).toThrow(HttpError);
+    }
+  });
+
+  it("rejects impossible dates that pass the shape check", () => {
+    for (const bad of ["2026-13-40", "2026-02-30", "2026-00-10", "2026-01-00", "2025-02-29"]) {
+      expect(() => optionalDateParam(bad, "from")).toThrow(HttpError);
+    }
   });
 });

--- a/packages/server/test/validate.test.ts
+++ b/packages/server/test/validate.test.ts
@@ -22,13 +22,23 @@ describe("positiveIntParam", () => {
   });
 
   it("rejects a leading sign, whitespace, and non-digits", () => {
-    for (const bad of ["+1", " 1", "1 ", "1.5", "0x10", ""]) {
+    for (const bad of ["+1", " 1", "1 ", "1.5", "0x10"]) {
       expect(() => positiveIntParam(ctxWithParam("idx", bad), "idx")).toThrow(HttpError);
     }
   });
 
   it("rejects zero (must be >= 1)", () => {
     expect(() => positiveIntParam(ctxWithParam("idx", "0"), "idx")).toThrow(HttpError);
+  });
+
+  it("rejects overlong indices that would parse to an imprecise float", () => {
+    // "99999999999999999999" parses to 1e20 — isSafeInteger rejects it, isInteger would not.
+    expect(() => positiveIntParam(ctxWithParam("idx", "9".repeat(20)), "idx")).toThrow(HttpError);
+  });
+
+  it("an empty/missing path param is rejected upstream by pathParam (404), not the digits guard", () => {
+    expect(() => positiveIntParam(ctxWithParam("idx", ""), "idx")).toThrow(HttpError);
+    expect(() => positiveIntParam(ctxWithParam("idx", undefined), "idx")).toThrow(HttpError);
   });
 });
 

--- a/packages/server/test/validate.test.ts
+++ b/packages/server/test/validate.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Request-validation helper unit tests: positiveIntParam rejects trailing garbage that
+ * Number.parseInt would otherwise accept.
+ */
+import { describe, expect, it } from "vitest";
+import type { Context } from "hono";
+import { positiveIntParam } from "../src/http/validate.js";
+import { HttpError } from "../src/http/errors.js";
+
+/** Minimal Context stub exposing a single path parameter. */
+function ctxWithParam(name: string, value: string | undefined): Context {
+  return { req: { param: (n: string) => (n === name ? value : undefined) } } as unknown as Context;
+}
+
+describe("positiveIntParam", () => {
+  it("parses a plain positive integer", () => {
+    expect(positiveIntParam(ctxWithParam("idx", "12"), "idx")).toBe(12);
+  });
+
+  it("rejects trailing garbage (parseInt would accept it)", () => {
+    expect(() => positiveIntParam(ctxWithParam("idx", "12abc"), "idx")).toThrow(HttpError);
+  });
+
+  it("rejects a leading sign, whitespace, and non-digits", () => {
+    for (const bad of ["+1", " 1", "1 ", "1.5", "0x10", ""]) {
+      expect(() => positiveIntParam(ctxWithParam("idx", bad), "idx")).toThrow(HttpError);
+    }
+  });
+
+  it("rejects zero (must be >= 1)", () => {
+    expect(() => positiveIntParam(ctxWithParam("idx", "0"), "idx")).toThrow(HttpError);
+  });
+});


### PR DESCRIPTION
## Summary
  - `positiveIntParam` used `Number.parseInt(..., 10)`, which returns `12` for
  `"12abc"` — a malformed path parameter (e.g. a Trace file index) silently passed validation. It now requires a digits-only string (`^\d+$`) before parsing.
  - `optionalDateParam`'s `YYYY-MM-DD` regex accepted impossible dates like `2026-13-40` or `2026-02-30`, letting malformed values flow into the usage query. It now round-trips the parsed components through UTC to confirm a real calendar day before accepting.

 ## Test plan
  - [x] `pnpm --filter @prismshadow/penguin-server typecheck`
  - [x] `pnpm --filter @prismshadow/penguin-server test` (270 passed, incl. new
  `validate.test.ts`: trailing garbage / signs / zero for ints; leap day,
  malformed shapes, and impossible dates for dates)
  - [x] `pnpm exec prettier --check` on changed files
