### PR TITLE
fix(llm): omit empty tools and keep tool_choice off the wire

### DIFF
--- a/packages/core/src/llm/generative-model.ts
+++ b/packages/core/src/llm/generative-model.ts
@@ -1095,11 +1095,21 @@ export function toolDefinitionsToSchemas(tools: ToolDefinition[]): ToolSchema[] 
   }));
 }
 
-/** Pre-builds UniConfig from GenerativeModelConfig (called once at construction time). */
+/**
+ * Pre-builds UniConfig from GenerativeModelConfig (called once at construction time).
+ *
+ * When the tool list is empty (connectivity probe, bare/meta LLM, vision describer), `tools`
+ * is omitted entirely instead of set to `[]`: strict OpenAI-compatible servers (e.g. vLLM)
+ * reject an empty array with a 400 ("tools must not be an empty array"), and omission is the
+ * protocol equivalent. `tool_choice` is likewise never set — AgentHub only puts it on the wire
+ * when UniConfig defines it, and leaving it off preserves the protocol default ("auto" when
+ * tools are present).
+ */
 export function buildUniConfig(config: GenerativeModelConfig): UniConfig {
-  const uniConfig: UniConfig = {
-    tools: toolDefinitionsToSchemas(config.tools),
-  };
+  const uniConfig: UniConfig = {};
+  if (config.tools.length > 0) {
+    uniConfig.tools = toolDefinitionsToSchemas(config.tools);
+  }
   if (config.systemPrompt !== undefined) {
     uniConfig.system_prompt = config.systemPrompt;
   }

--- a/packages/core/test/llm.test.ts
+++ b/packages/core/test/llm.test.ts
@@ -1048,10 +1048,23 @@ describe("config helpers", () => {
     expect(cfg.tools).toEqual([{ name: "t", description: "d" }]);
 
     const minimal = buildUniConfig({ modelId: "m", tools: [] });
-    expect(minimal.tools).toEqual([]);
+    expect("tools" in minimal).toBe(false);
     expect("system_prompt" in minimal).toBe(false);
     expect("max_tokens" in minimal).toBe(false);
     expect("thinking_level" in minimal).toBe(false);
+  });
+
+  it("omits tools when empty and never sets tool_choice (strict endpoints reject both)", () => {
+    // Empty tool list (connectivity probe, bare/meta LLM, vision describer): the `tools` key
+    // must be absent, not `[]` — AgentHub forwards any defined array verbatim, and strict
+    // OpenAI-compatible servers (e.g. vLLM) reject `tools: []` with a 400.
+    const empty = buildUniConfig({ modelId: "m", tools: [] });
+    expect("tools" in empty).toBe(false);
+    // `tool_choice` must never be set: AgentHub only emits it on the wire when UniConfig
+    // defines it, and leaving it off preserves the protocol default.
+    expect("tool_choice" in empty).toBe(false);
+    const withTools = buildUniConfig({ modelId: "m", tools: [{ name: "t", description: "d" }] });
+    expect("tool_choice" in withTools).toBe(false);
   });
 });
 

--- a/packages/server/test/models.test.ts
+++ b/packages/server/test/models.test.ts
@@ -430,6 +430,46 @@ describe("模型引用改键与连通性测试", () => {
     }
   });
 
