### PR TITLE
docs: list the built-in Skills in the READMEs and on the landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,22 @@ https://github.com/user-attachments/assets/9b7033e8-f08a-4c3f-bd33-547896664e6e
 
 **And generating this entire RAG app burned just $0.02 (¥0.2) of tokens — on DeepSeek V4 Pro.**
 
-Powering this is the built-in **AI App Development** Skill group — Penguin SDK, Penguin CLI and AgentHub model APIs, plus local model serving and fine-tuning (vLLM, Ollama, LLaMA-Factory) — so PenguinHarness can **build and tune AI applications** end to end, fully automatically.
-
 ### 3. 🧬 Self-evolution: it gets stronger with use
 
 With PenguinHarness Skills, an Agent evaluates and optimizes itself: run the benchmark, find the lost points, ship version N+1 — with a snapshot before every round, and every request observable in the Trace view.
 
 https://github.com/user-attachments/assets/922d13a6-5ffc-4685-9a39-352f02f9afc0
+
+## Built-in Skills
+
+Four Skill groups ship in the box ([docs](https://penguin.ooo/docs/skills)); Agents can also write and optimize their own:
+
+| Group                | Skills                                                                            |
+| -------------------- | --------------------------------------------------------------------------------- |
+| Office Productivity  | `data-analysis`, `firecrawl`                                                      |
+| Software Development | `web-design`, `software-engineering`                                              |
+| AI App Development   | `penguin-sdk`, `penguin-cli`, `agenthub-models`                                   |
+| Agent Tuning         | `agent-creation`, `benchmark-design`, `agent-evaluation`, `agent-optimization`    |
 
 ## Supported Models
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ https://github.com/user-attachments/assets/9b7033e8-f08a-4c3f-bd33-547896664e6e
 
 **And generating this entire RAG app burned just $0.02 (¥0.2) of tokens — on DeepSeek V4 Pro.**
 
+Powering this is the built-in **AI App Development** Skill group — Penguin SDK, Penguin CLI and AgentHub model APIs, plus local model serving and fine-tuning (vLLM, Ollama, LLaMA-Factory) — so PenguinHarness can **build and tune AI applications** end to end, fully automatically.
+
 ### 3. 🧬 Self-evolution: it gets stronger with use
 
 With PenguinHarness Skills, an Agent evaluates and optimizes itself: run the benchmark, find the lost points, ship version N+1 — with a snapshot before every round, and every request observable in the Trace view.

--- a/README.zh.md
+++ b/README.zh.md
@@ -60,13 +60,22 @@ https://github.com/user-attachments/assets/604eb626-0a5d-4a62-87e3-14ebade1cd5f
 
 **而生成整个 RAG 应用，仅消耗了 0.2 元（$0.02）的 token——使用 DeepSeek V4 Pro 模型。**
 
-这背后是内置的「**AI 应用开发**」Skill 组——Penguin SDK、Penguin CLI、AgentHub 模型调用，以及 vLLM / Ollama 本地部署与 LLaMA-Factory 微调——让 PenguinHarness 端到端**全自动构建和调优 AI 应用**。
-
 ### 3. 🧬 自进化，越用越强
 
 借助 PenguinHarness 技能库，Agent 自己评估、自己优化：跑 Benchmark、找失分点、发布 N+1 版——每轮之前自动快照，每个请求都可在轨迹观测中回放。
 
 https://github.com/user-attachments/assets/aec49ae9-b743-467b-b247-37bedfeaa36e
+
+## 内置 Skill 库
+
+开箱内置四组 Skill（[文档](https://penguin.ooo/docs/skills)），Agent 也能编写并优化自己的 Skill：
+
+| 分组        | Skill                                                                          |
+| ----------- | ------------------------------------------------------------------------------ |
+| 办公效率    | `data-analysis`、`firecrawl`                                                   |
+| 软件开发    | `web-design`、`software-engineering`                                           |
+| AI 应用开发 | `penguin-sdk`、`penguin-cli`、`agenthub-models`                                |
+| Agent 调优  | `agent-creation`、`benchmark-design`、`agent-evaluation`、`agent-optimization` |
 
 ## 支持的模型
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -60,6 +60,8 @@ https://github.com/user-attachments/assets/604eb626-0a5d-4a62-87e3-14ebade1cd5f
 
 **而生成整个 RAG 应用，仅消耗了 0.2 元（$0.02）的 token——使用 DeepSeek V4 Pro 模型。**
 
+这背后是内置的「**AI 应用开发**」Skill 组——Penguin SDK、Penguin CLI、AgentHub 模型调用，以及 vLLM / Ollama 本地部署与 LLaMA-Factory 微调——让 PenguinHarness 端到端**全自动构建和调优 AI 应用**。
+
 ### 3. 🧬 自进化，越用越强
 
 借助 PenguinHarness 技能库，Agent 自己评估、自己优化：跑 Benchmark、找失分点、发布 N+1 版——每轮之前自动快照，每个请求都可在轨迹观测中回放。

--- a/packages/landing/src/lib/strings-en.ts
+++ b/packages/landing/src/lib/strings-en.ts
@@ -85,7 +85,7 @@ export const en: Strings = {
       {
         title: "Harness for Building Agents",
         tag: "",
-        desc: "With the PenguinHarness SDK, an Agent builds complete Agent applications for you from scratch — and the AI App Development Skills make build-and-tune fully automatic.",
+        desc: "With the PenguinHarness SDK, an Agent builds complete Agent applications for you — autonomously, from scratch.",
       },
       {
         title: "Harness for Recursive Self-Improvement",
@@ -306,7 +306,7 @@ export const en: Strings = {
       },
       {
         title: "Skill library",
-        desc: "Built-in AI App Development Skills build and tune AI apps fully automatically — vLLM / Ollama deployment, LLaMA-Factory fine-tuning.",
+        desc: "Browse, install and quick-invoke Skills — Agents can write and optimize their own.",
       },
       {
         title: "Scheduled tasks",
@@ -331,6 +331,21 @@ export const en: Strings = {
       {
         title: "Multi-user management",
         desc: "Admins provision users; each gets an independent Project with isolated data.",
+      },
+    ],
+  },
+
+  skills: {
+    eyebrow: "Built-in Skills",
+    title: "The built-in Skill library at a glance",
+    subtitle: "Four Skill groups out of the box — Agents can write and optimize their own, too.",
+    groups: [
+      { title: "Office Productivity", skills: ["data-analysis", "firecrawl"] },
+      { title: "Software Development", skills: ["web-design", "software-engineering"] },
+      { title: "AI App Development", skills: ["penguin-sdk", "penguin-cli", "agenthub-models"] },
+      {
+        title: "Agent Tuning",
+        skills: ["agent-creation", "benchmark-design", "agent-evaluation", "agent-optimization"],
       },
     ],
   },

--- a/packages/landing/src/lib/strings-en.ts
+++ b/packages/landing/src/lib/strings-en.ts
@@ -85,7 +85,7 @@ export const en: Strings = {
       {
         title: "Harness for Building Agents",
         tag: "",
-        desc: "With the PenguinHarness SDK, an Agent builds complete Agent applications for you — autonomously, from scratch.",
+        desc: "With the PenguinHarness SDK, an Agent builds complete Agent applications for you from scratch — and the AI App Development Skills make build-and-tune fully automatic.",
       },
       {
         title: "Harness for Recursive Self-Improvement",
@@ -306,7 +306,7 @@ export const en: Strings = {
       },
       {
         title: "Skill library",
-        desc: "Browse, install and quick-invoke Skills — Agents can write and optimize their own.",
+        desc: "Built-in AI App Development Skills build and tune AI apps fully automatically — vLLM / Ollama deployment, LLaMA-Factory fine-tuning.",
       },
       {
         title: "Scheduled tasks",

--- a/packages/landing/src/lib/strings.ts
+++ b/packages/landing/src/lib/strings.ts
@@ -89,7 +89,7 @@ export const zh = {
       {
         title: "Harness for Building Agents",
         tag: "",
-        desc: "通过 PenguinHarness SDK，让 Agent 从零自主完成 Agent 应用的构建。",
+        desc: "通过 PenguinHarness SDK，让 Agent 从零自主完成 Agent 应用的构建；「AI 应用开发」Skill 组让构建和调优全自动。",
       },
       {
         title: "Harness for Recursive Self-Improvement",
@@ -300,7 +300,7 @@ export const zh = {
       },
       {
         title: "技能库",
-        desc: "浏览、安装、快捷调用 Skill，Agent 也能编写并优化自己的技能。",
+        desc: "内置「AI 应用开发」Skill 组，全自动构建和调优 AI 应用——vLLM / Ollama 部署、LLaMA-Factory 微调。",
       },
       {
         title: "定时任务",

--- a/packages/landing/src/lib/strings.ts
+++ b/packages/landing/src/lib/strings.ts
@@ -89,7 +89,7 @@ export const zh = {
       {
         title: "Harness for Building Agents",
         tag: "",
-        desc: "通过 PenguinHarness SDK，让 Agent 从零自主完成 Agent 应用的构建；「AI 应用开发」Skill 组让构建和调优全自动。",
+        desc: "通过 PenguinHarness SDK，让 Agent 从零自主完成 Agent 应用的构建。",
       },
       {
         title: "Harness for Recursive Self-Improvement",
@@ -300,7 +300,7 @@ export const zh = {
       },
       {
         title: "技能库",
-        desc: "内置「AI 应用开发」Skill 组，全自动构建和调优 AI 应用——vLLM / Ollama 部署、LLaMA-Factory 微调。",
+        desc: "浏览、安装、快捷调用 Skill，Agent 也能编写并优化自己的技能。",
       },
       {
         title: "定时任务",
@@ -325,6 +325,21 @@ export const zh = {
       {
         title: "多用户管理",
         desc: "管理员创建用户，各自拥有独立 Project，数据相互隔离。",
+      },
+    ],
+  },
+
+  skills: {
+    eyebrow: "内置 Skill",
+    title: "内置 Skill 库一览",
+    subtitle: "四组 Skill 开箱即用，Agent 也能编写并优化自己的 Skill。",
+    groups: [
+      { title: "办公效率", skills: ["data-analysis", "firecrawl"] },
+      { title: "软件开发", skills: ["web-design", "software-engineering"] },
+      { title: "AI 应用开发", skills: ["penguin-sdk", "penguin-cli", "agenthub-models"] },
+      {
+        title: "Agent 调优",
+        skills: ["agent-creation", "benchmark-design", "agent-evaluation", "agent-optimization"],
       },
     ],
   },

--- a/packages/landing/src/pages/home.tsx
+++ b/packages/landing/src/pages/home.tsx
@@ -8,6 +8,7 @@ import { Cases } from "../sections/cases";
 import { Benchmark } from "../sections/benchmark";
 import { Contract } from "../sections/contract";
 import { Features } from "../sections/features";
+import { Skills } from "../sections/skills";
 import { Security } from "../sections/security";
 import { Cta } from "../sections/cta";
 import { Community } from "../sections/community";
@@ -24,6 +25,7 @@ export function HomePage() {
       <Benchmark />
       <Contract />
       <Features />
+      <Skills />
       <Security />
       <Cta />
       <Community />

--- a/packages/landing/src/sections/skills.tsx
+++ b/packages/landing/src/sections/skills.tsx
@@ -1,0 +1,35 @@
+/** Built-in Skill library at a glance: the four Skill groups with their member Skills as chips. */
+import { S } from "../lib/strings";
+import { Section } from "../components/section";
+
+export function Skills() {
+  return (
+    <Section
+      id="skills"
+      eyebrow={S.skills.eyebrow}
+      title={S.skills.title}
+      subtitle={S.skills.subtitle}
+    >
+      <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
+        {S.skills.groups.map((group) => (
+          <article
+            key={group.title}
+            className="rounded-xl border border-gray-200 bg-white p-5 transition-colors hover:border-gray-300 dark:border-gray-800 dark:bg-gray-900 dark:hover:border-gray-700"
+          >
+            <h3 className="text-[15px] font-semibold tracking-tight">{group.title}</h3>
+            <ul className="mt-3 flex flex-wrap gap-1.5">
+              {group.skills.map((name) => (
+                <li
+                  key={name}
+                  className="rounded-full border border-gray-200 bg-gray-50 px-2.5 py-0.5 font-mono text-xs text-gray-600 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-400"
+                >
+                  {name}
+                </li>
+              ))}
+            </ul>
+          </article>
+        ))}
+      </div>
+    </Section>
+  );
+}


### PR DESCRIPTION
Reworked after review (see the review threads): instead of rewriting existing copy, this PR now adds a **separate compact section listing the currently shipped built-in Skills** in both READMEs and on the landing page. The first revision's claims about vLLM / Ollama deployment and LLaMA-Factory fine-tuning were reverted — those skills live in the still-open PR #19 (`feat/ai-app-deployment-skills`) and can be appended to these lists once it lands.

## Changes

- **README.md / README.zh.md** (structurally 1:1): new `## Built-in Skills` / `## 内置 Skill 库` section between "Why PenguinHarness" and "Supported Models" — one intro line plus the Group | Skills table (same shape as `packages/skills/README.md`), listing the four groups registered in `packages/skills/src/index.ts` (`office-productivity`, `software-development`, `ai-app-development`, `agent-tuning`).
- **Landing**: new `Skills` section (`packages/landing/src/sections/skills.tsx`, `id="skills"`, rendered between Features and Security) — four group cards with member-skill chips; strings added as `S.skills` to both dictionaries (`strings.ts` / `strings-en.ts`, type-synced via `Strings`). No changes to existing sections, nav, or copy.
- All first-revision copy edits reverted: the two README paragraphs are gone and the pillar card ("Harness for Building Agents") and feature card ("Skill library" / 技能库) descriptions are back to their original text.

New section copy:

> **Built-in Skills** — Four Skill groups ship in the box ([docs](https://penguin.ooo/docs/skills)); Agents can also write and optimize their own:
>
> **内置 Skill 库**——开箱内置四组 Skill（[文档](https://penguin.ooo/docs/skills)），Agent 也能编写并优化自己的 Skill：

## Verification

- `pnpm install --frozen-lockfile` (Node v24) — OK
- `pnpm -r build` — exit 0 (landing included)
- `pnpm typecheck` — all packages pass
- `pnpm test` — all suites pass
- `pnpm format` + `pnpm format:check` — all files (incl. both READMEs) pass Prettier

🤖 Generated with [Claude Code](https://claude.com/claude-code)
