### PR TITLE
Ignore the local design symlink and agent instruction files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,8 @@ cache/
 # playwright e2e artifacts
 packages/web/test-results/
 packages/web/playwright-report/
+
+# local design-doc symlink and agent instructions
+/design
+/AGENTS.md
+/CLAUDE.md


### PR DESCRIPTION
Adds `/design`, `/AGENTS.md` and `/CLAUDE.md` to `.gitignore`.

None of the three are tracked: `design` is a symlink to the
penguin-harness-design checkout and `CLAUDE.md` is a symlink to
`AGENTS.md`. Until now they only ever showed up as untracked noise in
`git status`, which makes it easy to miss a real stray file.

No changelog entry: this changes no user-visible behaviour, interface or
build output, and `changelog/0.1.0/` is frozen as of today's release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAUo8J65AoY32416MsNgyy