### PR TITLE
feat(web): collapsed-rail nav with last conversation, new chat, and localized tooltips

### DIFF
--- a/packages/web/e2e/layout.spec.mjs
+++ b/packages/web/e2e/layout.spec.mjs
@@ -12,7 +12,7 @@
  * - the collapsed rail shows, in product-specified order, last conversation / new chat /
  *   Agents / Skills / Models / Costs / Traces / Benchmark with localized (en + zh) hover
  *   tooltips; "last conversation" targets the newest non-archived session and is disabled
- *   while none exists;
+ *   while none exists; expanding from the rail restores the pinned sidebar;
  * - login page: a single brand penguin logo above the form (part of the form area; the
  *   background still only has the trace animation), the trace animation grows in after a
  *   delayed blank first paint, no two trace segments cross or touch (except where a fork shares
@@ -189,20 +189,33 @@ test("layout: collapsed rail — order, bilingual tooltips, last conversation", 
   expect(patched.ok(), "archive newest session").toBeTruthy();
   await page.reload(); // the session store loads on mount; the collapsed state persists via localStorage
 
-  await rail.getByRole("button", { name: "Last conversation" }).click();
-  await expect(page, "last conversation → newest non-archived session").toHaveURL(
-    `${BASE}/chat/${target}`,
-  );
+  // A click during the fetch window is a graceful no-op (the entry stays enabled while the
+  // list loads), so retry click+assert until the store has settled.
+  await expect(async () => {
+    await rail.getByRole("button", { name: "Last conversation" }).click();
+    await expect(page, "last conversation → newest non-archived session").toHaveURL(
+      `${BASE}/chat/${target}`,
+      { timeout: 1000 },
+    );
+  }).toPass({ timeout: 15_000 });
+  // Active fill = the *unprefixed* bg-gray-200/70 token (the resting state carries hover:bg-gray-200/70, which a bare substring match would also hit).
+  const ACTIVE_FILL = /(^|\s)bg-gray-200\/70(\s|$)/;
+  // On a conversation, the entry lights as "you are here" (any non-draft /chat/:id).
+  await expect(rail.getByRole("button", { name: "Last conversation" })).toHaveClass(ACTIVE_FILL);
 
   // --- New chat enters the draft page and shows the rail's gray active fill there ---
   await rail.getByRole("button", { name: "New chat" }).click();
   await expect(page).toHaveURL(`${BASE}/chat/new`);
-  await expect(rail.getByRole("button", { name: "New chat" })).toHaveClass(/bg-gray-200/);
+  await expect(rail.getByRole("button", { name: "New chat" })).toHaveClass(ACTIVE_FILL);
+  // The draft belongs to the new-chat entry: the last-conversation one must not stay lit here.
+  await expect(rail.getByRole("button", { name: "Last conversation" })).not.toHaveClass(
+    ACTIVE_FILL,
+  );
 
   // --- Page entries navigate and highlight like the pinned nav ---
   await rail.getByRole("link", { name: "Skills" }).click();
   await expect(page).toHaveURL(`${BASE}/skills`);
-  await expect(rail.getByRole("link", { name: "Skills" })).toHaveClass(/bg-gray-200/);
+  await expect(rail.getByRole("link", { name: "Skills" })).toHaveClass(ACTIVE_FILL);
 
   // --- zh: tooltips follow the product-specified wording ---
   await page.addInitScript(() => localStorage.setItem("penguin.lang", "zh"));
@@ -220,6 +233,11 @@ test("layout: collapsed rail — order, bilingual tooltips, last conversation", 
   ];
   expect(await attrs("aria-label"), "rail order (zh)").toEqual(ZH);
   expect(await attrs("title"), "rail tooltips (zh)").toEqual(ZH);
+
+  // --- Expand: the rail's top button (localized) restores the pinned sidebar ---
+  await page.getByRole("button", { name: "展开侧栏" }).click();
+  await expect(page.locator("aside")).toHaveClass(/w-64/);
+  await expect(page.getByRole("button", { name: "收起侧栏" })).toBeVisible();
 });
 
 test("layout: login — blank start, non-crossing traces, lang/theme controls", async ({ page }) => {

--- a/packages/web/e2e/layout.spec.mjs
+++ b/packages/web/e2e/layout.spec.mjs
@@ -9,6 +9,10 @@
  *   (the group header's provider name used to get pushed out of the button box and overlap
  *   the group-level actions);
  * - the sidebar's "New chat" button has no background fill (same gray-scale style as nav items);
+ * - the collapsed rail shows, in product-specified order, last conversation / new chat /
+ *   Agents / Skills / Models / Costs / Traces / Benchmark with localized (en + zh) hover
+ *   tooltips; "last conversation" targets the newest non-archived session and is disabled
+ *   while none exists;
  * - login page: a single brand penguin logo above the form (part of the form area; the
  *   background still only has the trace animation), the trace animation grows in after a
  *   delayed blank first paint, no two trace segments cross or touch (except where a fork shares
@@ -125,6 +129,97 @@ test("layout: en draft + context gauge + mobile models", async ({ page }) => {
     await newChat.evaluate((el) => getComputedStyle(el).backgroundColor),
     "new-chat button has no background fill",
   ).toBe("rgba(0, 0, 0, 0)");
+});
+
+test("layout: collapsed rail — order, bilingual tooltips, last conversation", async ({ page }) => {
+  await page.addInitScript(() => localStorage.setItem("penguin.lang", "en"));
+  await provisionAndLogin(page.request, "railuser", P);
+  const projects = await (await page.request.get(`${BASE}/api/projects`)).json();
+  const projectId = projects.projects[0].projectId;
+  const put = await page.request.put(`${BASE}/api/projects/${projectId}/models`, {
+    data: {
+      defaultModel: { provider: "custom", modelId: "claude-4-8" },
+      models: [{ provider: "custom", modelId: "claude-4-8", apiKey: "sk-mock" }],
+    },
+  });
+  expect(put.ok(), "put models").toBeTruthy();
+
+  // --- No sessions yet: the rail renders all 8 entries, "last conversation" disabled ---
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.goto(`${BASE}/chat`);
+  await page.getByRole("button", { name: "Collapse sidebar" }).click();
+  const rail = page.locator("aside nav");
+  const entries = rail.locator("a, button");
+  await expect(entries).toHaveCount(8);
+  await expect(rail.getByRole("button", { name: "Last conversation" })).toBeDisabled();
+
+  // --- Order and tooltips (en): aria-label defines the order, title carries the same copy ---
+  const EN = [
+    "Last conversation",
+    "New chat",
+    "Agents",
+    "Skills",
+    "Models",
+    "Costs",
+    "Trajectory",
+    "Evaluation Center",
+  ];
+  const attrs = (name) =>
+    entries.evaluateAll((els, n) => els.map((el) => el.getAttribute(n)), name);
+  expect(await attrs("aria-label"), "rail order (en)").toEqual(EN);
+  expect(await attrs("title"), "rail tooltips (en)").toEqual(EN);
+
+  // --- Three sessions via the API (distinct createdAt), newest archived: the rail must target the newest *non-archived* one ---
+  const mkSession = async () => {
+    const res = await page.request.post(
+      `${BASE}/api/projects/${projectId}/agents/default_agent/sessions`,
+      { data: { provider: "custom", modelId: "claude-4-8" } },
+    );
+    expect(res.ok(), "create session").toBeTruthy();
+    return (await res.json()).session.sessionId;
+  };
+  await mkSession();
+  await page.waitForTimeout(25);
+  const target = await mkSession();
+  await page.waitForTimeout(25);
+  const archived = await mkSession();
+  const patched = await page.request.patch(`${BASE}/api/sessions/${archived}`, {
+    data: { archived: true },
+  });
+  expect(patched.ok(), "archive newest session").toBeTruthy();
+  await page.reload(); // the session store loads on mount; the collapsed state persists via localStorage
+
+  await rail.getByRole("button", { name: "Last conversation" }).click();
+  await expect(page, "last conversation → newest non-archived session").toHaveURL(
+    `${BASE}/chat/${target}`,
+  );
+
+  // --- New chat enters the draft page and shows the rail's gray active fill there ---
+  await rail.getByRole("button", { name: "New chat" }).click();
+  await expect(page).toHaveURL(`${BASE}/chat/new`);
+  await expect(rail.getByRole("button", { name: "New chat" })).toHaveClass(/bg-gray-200/);
+
+  // --- Page entries navigate and highlight like the pinned nav ---
+  await rail.getByRole("link", { name: "Skills" }).click();
+  await expect(page).toHaveURL(`${BASE}/skills`);
+  await expect(rail.getByRole("link", { name: "Skills" })).toHaveClass(/bg-gray-200/);
+
+  // --- zh: tooltips follow the product-specified wording ---
+  await page.addInitScript(() => localStorage.setItem("penguin.lang", "zh"));
+  await page.reload();
+  await expect(entries).toHaveCount(8);
+  const ZH = [
+    "最近一次对话",
+    "新建对话",
+    "智能体",
+    "技能库",
+    "模型仓库",
+    "成本中心",
+    "轨迹观测",
+    "评估中心",
+  ];
+  expect(await attrs("aria-label"), "rail order (zh)").toEqual(ZH);
+  expect(await attrs("title"), "rail tooltips (zh)").toEqual(ZH);
 });
 
 test("layout: login — blank start, non-crossing traces, lang/theme controls", async ({ page }) => {

--- a/packages/web/src/components/layout/app-layout.tsx
+++ b/packages/web/src/components/layout/app-layout.tsx
@@ -38,8 +38,10 @@ function CollapsedRail({ onExpand }: { onExpand: () => void }) {
   const { user } = useAuth();
   const navigate = useNavigate();
   const { agents, setCurrentAgentId } = useProject();
-  const { sessions } = useSessions();
+  const { sessions, loading } = useSessions();
   const activeSessionId = useMatch("/chat/:sessionId")?.params.sessionId ?? null;
+  /** On some conversation (any non-draft /chat/:id): the "you are here" state of the last-conversation entry. */
+  const onConversation = activeSessionId !== null && activeSessionId !== DRAFT_SESSION_ID;
 
   /** Newest non-archived Session across the current Project by createdAt (the flat list is only ordered per Agent). */
   const lastSession = useMemo(
@@ -88,16 +90,18 @@ function CollapsedRail({ onExpand }: { onExpand: () => void }) {
         <GlyphIcon d="M9 6l6 6-6 6M20 4v16" size={18} />
       </button>
       <nav className="mt-1 flex flex-col items-center gap-1">
-        {/* 1. Last conversation: disabled (dimmed, tooltip kept) while the Project has no non-archived Session yet. */}
+        {/* 1. Last conversation: lit on any non-draft conversation. Dimmed/disabled (tooltip kept) only
+            once the list has settled with no non-archived Session — while it is still loading the
+            entry keeps its normal look (no flash) and a click is a graceful no-op. */}
         <button
           type="button"
           title={S.nav.lastConversation}
           aria-label={S.nav.lastConversation}
-          disabled={!lastSession}
+          disabled={!lastSession && !loading}
           onClick={openLastSession}
           className={
-            lastSession
-              ? railItemClass(activeSessionId === lastSession.sessionId)
+            lastSession || loading
+              ? railItemClass(onConversation)
               : "flex h-8 w-8 cursor-not-allowed items-center justify-center rounded-md text-gray-300 dark:text-gray-700"
           }
         >

--- a/packages/web/src/components/layout/app-layout.tsx
+++ b/packages/web/src/components/layout/app-layout.tsx
@@ -4,35 +4,140 @@
  * - <md: top thin bar (hamburger -> sidebar drawer + brand name) + main content.
  * All chrome uses solid backgrounds and avoids stacking contexts (frosted-glass/transform would trap overlay z-index).
  */
-import { useState } from "react";
-import { NavLink, Outlet } from "react-router";
+import { useMemo, useState } from "react";
+import { NavLink, Outlet, useMatch, useNavigate } from "react-router";
+import type { SessionInfo } from "@prismshadow/penguin-server/api";
 import { S } from "../../lib/strings";
 import { useAuth } from "../../state/auth";
+import { useProject } from "../../state/project";
+import { useSessions } from "../../state/sessions";
 import { Drawer } from "../ui/drawer";
-import { Sidebar } from "./sidebar";
+import { GlyphIcon } from "../ui/glyph-icon";
+import { NAV_ICONS, NEW_CHAT_ICON, Sidebar } from "./sidebar";
+import { DRAFT_SESSION_ID } from "../../features/chat/chat-page";
 import { ChangePasswordDialog } from "../account/change-password-dialog";
 
-/** Narrow-rail nav icons (matches Sidebar NAV_ICONS). */
-const RAIL_NAV: ReadonlyArray<{ to: string; label: string; icon: string }> = [
-  { to: "/chat", label: "chat", icon: "M8 10h8M8 14h5M21 12a9 9 0 1 1-4.2-7.6L21 4v5h-5" },
-  {
-    to: "/agents",
-    label: "agents",
-    icon: "M12 3v3m-6 4a6 6 0 0 1 12 0v5a3 3 0 0 1-3 3H9a3 3 0 0 1-3-3v-5zm3 3h.01M15 13h.01",
-  },
-  {
-    to: "/skills",
-    label: "skills",
-    icon: "M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2zM22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z",
-  },
-  {
-    to: "/models",
-    label: "models",
-    icon: "M7 7h10v10H7zM4 10h3m10 0h3M4 14h3m10 0h3M10 4v3m4-3v3m-4 10v3m4-3v3",
-  },
-  { to: "/usage", label: "usage", icon: "M4 20V10m6 10V4m6 16v-7m4 7H2" },
-  { to: "/traces", label: "traces", icon: "M4 6h16M4 12h10M4 18h13" },
-];
+/** "Last conversation" glyph (chat lines + resume arrow), used only by the rail. */
+const LAST_CHAT_ICON = "M8 10h8M8 14h5M21 12a9 9 0 1 1-4.2-7.6L21 4v5h-5";
+
+/** Shared look of rail entries (icon buttons and NavLinks alike): solid gray fill when active, gray hover otherwise. */
+const railItemClass = (active: boolean) =>
+  `flex h-8 w-8 items-center justify-center rounded-md transition-colors duration-150 ${
+    active
+      ? "bg-gray-200/70 text-gray-900 dark:bg-gray-800 dark:text-gray-100"
+      : "text-gray-500 hover:bg-gray-200/70 hover:text-gray-800 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+  }`;
+
+/**
+ * Collapsed narrow rail: expand button on top; below it, in product-specified order, last
+ * conversation / new chat / Agents / Skills / Models / Costs / Traces / Benchmark (every entry
+ * carries a localized title + aria-label, so hover tooltips follow the UI language); user
+ * avatar at the bottom. No Logo shown.
+ */
+function CollapsedRail({ onExpand }: { onExpand: () => void }) {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const { agents, setCurrentAgentId } = useProject();
+  const { sessions } = useSessions();
+  const activeSessionId = useMatch("/chat/:sessionId")?.params.sessionId ?? null;
+
+  /** Newest non-archived Session across the current Project by createdAt (the flat list is only ordered per Agent). */
+  const lastSession = useMemo(
+    () =>
+      sessions.reduce<SessionInfo | null>(
+        (best, s) =>
+          !s.archived && (!best || Date.parse(s.createdAt) > Date.parse(best.createdAt)) ? s : best,
+        null,
+      ),
+    [sessions],
+  );
+
+  /** Mirrors Sidebar.openSession: the current Agent follows the opened Session's Agent. */
+  const openLastSession = () => {
+    if (!lastSession) return;
+    setCurrentAgentId(lastSession.agentId);
+    navigate(`/chat/${lastSession.sessionId}`);
+  };
+
+  /** Mirrors the pinned sidebar's "New chat": default_agent draft, falling back to the first Agent (an unresolved list defers resolution to the draft page). */
+  const newChat = () => {
+    const agentId = (agents.find((a) => a.agentId === "default_agent") ?? agents[0])?.agentId;
+    if (agentId) setCurrentAgentId(agentId);
+    navigate(`/chat/${DRAFT_SESSION_ID}`, agentId ? { state: { agentId } } : undefined);
+  };
+
+  /** Page entries (rail positions 3-8): same routes as the pinned nav; Agents uses the rail-specific short label. */
+  const pages: ReadonlyArray<{ to: string; label: string; icon: string }> = [
+    { to: "/agents", label: S.nav.railAgents, icon: NAV_ICONS.agents },
+    { to: "/skills", label: S.nav.skills, icon: NAV_ICONS.skills },
+    { to: "/models", label: S.nav.models, icon: NAV_ICONS.models },
+    { to: "/usage", label: S.nav.usage, icon: NAV_ICONS.usage },
+    { to: "/traces", label: S.nav.traces, icon: NAV_ICONS.traces },
+    { to: "/benchmark", label: S.nav.benchmark, icon: NAV_ICONS.benchmark },
+  ];
+
+  return (
+    <div className="flex h-full flex-col items-center gap-1 py-2.5">
+      <button
+        type="button"
+        title={S.nav.expandSidebar}
+        aria-label={S.nav.expandSidebar}
+        onClick={onExpand}
+        className="flex h-8 w-8 items-center justify-center rounded-md text-gray-500 transition-colors duration-150 hover:bg-gray-200/70 hover:text-gray-800 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+      >
+        <GlyphIcon d="M9 6l6 6-6 6M20 4v16" size={18} />
+      </button>
+      <nav className="mt-1 flex flex-col items-center gap-1">
+        {/* 1. Last conversation: disabled (dimmed, tooltip kept) while the Project has no non-archived Session yet. */}
+        <button
+          type="button"
+          title={S.nav.lastConversation}
+          aria-label={S.nav.lastConversation}
+          disabled={!lastSession}
+          onClick={openLastSession}
+          className={
+            lastSession
+              ? railItemClass(activeSessionId === lastSession.sessionId)
+              : "flex h-8 w-8 cursor-not-allowed items-center justify-center rounded-md text-gray-300 dark:text-gray-700"
+          }
+        >
+          <GlyphIcon d={LAST_CHAT_ICON} size={18} />
+        </button>
+        {/* 2. New chat: shows the same gray active fill while on the draft page (pinned-sidebar convention). */}
+        <button
+          type="button"
+          title={S.chat.newSessionMenu}
+          aria-label={S.chat.newSessionMenu}
+          onClick={newChat}
+          className={railItemClass(activeSessionId === DRAFT_SESSION_ID)}
+        >
+          <GlyphIcon d={NEW_CHAT_ICON} size={18} />
+        </button>
+        {/* 3-8. Page entries */}
+        {pages.map((item) => (
+          <NavLink
+            key={item.to}
+            to={item.to}
+            title={item.label}
+            aria-label={item.label}
+            className={({ isActive }) => railItemClass(isActive)}
+          >
+            <GlyphIcon d={item.icon} size={18} />
+          </NavLink>
+        ))}
+      </nav>
+      <button
+        type="button"
+        title={`${user?.userId ?? ""} · ${S.nav.expandSidebar}`}
+        aria-label={user?.userId ?? S.auth.admin}
+        onClick={onExpand}
+        className="mt-auto flex h-8 w-8 items-center justify-center rounded-full bg-gray-900 text-xs font-bold text-white dark:bg-gray-200 dark:text-gray-900"
+      >
+        {(user?.userId ?? "?").slice(0, 1).toUpperCase()}
+      </button>
+    </div>
+  );
+}
 
 export function AppLayout() {
   const { user } = useAuth();
@@ -58,69 +163,7 @@ export function AppLayout() {
         }`}
       >
         {collapsed ? (
-          // Collapsed narrow rail: expand button on top, icon nav below, user avatar at the bottom; no Logo shown.
-          <div className="flex h-full flex-col items-center gap-1 py-2.5">
-            <button
-              type="button"
-              title={S.nav.expandSidebar}
-              aria-label={S.nav.expandSidebar}
-              onClick={toggleCollapsed}
-              className="flex h-8 w-8 items-center justify-center rounded-md text-gray-500 transition-colors duration-150 hover:bg-gray-200/70 hover:text-gray-800 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
-            >
-              <svg
-                width="18"
-                height="18"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.7"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                aria-hidden
-              >
-                <path d="M9 6l6 6-6 6M20 4v16" />
-              </svg>
-            </button>
-            <nav className="mt-1 flex flex-col items-center gap-1">
-              {RAIL_NAV.map((item) => (
-                <NavLink
-                  key={item.to}
-                  to={item.to}
-                  title={item.label}
-                  className={({ isActive }) =>
-                    `flex h-8 w-8 items-center justify-center rounded-md transition-colors duration-150 ${
-                      isActive
-                        ? "bg-gray-200/70 text-gray-900 dark:bg-gray-800 dark:text-gray-100"
-                        : "text-gray-500 hover:bg-gray-200/70 hover:text-gray-800 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
-                    }`
-                  }
-                >
-                  <svg
-                    width="18"
-                    height="18"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="1.7"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    aria-hidden
-                  >
-                    <path d={item.icon} />
-                  </svg>
-                </NavLink>
-              ))}
-            </nav>
-            <button
-              type="button"
-              title={`${user?.userId ?? ""} · ${S.nav.expandSidebar}`}
-              aria-label={user?.userId ?? S.auth.admin}
-              onClick={toggleCollapsed}
-              className="mt-auto flex h-8 w-8 items-center justify-center rounded-full bg-gray-900 text-xs font-bold text-white dark:bg-gray-200 dark:text-gray-900"
-            >
-              {(user?.userId ?? "?").slice(0, 1).toUpperCase()}
-            </button>
-          </div>
+          <CollapsedRail onExpand={toggleCollapsed} />
         ) : (
           <Sidebar onCollapse={toggleCollapsed} />
         )}

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -70,7 +70,8 @@ function DropdownCaret() {
   );
 }
 
-const NAV_ICONS = {
+/** Page-nav glyphs (shared with the collapsed rail in app-layout.tsx). */
+export const NAV_ICONS = {
   agents: "M12 3v3m-6 4a6 6 0 0 1 12 0v5a3 3 0 0 1-3 3H9a3 3 0 0 1-3-3v-5zm3 3h.01M15 13h.01",
   /** Skill library (an open book: two pages + spine). */
   skills: "M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2zM22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z",
@@ -81,6 +82,9 @@ const NAV_ICONS = {
   benchmark:
     "M7 4h10v5a5 5 0 0 1-10 0V4zM7 5H4v1a3 3 0 0 0 3 3m10-4h3v1a3 3 0 0 1-3 3M12 14v4m-4 0h8",
 } as const;
+
+/** New-chat pencil (the pinned "New chat" button and the collapsed rail share it). */
+export const NEW_CHAT_ICON = "M12 20h9M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z";
 
 /** Standard gear (lucide settings): full tooth outline + center circle, crisp and undistorted at 16px. */
 const GEAR_ICON =
@@ -514,7 +518,7 @@ export function Sidebar({
           }`}
         >
           <span className="text-gray-500 dark:text-gray-400">
-            <Icon d="M12 20h9M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
+            <Icon d={NEW_CHAT_ICON} />
           </span>
           {S.chat.newSessionMenu}
         </button>

--- a/packages/web/src/lib/strings-en.ts
+++ b/packages/web/src/lib/strings-en.ts
@@ -17,6 +17,9 @@ export const en: Strings = {
     usage: "Costs",
     traces: "Trajectory",
     benchmark: "Evaluation Center",
+    // Collapsed-rail tooltips (product-specified wording; new chat reuses chat.newSessionMenu, the other pages reuse the page names above).
+    lastConversation: "Last conversation",
+    railAgents: "Agents",
     collapseSidebar: "Collapse sidebar",
     expandSidebar: "Expand sidebar",
     collapseGroup: "Collapse",

--- a/packages/web/src/lib/strings-en.ts
+++ b/packages/web/src/lib/strings-en.ts
@@ -19,6 +19,7 @@ export const en: Strings = {
     benchmark: "Evaluation Center",
     // Collapsed-rail tooltips (product-specified wording; new chat reuses chat.newSessionMenu, the other pages reuse the page names above).
     lastConversation: "Last conversation",
+    // Deliberately equal to nav.agents: the key exists for the zh-only wording difference (智能体 vs 智能体仓库).
     railAgents: "Agents",
     collapseSidebar: "Collapse sidebar",
     expandSidebar: "Expand sidebar",

--- a/packages/web/src/lib/strings.ts
+++ b/packages/web/src/lib/strings.ts
@@ -19,6 +19,9 @@ export const zh = {
     usage: "成本中心",
     traces: "轨迹观测",
     benchmark: "评估中心",
+    // Collapsed-rail tooltips (product-specified wording; new chat reuses chat.newSessionMenu, the other pages reuse the page names above).
+    lastConversation: "最近一次对话",
+    railAgents: "智能体",
     collapseSidebar: "收起侧栏",
     expandSidebar: "展开侧栏",
     collapseGroup: "折叠",


### PR DESCRIPTION
## Summary

Implements the product requirement for the collapsed sidebar (narrow rail): it now shows, top to bottom, **last conversation, new chat, Agents, Skills, Models, Costs, Traces, Benchmark**, and every icon's hover tooltip is bilingual (follows the UI language).

Before this change the rail showed a generic `/chat` entry plus five page links (Benchmark missing) with hardcoded English `title`s ("chat", "agents", ...).

## Rail order and behavior

| # | Entry | Behavior |
|---|-------|----------|
| 1 | Last conversation | Navigates to the newest **non-archived** Session across the current Project (by `createdAt`; the flat store list is only ordered per Agent). Scopes the current Agent to that Session's Agent, matching `Sidebar.openSession`. When no such Session exists the button renders disabled (dimmed, tooltip kept) — falling back to new-chat would duplicate the adjacent button's action. |
| 2 | New chat | Mirrors the pinned sidebar's "New chat": `default_agent` draft via `/chat/new` (falls back to the first Agent), same gray active fill while on the draft page. |
| 3-8 | Agents / Skills / Models / Costs / Traces / Benchmark | `NavLink`s with the pinned nav's active-fill convention; Benchmark added. |

## Tooltip i18n

Each entry gets `title` + `aria-label` from the string tables (`strings.ts` zh / `strings-en.ts` en), read at render time so locale switching applies. Copy per the product owner's zh wording:

- New keys: `nav.lastConversation` (最近一次对话 / Last conversation) and `nav.railAgents` (智能体 / Agents — the rail uses the owner's short wording; the page keeps its full name 智能体仓库).
- Reused keys: `chat.newSessionMenu` (新建对话 / New chat) and the existing page names `nav.skills/models/usage/traces/benchmark` (技能库 / 模型仓库 / 成本中心 / 轨迹观测 / 评估中心), avoiding duplicated copy.

## Implementation notes

- The rail moved into a dedicated `CollapsedRail` component in `app-layout.tsx`; it reuses `Sidebar`'s `NAV_ICONS` and the new-chat pencil glyph (both now exported) plus the shared `GlyphIcon`, replacing the previously duplicated inline SVG paths.
- No changes to expand/collapse mechanics, persistence (`penguin.sidebarCollapsed`), or the pinned sidebar besides the icon-constant extraction.

## Verification

- `pnpm -r build`, `pnpm typecheck`, `pnpm test` (docs 11, skills 16, landing 26, core 396, server 297, cli 121, web 351 — all green), `pnpm format` + `pnpm format:check`.
- `SKIP_BUILD=1 pnpm --filter @prismshadow/penguin-web test:e2e`: 15/15 passed, including a new `layout.spec.mjs` test covering rail order + en/zh tooltips (asserted via `aria-label`/`title`), the disabled empty state, last-conversation targeting the newest non-archived Session (with a newer archived one present), and draft/page navigation with active highlighting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)