+  it("连通性测试请求体不含 tools 与 tool_choice（空工具列表整体省略，vLLM 等严格端点不再 400）", async () => {
+    // The probe runs with an empty tool list. The wire body must omit `tools` entirely —
+    // `tools: []` is rejected by strict OpenAI-compatible servers (vLLM: "tools must not be an
+    // empty array") — and must never carry `tool_choice`.
+    const bodies: Record<string, unknown>[] = [];
+    const server = createServer((req, res) => {
+      let raw = "";
+      req.on("data", (chunk: Buffer) => (raw += chunk.toString("utf8")));
+      req.on("end", () => {
+        try {
+          bodies.push(JSON.parse(raw) as Record<string, unknown>);
+        } catch {
+          bodies.push({});
+        }
+        res.statusCode = 401;
+        res.setHeader("content-type", "application/json");
+        res.end(JSON.stringify({ error: { message: "test-reject", type: "invalid_request" } }));
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const port = (server.address() as AddressInfo).port;
+    try {
+      const res = await api.post(testUrl(), {
+        provider: "custom",
+        modelId: "probe-wire-model",
+        clientType: "openai",
+        apiKey: "sk-test-local",
+        baseUrl: `http://127.0.0.1:${port}/v1`,
+      });
+      expect(res.status).toBe(200);
+      expect(bodies.length).toBeGreaterThan(0);
+      for (const body of bodies) {
+        expect("tools" in body).toBe(false);
+        expect("tool_choice" in body).toBe(false);
+      }
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
   it("连通性测试：已保存的模型与**尚未保存**的自定义模型都可测（LLM 层不抛异常，一律收敛）", async () => {
     await api.put(url(), {
       models: [{ provider: "openai", modelId: "gpt-5.5", apiKey: "sk-invalid-key-for-test" }],


### PR DESCRIPTION
## Problem

Against a local vLLM server (OpenAI-compatible endpoint serving Qwen3.5-27B), two 400s were reported:

1. The model connectivity test (连通性测试) fails with:

   > `400 validation error: tools must not be an empty array. Either provide at least one tool or omit the field entirely.`

   `buildUniConfig` (`packages/core/src/llm/generative-model.ts`) unconditionally set `UniConfig.tools`, even when the tool list is empty — and three call sites construct a tool-less `GenerativeModel`: the connectivity probe (`testModel` in `packages/server/src/services/project-config-service.ts`), the bare meta LLM (title generation), and the vision describer (both in `packages/core/src/agent.ts`). AgentHub's OpenAI client forwards any defined array verbatim, so the wire body carried `tools: []`, which strict endpoints reject.

2. Normal agent requests fail with:

   > `llm request error: 400 "auto" tool choice requires --enable-auto-tool-choice and --tool-call-parser to be set.`

## What changed

- `buildUniConfig` now omits `tools` from `UniConfig` entirely when the tool list is empty (`UniConfig.tools` is already optional). Omission is behavior-preserving: a request without a `tools` field is the OpenAI-protocol equivalent of "no tools", and this fixes the probe plus the meta/vision LLM requests in one place.
- For `tool_choice`, no code change turned out to be needed — the harness already never sends it (see the investigation below; omitting it is behavior-preserving since `"auto"` is the protocol default when tools are present). Two regression tests now lock that contract at both layers:
  - Unit: `buildUniConfig` with an empty tool list yields no `tools` key, and never a `tool_choice` key (`packages/core/test/llm.test.ts`).
  - Wire: the probe route, driven against a local OpenAI-compatible capture server, asserts the request body contains neither `tools` nor `tool_choice` (`packages/server/test/models.test.ts`).

## AgentHub investigation (`@prismshadow/agenthub`)

Findings from reading the installed dist (0.4.0) and verifying empirically with a local HTTP capture server driving `AutoLLMClient` (`clientType: "openai"`):

- `dist/openai/client.js` (`transformUniConfigToModelConfig`): `tools` is emitted iff `config.tools !== undefined` — so `[]` goes on the wire as `tools: []` while an absent field is omitted; `tool_choice` is emitted iff `config.tool_choice !== undefined`. No AgentHub client (openai / glm5_1 / kimi_k2_6 / deepseek_v4 / gpt5_5) hardcodes a `tool_choice` default, and `autoClient`/`baseClient` don't inject one.
- Capture-server results: `UniConfig{tools: []}` → body keys `messages, model, stream, stream_options, tools` with `tools: []` and no `tool_choice`; `UniConfig{tools:[oneTool]}` → `tools` present, still no `tool_choice`; `UniConfig{}` → neither key.
- This repo never sets `UniConfig.tool_choice` (no occurrence in the source or in git history), so requests already omit it. Leaving the optional `UniConfig.tool_choice` unset is the supported knob; no `pnpm patch` was needed.
- `npm view @prismshadow/agenthub versions` → `0.1.0 … 0.4.0`; 0.4.0 (published 2026-07-20) is the latest and is what the lockfile already pins. There is no newer version to bump to.
- The `"auto"` in failure 2 therefore comes from vLLM itself: when a request carries a non-empty `tools` array without `tool_choice`, vLLM's `ChatCompletionRequest` validator defaults it to `"auto"` server-side and then rejects unless vLLM was started with `--enable-auto-tool-choice --tool-call-parser <parser>`. Real agent tool use on vLLM requires those server flags regardless of the client; after this fix, tool-less requests (probe / title generation / vision describing) carry no tool fields at all and no longer trigger any tool validation.

## Verification

- `pnpm -r build` — pass
- `pnpm typecheck` — pass (all packages)
- `pnpm test` — all pass: core 373 passed | 2 skipped (pre-existing env-gated e2e), server 286, cli 119, web 312, docs 11, landing 12, skills 16
- `pnpm format` / `pnpm format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)