### PR TITLE
feat(core): reserved-port and API-key guardrails in the default system prompt

### DIFF
--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -14,11 +14,12 @@
  * Docs: /docs/cli § "penguin server / penguin web".
  */
 import { spawn } from "node:child_process";
+import { DEFAULT_SERVER_PORT } from "@prismshadow/penguin-core";
 import type { Command } from "commander";
 import type { Messages } from "../i18n.js";
 
-/** Default service port (deliberately avoids common defaults like 3000/8080). */
-export const DEFAULT_PORT = 7364;
+/** Default service port — core's DEFAULT_SERVER_PORT (7364), the single source of truth. */
+export const DEFAULT_PORT = DEFAULT_SERVER_PORT;
 /** Default service listen host. */
 export const DEFAULT_HOST = "127.0.0.1";
 

--- a/packages/cli/test/serve.test.ts
+++ b/packages/cli/test/serve.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { Command } from "commander";
-import { DEFAULT_SERVER_PORT, RESERVED_PORTS } from "@prismshadow/penguin-core";
+import { DEFAULT_SERVER_PORT } from "@prismshadow/penguin-core";
 import {
   DEFAULT_HOST,
   DEFAULT_PORT,
@@ -12,9 +12,8 @@ import {
 import { getMessages } from "../src/i18n.js";
 
 describe("resolvePort (option > env var > default 7364)", () => {
-  it("derives DEFAULT_PORT from core's DEFAULT_SERVER_PORT (a reserved port)", () => {
+  it("derives DEFAULT_PORT from core's DEFAULT_SERVER_PORT", () => {
     expect(DEFAULT_PORT).toBe(DEFAULT_SERVER_PORT);
-    expect(RESERVED_PORTS).toContain(DEFAULT_PORT);
   });
   it("uses the default 7364 when neither is given", () => {
     expect(DEFAULT_PORT).toBe(7364);

--- a/packages/cli/test/serve.test.ts
+++ b/packages/cli/test/serve.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { Command } from "commander";
+import { DEFAULT_SERVER_PORT, RESERVED_PORTS } from "@prismshadow/penguin-core";
 import {
   DEFAULT_HOST,
   DEFAULT_PORT,
@@ -11,6 +12,10 @@ import {
 import { getMessages } from "../src/i18n.js";
 
 describe("resolvePort (option > env var > default 7364)", () => {
+  it("derives DEFAULT_PORT from core's DEFAULT_SERVER_PORT (a reserved port)", () => {
+    expect(DEFAULT_PORT).toBe(DEFAULT_SERVER_PORT);
+    expect(RESERVED_PORTS).toContain(DEFAULT_PORT);
+  });
   it("uses the default 7364 when neither is given", () => {
     expect(DEFAULT_PORT).toBe(7364);
     expect(resolvePort(undefined, undefined)).toBe(7364);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,7 +19,7 @@
 export * from "./omnimessage/index.js";
 export * from "./interfaces.js";
 
-// Reserved service ports (shared by CLI / server; interpolated into the default system prompt)
+// Reserved service ports (the default-port source of truth shared by CLI / server)
 export * from "./ports.js";
 
 // Submodules

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,9 @@
 export * from "./omnimessage/index.js";
 export * from "./interfaces.js";
 
+// Reserved service ports (shared by CLI / server; interpolated into the default system prompt)
+export * from "./ports.js";
+
 // Submodules
 export * from "./state/index.js";
 export * from "./llm/index.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,7 +19,7 @@
 export * from "./omnimessage/index.js";
 export * from "./interfaces.js";
 
-// Reserved service ports (the default-port source of truth shared by CLI / server)
+// Default server port (the single source of truth shared by CLI / server)
 export * from "./ports.js";
 
 // Submodules

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,8 +19,8 @@
 export * from "./omnimessage/index.js";
 export * from "./interfaces.js";
 
-// Default server port (the single source of truth shared by CLI / server)
-export * from "./ports.js";
+// Only the default server port leaves internal: the CLI / server default-port source of truth.
+export { DEFAULT_SERVER_PORT } from "./internal/ports.js";
 
 // Submodules
 export * from "./state/index.js";

--- a/packages/core/src/internal/ports.ts
+++ b/packages/core/src/internal/ports.ts
@@ -1,0 +1,10 @@
+/**
+ * Default PenguinHarness server port (internal shared constant; the barrel re-exports
+ * only DEFAULT_SERVER_PORT, as the CLI `penguin server` / `penguin web` and server
+ * default-port source of truth — previously each hardcoded the number). It is a
+ * fallback only: the `--port` flag and the PORT environment variable override it at
+ * runtime.
+ */
+
+/** Default main server / Web UI port; deliberately avoids common defaults like 3000/8080. */
+export const DEFAULT_SERVER_PORT = 7364;

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -1,0 +1,21 @@
+/**
+ * Reserved PenguinHarness service ports — the single source of truth for the ports our
+ * own services listen on.
+ *
+ * The CLI (`penguin server` / `penguin web`) and the server derive their default port
+ * from here. The vite dev configs (packages/web|landing|docs) cannot import core TS, so
+ * they hardcode the same numbers with a comment pointing back at this file. The full
+ * list is interpolated into the default system prompt so agents never kill processes
+ * listening on these ports.
+ */
+
+/** Default main server / Web UI port (`penguin server` / `penguin web`; deliberately avoids common defaults like 3000/8080). */
+export const DEFAULT_SERVER_PORT = 7364;
+
+/** Ports reserved for PenguinHarness's own services; never kill their listeners to free a port. */
+export const RESERVED_PORTS: readonly number[] = [
+  DEFAULT_SERVER_PORT, // main server / Web UI
+  7365, // web dev server (packages/web/vite.config.ts; proxies /api to the main server)
+  7366, // landing dev server (packages/landing/vite.config.ts)
+  7367, // docs dev server (packages/docs/vite.config.ts)
+];

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -1,21 +1,9 @@
 /**
- * Reserved PenguinHarness service ports — the single source of truth for the default
- * ports our own services listen on.
- *
- * The CLI (`penguin server` / `penguin web`) and the server derive their default port
- * from here; these are fallbacks only — the `--port` flag and the PORT environment
- * variable still override them at runtime. The vite dev configs (packages/web|landing|docs)
- * cannot import core TS, so they hardcode the same numbers with a comment pointing back
- * at this file.
+ * Default PenguinHarness server port — the single source of truth shared by the CLI
+ * (`penguin server` / `penguin web`) and the server, which previously each hardcoded
+ * the number. It is a fallback only: the `--port` flag and the PORT environment
+ * variable override it at runtime.
  */
 
-/** Default main server / Web UI port (`penguin server` / `penguin web`; deliberately avoids common defaults like 3000/8080). */
+/** Default main server / Web UI port; deliberately avoids common defaults like 3000/8080. */
 export const DEFAULT_SERVER_PORT = 7364;
-
-/** Default ports of PenguinHarness's own services; never kill their listeners or reuse the ports for other servers. */
-export const RESERVED_PORTS: readonly number[] = [
-  DEFAULT_SERVER_PORT, // main server / Web UI
-  7365, // web dev server (packages/web/vite.config.ts; proxies /api to the main server)
-  7366, // landing dev server (packages/landing/vite.config.ts)
-  7367, // docs dev server (packages/docs/vite.config.ts)
-];

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -1,9 +1,0 @@
-/**
- * Default PenguinHarness server port — the single source of truth shared by the CLI
- * (`penguin server` / `penguin web`) and the server, which previously each hardcoded
- * the number. It is a fallback only: the `--port` flag and the PORT environment
- * variable override it at runtime.
- */
-
-/** Default main server / Web UI port; deliberately avoids common defaults like 3000/8080. */
-export const DEFAULT_SERVER_PORT = 7364;

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -1,18 +1,18 @@
 /**
- * Reserved PenguinHarness service ports — the single source of truth for the ports our
- * own services listen on.
+ * Reserved PenguinHarness service ports — the single source of truth for the default
+ * ports our own services listen on.
  *
  * The CLI (`penguin server` / `penguin web`) and the server derive their default port
- * from here. The vite dev configs (packages/web|landing|docs) cannot import core TS, so
- * they hardcode the same numbers with a comment pointing back at this file. The full
- * list is interpolated into the default system prompt so agents never kill processes
- * listening on these ports.
+ * from here; these are fallbacks only — the `--port` flag and the PORT environment
+ * variable still override them at runtime. The vite dev configs (packages/web|landing|docs)
+ * cannot import core TS, so they hardcode the same numbers with a comment pointing back
+ * at this file.
  */
 
 /** Default main server / Web UI port (`penguin server` / `penguin web`; deliberately avoids common defaults like 3000/8080). */
 export const DEFAULT_SERVER_PORT = 7364;
 
-/** Ports reserved for PenguinHarness's own services; never kill their listeners to free a port. */
+/** Default ports of PenguinHarness's own services; never kill their listeners or reuse the ports for other servers. */
 export const RESERVED_PORTS: readonly number[] = [
   DEFAULT_SERVER_PORT, // main server / Web UI
   7365, // web dev server (packages/web/vite.config.ts; proxies /api to the main server)

--- a/packages/core/src/state/default-config.ts
+++ b/packages/core/src/state/default-config.ts
@@ -19,6 +19,7 @@
  */
 import type { MCPServerConfig, ThinkingLevelName, ToolDefinitionConfig } from "../interfaces.js";
 import type { CompactionMode } from "../omnimessage/types.js";
+import { RESERVED_PORTS } from "../ports.js";
 
 /** Docs: /docs/configuration § "System prompt placeholders". */
 export const AGENTS_MD_PLACEHOLDER = "{{AGENTS_MD}}";
@@ -92,13 +93,15 @@ Communicate with the user precisely and concisely, yet with warmth. Do not repea
 # Constraints
 - Make the smallest change that satisfies the request; do not modify unrelated files.
 - Destructive operations are forbidden.
-- Never kill a process you did not start yourself (e.g. to free a busy port) unless the user explicitly asks you to.
+- Never kill a process you did not start yourself unless the user explicitly asks you to, and never kill a process listening on the reserved PenguinHarness service ports (${RESERVED_PORTS.join(", ")}). When a port you want is busy, pick another free port; never free it by killing the listener.
 - If a tool call fails, read the error, adjust, and retry; never repeat the same failing input.
+- On an API authentication/authorization or API-key error (401/403, invalid or missing key), retry at most once.
 
 # Stop rules
 - Stop and give the final answer once the success criteria are met.
 - If the request is ambiguous, stop and ask the user for clarification instead of guessing their intent.
 - If you hit an error you cannot resolve, stop and report the blocker to the user.
+- If an API auth/key error persists after that one retry, stop calling tools and ask the user to supply or update the key (per-agent secrets: \`penguin config vault set\`; model credentials: \`penguin config model add\`). Updated secrets only take effect in the next conversation, so further retries cannot succeed.
 
 # Tool use
 - Prefer solving problems with your tools: inspect the real files and environment and run real commands instead of answering from memory or guessing.

--- a/packages/core/src/state/default-config.ts
+++ b/packages/core/src/state/default-config.ts
@@ -19,7 +19,6 @@
  */
 import type { MCPServerConfig, ThinkingLevelName, ToolDefinitionConfig } from "../interfaces.js";
 import type { CompactionMode } from "../omnimessage/types.js";
-import { RESERVED_PORTS } from "../ports.js";
 
 /** Docs: /docs/configuration § "System prompt placeholders". */
 export const AGENTS_MD_PLACEHOLDER = "{{AGENTS_MD}}";
@@ -93,7 +92,7 @@ Communicate with the user precisely and concisely, yet with warmth. Do not repea
 # Constraints
 - Make the smallest change that satisfies the request; do not modify unrelated files.
 - Destructive operations are forbidden.
-- Never kill a process you did not start yourself unless the user explicitly asks you to, and never kill a process listening on the reserved PenguinHarness service ports (${RESERVED_PORTS.join(", ")}). When a port you want is busy, pick another free port; never free it by killing the listener.
+- Never kill a process you did not start yourself unless the user explicitly asks you to, including PenguinHarness's own services. Never take a PenguinHarness service port for your own servers; when a port you want is busy, pick another free port instead of killing the listener.
 - If a tool call fails, read the error, adjust, and retry; never repeat the same failing input.
 - On an API authentication/authorization or API-key error (401/403, invalid or missing key), retry at most once.
 
@@ -101,7 +100,7 @@ Communicate with the user precisely and concisely, yet with warmth. Do not repea
 - Stop and give the final answer once the success criteria are met.
 - If the request is ambiguous, stop and ask the user for clarification instead of guessing their intent.
 - If you hit an error you cannot resolve, stop and report the blocker to the user.
-- If an API auth/key error persists after that one retry, stop calling tools and ask the user to supply or update the key (per-agent secrets: \`penguin config vault set\`; model credentials: \`penguin config model add\`). Updated secrets only take effect in the next conversation, so further retries cannot succeed.
+- If an API auth/key error persists after that one retry, stop calling tools and ask the user to update the key in the agent's vault or the model settings outside the chat — the secret value must never be pasted into the conversation. Updated secrets only take effect in the next conversation, so further retries cannot succeed.
 
 # Tool use
 - Prefer solving problems with your tools: inspect the real files and environment and run real commands instead of answering from memory or guessing.

--- a/packages/core/test/state.test.ts
+++ b/packages/core/test/state.test.ts
@@ -44,6 +44,7 @@ import {
   type ModelRef,
   type ProjectConfig,
 } from "../src/state/index.js";
+import { DEFAULT_SERVER_PORT, RESERVED_PORTS } from "../src/ports.js";
 import { sessionEnvironment } from "../src/internal/session-support.js";
 
 let tmpRoot: string;
@@ -313,6 +314,21 @@ describe("assembleSystemPrompt", () => {
     expect(prompt).not.toContain(PLATFORM_PLACEHOLDER);
     expect(prompt).not.toContain(OS_VERSION_PLACEHOLDER);
     expect(prompt).not.toContain(DATE_PLACEHOLDER);
+  });
+
+  it("default prompt carries the reserved-port and API-key guardrails", async () => {
+    const state = await loadOrInitAgentState();
+    const prompt = assembleSystemPrompt(state);
+    // The Constraints bullet interpolates RESERVED_PORTS, so the prompt and the constant cannot drift.
+    expect(RESERVED_PORTS).toContain(DEFAULT_SERVER_PORT);
+    expect(prompt).toContain(`(${RESERVED_PORTS.join(", ")})`);
+    expect(prompt).toContain("pick another free port");
+    // Auth/key failures: retry at most once (Constraints), then stop and ask for the key (Stop rules).
+    expect(prompt).toContain("retry at most once");
+    expect(prompt).toContain("stop calling tools");
+    expect(prompt).toContain("penguin config vault set");
+    expect(prompt).toContain("penguin config model add");
+    expect(prompt).toContain("next conversation");
   });
 
   it("replaces AGENTS.md and specific Session environment fields at template locations", () => {

--- a/packages/core/test/state.test.ts
+++ b/packages/core/test/state.test.ts
@@ -44,7 +44,6 @@ import {
   type ModelRef,
   type ProjectConfig,
 } from "../src/state/index.js";
-import { DEFAULT_SERVER_PORT, RESERVED_PORTS } from "../src/ports.js";
 import { sessionEnvironment } from "../src/internal/session-support.js";
 
 let tmpRoot: string;
@@ -316,19 +315,20 @@ describe("assembleSystemPrompt", () => {
     expect(prompt).not.toContain(DATE_PLACEHOLDER);
   });
 
-  it("default prompt carries the reserved-port and API-key guardrails", async () => {
+  it("default prompt carries the port and API-key guardrails", async () => {
     const state = await loadOrInitAgentState();
     const prompt = assembleSystemPrompt(state);
-    // The Constraints bullet interpolates RESERVED_PORTS, so the prompt and the constant cannot drift.
-    expect(RESERVED_PORTS).toContain(DEFAULT_SERVER_PORT);
-    expect(prompt).toContain(`(${RESERVED_PORTS.join(", ")})`);
+    // Ports: never kill listeners or take PenguinHarness service ports; numbers are deliberately not listed.
     expect(prompt).toContain("pick another free port");
-    // Auth/key failures: retry at most once (Constraints), then stop and ask for the key (Stop rules).
+    expect(prompt).toContain("PenguinHarness service port");
+    expect(prompt).not.toContain("7364");
+    // Auth/key failures: retry at most once (Constraints), then stop and ask the user to update
+    // the key outside the chat (Stop rules) — no CLI commands, no secret values in the conversation.
     expect(prompt).toContain("retry at most once");
     expect(prompt).toContain("stop calling tools");
-    expect(prompt).toContain("penguin config vault set");
-    expect(prompt).toContain("penguin config model add");
+    expect(prompt).toContain("never be pasted into the conversation");
     expect(prompt).toContain("next conversation");
+    expect(prompt).not.toContain("penguin config vault set");
   });
 
   it("replaces AGENTS.md and specific Session environment fields at template locations", () => {

--- a/packages/docs/vite.config.ts
+++ b/packages/docs/vite.config.ts
@@ -16,5 +16,7 @@ import { defineConfig } from "vite";
 export default defineConfig({
   base: process.env.BASE_PATH ?? "/",
   plugins: [react(), tailwindcss()],
+  // Reserved PenguinHarness dev port — keep in sync with RESERVED_PORTS in
+  // @prismshadow/penguin-core (src/ports.ts); vite configs cannot import core TS.
   server: { port: 7367 },
 });

--- a/packages/docs/vite.config.ts
+++ b/packages/docs/vite.config.ts
@@ -16,7 +16,7 @@ import { defineConfig } from "vite";
 export default defineConfig({
   base: process.env.BASE_PATH ?? "/",
   plugins: [react(), tailwindcss()],
-  // Reserved PenguinHarness dev port — keep in sync with RESERVED_PORTS in
-  // @prismshadow/penguin-core (src/ports.ts); vite configs cannot import core TS.
+  // Fixed PenguinHarness dev port (stands alone — only the main server default is
+  // shared, as DEFAULT_SERVER_PORT in core; vite configs cannot import core TS).
   server: { port: 7367 },
 });

--- a/packages/landing/vite.config.ts
+++ b/packages/landing/vite.config.ts
@@ -13,5 +13,7 @@ import { defineConfig } from "vite";
 export default defineConfig({
   base: process.env.BASE_PATH ?? "/",
   plugins: [react(), tailwindcss()],
+  // Reserved PenguinHarness dev port — keep in sync with RESERVED_PORTS in
+  // @prismshadow/penguin-core (src/ports.ts); vite configs cannot import core TS.
   server: { port: 7366 },
 });

--- a/packages/landing/vite.config.ts
+++ b/packages/landing/vite.config.ts
@@ -13,7 +13,7 @@ import { defineConfig } from "vite";
 export default defineConfig({
   base: process.env.BASE_PATH ?? "/",
   plugins: [react(), tailwindcss()],
-  // Reserved PenguinHarness dev port — keep in sync with RESERVED_PORTS in
-  // @prismshadow/penguin-core (src/ports.ts); vite configs cannot import core TS.
+  // Fixed PenguinHarness dev port (stands alone — only the main server default is
+  // shared, as DEFAULT_SERVER_PORT in core; vite configs cannot import core TS).
   server: { port: 7366 },
 });

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -12,7 +12,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { resolveRoot } from "@prismshadow/penguin-core";
+import { DEFAULT_SERVER_PORT, resolveRoot } from "@prismshadow/penguin-core";
 
 export interface ServerConfig {
   /** Local data root directory (shared with the SDK/CLI). */
@@ -52,7 +52,7 @@ export function resolveServerConfig(env: NodeJS.ProcessEnv = process.env): Serve
   // An empty PORT string is treated as unset (the common `.env` case of an empty
   // `PORT=`): Number("") === 0 would pass the range check and bind to a random
   // port; this matches the CLI's resolvePort convention.
-  const port = Number(env.PORT || 7364);
+  const port = Number(env.PORT || DEFAULT_SERVER_PORT);
   if (!Number.isInteger(port) || port < 0 || port > 65535) {
     throw new Error(`Invalid port configuration PORT=${env.PORT}`);
   }

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -14,6 +14,8 @@ import { defineConfig } from "vite";
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   server: {
+    // Reserved PenguinHarness dev port — keep in sync with RESERVED_PORTS in
+    // @prismshadow/penguin-core (src/ports.ts); vite configs cannot import core TS.
     port: 7365,
     proxy: {
       "/api": {

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -14,8 +14,8 @@ import { defineConfig } from "vite";
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   server: {
-    // Reserved PenguinHarness dev port — keep in sync with RESERVED_PORTS in
-    // @prismshadow/penguin-core (src/ports.ts); vite configs cannot import core TS.
+    // Fixed PenguinHarness dev port (stands alone — only the main server default is
+    // shared, as DEFAULT_SERVER_PORT in core; vite configs cannot import core TS).
     port: 7365,
     proxy: {
       "/api": {


### PR DESCRIPTION
## Server port: one constant, and a prompt rule that keeps agents off our ports

Agents kept killing PenguinHarness's own services when they wanted a port — the default server port was hardcoded in two places, and the default prompt had just a generic "never kill a process you did not start" rule.

`packages/core/src/internal/ports.ts` now carries `DEFAULT_SERVER_PORT = 7364`, the single source of truth for the main server / Web UI default (`penguin server` / `penguin web`). Per review it lives under `internal/`; the core barrel keeps one documented named re-export (`export { DEFAULT_SERVER_PORT } from "./internal/ports.js";`) because the CLI's `DEFAULT_PORT` (`packages/cli/src/commands/serve.ts`) and the server's `PORT` fallback (`packages/server/src/config.ts`) both derive from it via the barrel — so the numbers cannot drift. It is a fallback only: the `--port` flag and the `PORT` env var still override it at runtime. The web / landing / docs vite dev ports (7365–7367) stay in their own configs: vite configs cannot import core TS, and per review the central `RESERVED_PORTS` list was dropped — it lost its only consumer once the prompt stopped enumerating ports.

Per review, the prompt does not list port numbers (ports can be overridden at runtime, so a baked-in list could go stale); the `# Constraints` bullet covers both killing listeners and squatting the ports:

> - Never kill a process you did not start yourself unless the user explicitly asks you to, including PenguinHarness's own services. Never take a PenguinHarness service port for your own servers; when a port you want is busy, pick another free port instead of killing the listener.

## API auth/key failures: retry once, then stop and ask

When a tool call hits an authentication/authorization or API-key error, retrying past one attempt is pointless — the fix is a new key, which the agent cannot supply itself, and vault updates only reach the shell environment of the next conversation. New `# Constraints` bullet:

> - On an API authentication/authorization or API-key error (401/403, invalid or missing key), retry at most once.

and new `# Stop rules` bullet (per review: no CLI commands — the user updates the key in the agent's vault / model settings, and the secret value must never enter the chat):

> - If an API auth/key error persists after that one retry, stop calling tools and ask the user to update the key in the agent's vault or the model settings outside the chat — the secret value must never be pasted into the conversation. Updated secrets only take effect in the next conversation, so further retries cannot succeed.

This is prompt-level only: it governs the agent's own tool calls (e.g. `curl` against some third-party API mid-task). The engine-side classification in `generative-model.ts` already treats 401/403 on LLM requests as non-retryable and is unchanged.

## Seed-only caveat

`DEFAULT_SYSTEM_PROMPT` seeds each agent's editable `system_config.yaml` at initialization. `loadOrInitAgentState` only writes defaults when `system_config.yaml` does not exist, and `provisionProjectAgents` never overwrites an existing agent — there is no re-seed on version bumps. Existing agents therefore keep their current prompt; the new rules reach newly created agents. No migration is attempted here.

## Verification

`pnpm -r build`, `pnpm typecheck`, and `pnpm format:check` clean. `pnpm test` — 1129 passing (+2 skipped) across 7 packages (core 373, server 285, web 312, cli 120, skills 16, landing 12, docs 11), including a core test asserting the default prompt carries both guardrails (and no port numbers or CLI commands) and a CLI test pinning `DEFAULT_PORT === DEFAULT_SERVER_PORT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)