### PR TITLE
feat: AgentHub 0.4.1 and a model-catalog refresh across every provider group

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,15 +82,17 @@ Four Skill groups ship in the box ([docs](https://penguin.ooo/docs/skills)); Age
 | Model                 | Providers                                                                        |
 | --------------------- | -------------------------------------------------------------------------------- |
 | DeepSeek V4           | DeepSeek, OpenRouter, Fireworks AI, SiliconFlow, Qwen Token Plan                 |
-| Kimi K3               | OpenRouter, Qwen Pay-As-You-Go                                                   |
-| Kimi K2.6             | Moonshot AI                                                                      |
+| Kimi K3               | Moonshot AI, OpenRouter, Qwen Pay-As-You-Go                                      |
+| Kimi K2.6             | Moonshot AI, OpenRouter, SiliconFlow                                             |
 | GLM 5.2               | Z.AI, OpenRouter, Fireworks AI, SiliconFlow, Qwen Token Plan, Qwen Pay-As-You-Go |
 | Hunyuan 3             | OpenRouter                                                                       |
 | Qwen 3.8 Max          | Qwen Token Plan (preview)                                                        |
 | GPT 5.5               | OpenAI, OpenRouter                                                               |
-| Gemini 3.6 Flash      | OpenRouter                                                                       |
+| Gemini 3.6 Flash      | Google Gemini, OpenRouter                                                        |
 | Gemini 3.5 Flash      | Google Gemini, OpenRouter                                                        |
-| Gemini 3.5 Flash Lite | OpenRouter                                                                       |
+| Gemini 3.5 Flash-Lite | Google Gemini, OpenRouter                                                        |
+| Claude Fable 5        | Anthropic, OpenRouter                                                            |
+| Claude Sonnet 5       | Anthropic, OpenRouter                                                            |
 | Claude Opus 4.8       | Anthropic, OpenRouter                                                            |
 
 Any OpenAI-protocol endpoint is supported: pick a preset above, or point a custom endpoint at any of the 1000+ online and local models.

--- a/README.md
+++ b/README.md
@@ -79,17 +79,19 @@ Four Skill groups ship in the box ([docs](https://penguin.ooo/docs/skills)); Age
 
 ## Supported Models
 
-| Model            | Providers                                                                        |
-| ---------------- | -------------------------------------------------------------------------------- |
-| DeepSeek V4      | DeepSeek, OpenRouter, Fireworks AI, SiliconFlow, Qwen Token Plan                 |
-| Kimi K3          | OpenRouter, Qwen Pay-As-You-Go                                                   |
-| Kimi K2.6        | Moonshot AI                                                                      |
-| GLM 5.2          | Z.AI, OpenRouter, Fireworks AI, SiliconFlow, Qwen Token Plan, Qwen Pay-As-You-Go |
-| Hunyuan 3        | OpenRouter                                                                       |
-| Qwen 3.8 Max     | Qwen Token Plan (preview)                                                        |
-| GPT 5.5          | OpenAI, OpenRouter                                                               |
-| Gemini 3.5 Flash | Google Gemini, OpenRouter                                                        |
-| Claude Opus 4.8  | Anthropic, OpenRouter                                                            |
+| Model                 | Providers                                                                        |
+| --------------------- | -------------------------------------------------------------------------------- |
+| DeepSeek V4           | DeepSeek, OpenRouter, Fireworks AI, SiliconFlow, Qwen Token Plan                 |
+| Kimi K3               | OpenRouter, Qwen Pay-As-You-Go                                                   |
+| Kimi K2.6             | Moonshot AI                                                                      |
+| GLM 5.2               | Z.AI, OpenRouter, Fireworks AI, SiliconFlow, Qwen Token Plan, Qwen Pay-As-You-Go |
+| Hunyuan 3             | OpenRouter                                                                       |
+| Qwen 3.8 Max          | Qwen Token Plan (preview)                                                        |
+| GPT 5.5               | OpenAI, OpenRouter                                                               |
+| Gemini 3.6 Flash      | OpenRouter                                                                       |
+| Gemini 3.5 Flash      | Google Gemini, OpenRouter                                                        |
+| Gemini 3.5 Flash Lite | OpenRouter                                                                       |
+| Claude Opus 4.8       | Anthropic, OpenRouter                                                            |
 
 Any OpenAI-protocol endpoint is supported: pick a preset above, or point a custom endpoint at any of the 1000+ online and local models.
 

--- a/README.md
+++ b/README.md
@@ -79,23 +79,18 @@ Four Skill groups ship in the box ([docs](https://penguin.ooo/docs/skills)); Age
 
 ## Supported Models
 
-| Model                 | Providers                                                                        |
-| --------------------- | -------------------------------------------------------------------------------- |
-| DeepSeek V4           | DeepSeek, OpenRouter, Fireworks AI, SiliconFlow, Qwen Token Plan                 |
-| Kimi K3               | Moonshot AI, OpenRouter, Qwen Pay-As-You-Go                                      |
-| Kimi K2.6             | Moonshot AI, OpenRouter, SiliconFlow                                             |
-| GLM 5.2               | Z.AI, OpenRouter, Fireworks AI, SiliconFlow, Qwen Token Plan, Qwen Pay-As-You-Go |
-| Hunyuan 3             | OpenRouter                                                                       |
-| Qwen 3.8 Max          | Qwen Token Plan (preview)                                                        |
-| GPT 5.5               | OpenAI, OpenRouter                                                               |
-| Gemini 3.6 Flash      | Google Gemini, OpenRouter                                                        |
-| Gemini 3.5 Flash      | Google Gemini, OpenRouter                                                        |
-| Gemini 3.5 Flash-Lite | Google Gemini, OpenRouter                                                        |
-| Claude Fable 5        | Anthropic, OpenRouter                                                            |
-| Claude Sonnet 5       | Anthropic, OpenRouter                                                            |
-| Claude Opus 4.8       | Anthropic, OpenRouter                                                            |
+| Model            | Providers                                                                        |
+| ---------------- | -------------------------------------------------------------------------------- |
+| DeepSeek V4      | DeepSeek, OpenRouter, Fireworks AI, SiliconFlow, Qwen Token Plan                 |
+| Kimi K3          | Moonshot AI, OpenRouter, Qwen Pay-As-You-Go                                      |
+| GLM 5.2          | Z.AI, OpenRouter, Fireworks AI, SiliconFlow, Qwen Token Plan, Qwen Pay-As-You-Go |
+| Hunyuan 3        | OpenRouter                                                                       |
+| Qwen 3.8 Max     | Qwen Token Plan (preview)                                                        |
+| GPT 5.6          | OpenRouter                                                                       |
+| Gemini 3.6 Flash | Google Gemini, OpenRouter                                                        |
+| Claude 5         | Anthropic, OpenRouter                                                            |
 
-Any OpenAI-protocol endpoint is supported: pick a preset above, or point a custom endpoint at any of the 1000+ online and local models.
+Each family's latest generation only — the app's **Models** page lists every built-in preset, and any OpenAI-protocol endpoint works too: pick a preset, or point a custom endpoint at any of the 1000+ online and local models.
 
 ## Requirements
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -79,17 +79,19 @@ https://github.com/user-attachments/assets/aec49ae9-b743-467b-b247-37bedfeaa36e
 
 ## 支持的模型
 
-| 模型             | 可用供应商                                                                       |
-| ---------------- | -------------------------------------------------------------------------------- |
-| DeepSeek V4      | DeepSeek, OpenRouter, Fireworks AI, SiliconFlow, Qwen Token Plan                 |
-| Kimi K3          | OpenRouter, Qwen Pay-As-You-Go                                                   |
-| Kimi K2.6        | Moonshot AI                                                                      |
-| GLM 5.2          | Z.AI, OpenRouter, Fireworks AI, SiliconFlow, Qwen Token Plan, Qwen Pay-As-You-Go |
-| Hunyuan 3        | OpenRouter                                                                       |
-| Qwen 3.8 Max     | Qwen Token Plan（预览）                                                          |
-| GPT 5.5          | OpenAI, OpenRouter                                                               |
-| Gemini 3.5 Flash | Google Gemini, OpenRouter                                                        |
-| Claude Opus 4.8  | Anthropic, OpenRouter                                                            |
+| 模型                  | 可用供应商                                                                       |
+| --------------------- | -------------------------------------------------------------------------------- |
+| DeepSeek V4           | DeepSeek, OpenRouter, Fireworks AI, SiliconFlow, Qwen Token Plan                 |
+| Kimi K3               | OpenRouter, Qwen Pay-As-You-Go                                                   |
+| Kimi K2.6             | Moonshot AI                                                                      |
+| GLM 5.2               | Z.AI, OpenRouter, Fireworks AI, SiliconFlow, Qwen Token Plan, Qwen Pay-As-You-Go |
+| Hunyuan 3             | OpenRouter                                                                       |
+| Qwen 3.8 Max          | Qwen Token Plan（预览）                                                          |
+| GPT 5.5               | OpenAI, OpenRouter                                                               |
+| Gemini 3.6 Flash      | OpenRouter                                                                       |
+| Gemini 3.5 Flash      | Google Gemini, OpenRouter                                                        |
+| Gemini 3.5 Flash Lite | OpenRouter                                                                       |
+| Claude Opus 4.8       | Anthropic, OpenRouter                                                            |
 
 只要是 OpenAI 协议的端点都可以接入：从上表选择预置，或用自定义端点连接 1000+ 在线与本地模型。
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -82,15 +82,17 @@ https://github.com/user-attachments/assets/aec49ae9-b743-467b-b247-37bedfeaa36e
 | 模型                  | 可用供应商                                                                       |
 | --------------------- | -------------------------------------------------------------------------------- |
 | DeepSeek V4           | DeepSeek, OpenRouter, Fireworks AI, SiliconFlow, Qwen Token Plan                 |
-| Kimi K3               | OpenRouter, Qwen Pay-As-You-Go                                                   |
-| Kimi K2.6             | Moonshot AI                                                                      |
+| Kimi K3               | Moonshot AI, OpenRouter, Qwen Pay-As-You-Go                                      |
+| Kimi K2.6             | Moonshot AI, OpenRouter, SiliconFlow                                             |
 | GLM 5.2               | Z.AI, OpenRouter, Fireworks AI, SiliconFlow, Qwen Token Plan, Qwen Pay-As-You-Go |
 | Hunyuan 3             | OpenRouter                                                                       |
 | Qwen 3.8 Max          | Qwen Token Plan（预览）                                                          |
 | GPT 5.5               | OpenAI, OpenRouter                                                               |
-| Gemini 3.6 Flash      | OpenRouter                                                                       |
+| Gemini 3.6 Flash      | Google Gemini, OpenRouter                                                        |
 | Gemini 3.5 Flash      | Google Gemini, OpenRouter                                                        |
-| Gemini 3.5 Flash Lite | OpenRouter                                                                       |
+| Gemini 3.5 Flash-Lite | Google Gemini, OpenRouter                                                        |
+| Claude Fable 5        | Anthropic, OpenRouter                                                            |
+| Claude Sonnet 5       | Anthropic, OpenRouter                                                            |
 | Claude Opus 4.8       | Anthropic, OpenRouter                                                            |
 
 只要是 OpenAI 协议的端点都可以接入：从上表选择预置，或用自定义端点连接 1000+ 在线与本地模型。

--- a/README.zh.md
+++ b/README.zh.md
@@ -79,23 +79,18 @@ https://github.com/user-attachments/assets/aec49ae9-b743-467b-b247-37bedfeaa36e
 
 ## 支持的模型
 
-| 模型                  | 可用供应商                                                                       |
-| --------------------- | -------------------------------------------------------------------------------- |
-| DeepSeek V4           | DeepSeek, OpenRouter, Fireworks AI, SiliconFlow, Qwen Token Plan                 |
-| Kimi K3               | Moonshot AI, OpenRouter, Qwen Pay-As-You-Go                                      |
-| Kimi K2.6             | Moonshot AI, OpenRouter, SiliconFlow                                             |
-| GLM 5.2               | Z.AI, OpenRouter, Fireworks AI, SiliconFlow, Qwen Token Plan, Qwen Pay-As-You-Go |
-| Hunyuan 3             | OpenRouter                                                                       |
-| Qwen 3.8 Max          | Qwen Token Plan（预览）                                                          |
-| GPT 5.5               | OpenAI, OpenRouter                                                               |
-| Gemini 3.6 Flash      | Google Gemini, OpenRouter                                                        |
-| Gemini 3.5 Flash      | Google Gemini, OpenRouter                                                        |
-| Gemini 3.5 Flash-Lite | Google Gemini, OpenRouter                                                        |
-| Claude Fable 5        | Anthropic, OpenRouter                                                            |
-| Claude Sonnet 5       | Anthropic, OpenRouter                                                            |
-| Claude Opus 4.8       | Anthropic, OpenRouter                                                            |
+| 模型             | 可用供应商                                                                       |
+| ---------------- | -------------------------------------------------------------------------------- |
+| DeepSeek V4      | DeepSeek, OpenRouter, Fireworks AI, SiliconFlow, Qwen Token Plan                 |
+| Kimi K3          | Moonshot AI, OpenRouter, Qwen Pay-As-You-Go                                      |
+| GLM 5.2          | Z.AI, OpenRouter, Fireworks AI, SiliconFlow, Qwen Token Plan, Qwen Pay-As-You-Go |
+| Hunyuan 3        | OpenRouter                                                                       |
+| Qwen 3.8 Max     | Qwen Token Plan（预览）                                                          |
+| GPT 5.6          | OpenRouter                                                                       |
+| Gemini 3.6 Flash | Google Gemini, OpenRouter                                                        |
+| Claude 5         | Anthropic, OpenRouter                                                            |
 
-只要是 OpenAI 协议的端点都可以接入：从上表选择预置，或用自定义端点连接 1000+ 在线与本地模型。
+上表每个系列只列最新一代，完整预置清单请在应用的**模型**页查看；只要是 OpenAI 协议的端点都可以接入：选择预置，或用自定义端点连接 1000+ 在线与本地模型。
 
 ## 系统需求
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,7 +22,7 @@
     "penguin": "tsx src/index.ts"
   },
   "dependencies": {
-    "@prismshadow/agenthub": "^0.4.0",
+    "@prismshadow/agenthub": "^0.4.1",
     "@prismshadow/penguin-core": "workspace:*",
     "@prismshadow/penguin-server": "workspace:*",
     "@prismshadow/penguin-skills": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,7 +36,7 @@
     "build": "tsup"
   },
   "dependencies": {
-    "@prismshadow/agenthub": "^0.4.0",
+    "@prismshadow/agenthub": "^0.4.1",
     "@prismshadow/penguin-skills": "workspace:*",
     "smol-toml": "^1.3.0",
     "yaml": "^2.5.0"

--- a/packages/core/src/state/model-catalog.ts
+++ b/packages/core/src/state/model-catalog.ts
@@ -319,7 +319,7 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     // Same published-cache-price convention as gemini-3.6-flash above (2026-07-22: $0.03/mtok
     // cache hit, $0.30 input, $2.50 output).
     modelId: "google/gemini-3.5-flash-lite",
-    displayName: "Gemini 3.5 Flash Lite",
+    displayName: "Gemini 3.5 Flash-Lite",
     provider: "openrouter",
     contextWindow: 1048576,
     pricing: usd(0.03, 0.3, 2.5),
@@ -344,6 +344,16 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     provider: "openrouter",
     contextWindow: 1000000,
     pricing: usd(3, 3, 15),
+    supportsVision: true,
+    clientType: "openai",
+    baseUrl: OPENROUTER_BASE_URL,
+  },
+  {
+    modelId: "moonshotai/kimi-k2.6",
+    displayName: "Kimi K2.6",
+    provider: "openrouter",
+    contextWindow: 262144,
+    pricing: usd(0.144, 0.684, 3.42),
     supportsVision: true,
     clientType: "openai",
     baseUrl: OPENROUTER_BASE_URL,
@@ -384,6 +394,18 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     provider: "openrouter",
     contextWindow: 1000000,
     pricing: usd(5, 5, 30),
+    supportsVision: true,
+    clientType: "openai",
+    baseUrl: OPENROUTER_BASE_URL,
+  },
+  {
+    // Neither the OpenRouter page nor AgentHub's registry publishes a cache price for this
+    // model, so cache_read repeats the input price (no discount assumed).
+    modelId: "qwen/qwen3.6-35b-a3b",
+    displayName: "Qwen 3.6 35B A3B",
+    provider: "openrouter",
+    contextWindow: 262144,
+    pricing: usd(0.14, 0.14, 1),
     supportsVision: true,
     clientType: "openai",
     baseUrl: OPENROUTER_BASE_URL,
@@ -435,6 +457,16 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     provider: "openrouter",
     contextWindow: 1000000,
     pricing: usd(0.93, 0.93, 3),
+    supportsVision: false,
+    clientType: "openai",
+    baseUrl: OPENROUTER_BASE_URL,
+  },
+  {
+    modelId: "z-ai/glm-5.1",
+    displayName: "GLM-5.1",
+    provider: "openrouter",
+    contextWindow: 204800,
+    pricing: usd(0.1794, 0.966, 3.036),
     supportsVision: false,
     clientType: "openai",
     baseUrl: OPENROUTER_BASE_URL,
@@ -529,6 +561,38 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     provider: "siliconflow",
     contextWindow: 262144,
     pricing: cny(1.3, 6.5, 27),
+    supportsVision: true,
+    clientType: "openai",
+    baseUrl: SILICONFLOW_BASE_URL,
+  },
+  // The three Pro/ and Qwen/ entries below carry no pricing: AgentHub's registry publishes
+  // none for them, and SiliconFlow's price list sits behind an authenticated API (the public
+  // /v1/models endpoint returns 401 and the console page is client-rendered). Rather than
+  // invent a rate, the entries ship unpriced — the same state as qwen3.8-max-preview, so their
+  // cost reads as 0 until a published price can be filled in.
+  {
+    modelId: "Pro/moonshotai/Kimi-K2.6",
+    displayName: "Kimi K2.6",
+    provider: "siliconflow",
+    contextWindow: 262144,
+    supportsVision: true,
+    clientType: "openai",
+    baseUrl: SILICONFLOW_BASE_URL,
+  },
+  {
+    modelId: "Pro/zai-org/GLM-5.1",
+    displayName: "GLM-5.1",
+    provider: "siliconflow",
+    contextWindow: 200000,
+    supportsVision: false,
+    clientType: "openai",
+    baseUrl: SILICONFLOW_BASE_URL,
+  },
+  {
+    modelId: "Qwen/Qwen3.6-35B-A3B",
+    displayName: "Qwen 3.6 35B A3B",
+    provider: "siliconflow",
+    contextWindow: 262144,
     supportsVision: true,
     clientType: "openai",
     baseUrl: SILICONFLOW_BASE_URL,
@@ -643,11 +707,27 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
   },
   // -- Google Gemini (official USD pricing) --
   {
+    modelId: "gemini-3.6-flash",
+    displayName: "Gemini 3.6 Flash",
+    provider: "google",
+    contextWindow: 1048576,
+    pricing: usd(0.15, 1.5, 7.5),
+    supportsVision: true,
+  },
+  {
     modelId: "gemini-3.5-flash",
     displayName: "Gemini 3.5 Flash",
     provider: "google",
     contextWindow: 1048576,
     pricing: usd(0.15, 1.5, 9),
+    supportsVision: true,
+  },
+  {
+    modelId: "gemini-3.5-flash-lite",
+    displayName: "Gemini 3.5 Flash-Lite",
+    provider: "google",
+    contextWindow: 1048576,
+    pricing: usd(0.03, 0.3, 2.5),
     supportsVision: true,
   },
   {
@@ -677,6 +757,14 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
   },
   // -- Anthropic (official USD pricing; cache write = 1.25 x input) --
   {
+    modelId: "claude-fable-5",
+    displayName: "Claude Fable 5",
+    provider: "anthropic",
+    contextWindow: 1000000,
+    pricing: usd(1, 12.5, 50),
+    supportsVision: true,
+  },
+  {
     modelId: "claude-opus-4-8",
     displayName: "Claude Opus 4.8",
     provider: "anthropic",
@@ -690,6 +778,14 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     provider: "anthropic",
     contextWindow: 1000000,
     pricing: usd(0.5, 6.25, 25),
+    supportsVision: true,
+  },
+  {
+    modelId: "claude-sonnet-5",
+    displayName: "Claude Sonnet 5",
+    provider: "anthropic",
+    contextWindow: 1000000,
+    pricing: usd(0.2, 2.5, 10),
     supportsVision: true,
   },
   {
@@ -778,6 +874,14 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
   },
   // -- Moonshot (Kimi) (official CNY pricing) --
   {
+    modelId: "kimi-k3",
+    displayName: "Kimi K3",
+    provider: "moonshot",
+    contextWindow: 1048576,
+    pricing: cny(2, 20, 100),
+    supportsVision: true,
+  },
+  {
     modelId: "kimi-k2.6",
     displayName: "Kimi K2.6",
     provider: "moonshot",
@@ -816,7 +920,7 @@ export interface ModelEnvInfo {
 
 /**
  * Resolves the env var fallback for a model: mirrors AgentHub's
- * AutoLLMClient routing rules (verified against agenthub v0.3.3 autoClient.ts) - an explicit
+ * AutoLLMClient routing rules (verified against agenthub v0.4.1 autoClient.ts) - an explicit
  * client_type takes priority, otherwise routes to a client by lowercase substring match on
  * model_id, returning the var pair that client reads; branch order matches AutoLLMClient.
  * Returns undefined on no match (AgentHub will reject that id: it needs an explicit
@@ -837,6 +941,8 @@ export function resolveModelEnv(modelId: string, clientType?: string): ModelEnvI
   }
   if (t.includes("gpt-5.4") || t.includes("gpt-5.5")) return env("OPENAI");
   if (t.includes("glm-5")) return env("ZAI");
+  // agenthub 0.4.1 routes kimi-k3 to its own client, which reads the same MOONSHOT_* pair.
+  if (t.includes("kimi-k3")) return env("MOONSHOT");
   if (t.includes("kimi-k2.5") || t.includes("kimi-k2.6")) return env("MOONSHOT");
   if (t.includes("deepseek-v4")) return env("DEEPSEEK");
   if (t.includes("openai")) return env("OPENAI");

--- a/packages/core/src/state/model-catalog.ts
+++ b/packages/core/src/state/model-catalog.ts
@@ -222,7 +222,12 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
   // 2026-07-20 list no cache pricing on their OpenRouter pages, so cache_read carries the
   // standard input price; their :free tier stores a genuine $0 price (not "unknown"), so
   // costs correctly compute to 0. GPT models are uniformly vision-capable (OpenAI
-  // product-line policy) even where the gateway page omits the modality. --
+  // product-line policy) even where the gateway page omits the modality.
+  // Two cache_read conventions coexist in this block: rows whose upstream publishes a
+  // cache-hit price store that real price (the google/gemini-3.6-flash and
+  // google/gemini-3.5-flash-lite entries below), while the 2026-07-20 rows still repeat the
+  // input price. Several of those older rows do have a published cache price upstream and
+  // should be re-read in one pass; until then treat their cache_read as an upper bound. --
   {
     modelId: "anthropic/claude-fable-5",
     displayName: "Claude Fable 5",
@@ -284,13 +289,18 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     baseUrl: OPENROUTER_BASE_URL,
   },
   {
-    // Context window and list price read from the model's OpenRouter page (2026-07-22);
-    // the page publishes no cache price, so cache_read carries the standard input price.
+    // Unlike the older OpenRouter entries above, upstream **does** publish a cache-hit price
+    // for the Gemini rows (2026-07-22: $0.15/mtok here, agreed by the OpenRouter models API
+    // and AgentHub's own supported-model registry), so cache_read stores the real discounted
+    // price rather than repeating the input price: cache_read is billed as its own bucket in
+    // the cost center, and an input-priced cache_read overstates cache-heavy spend 10x.
+    // cache_write repeats the input price (no separate per-token cache-write fee), matching
+    // the direct-vendor Gemini rows below.
     modelId: "google/gemini-3.6-flash",
     displayName: "Gemini 3.6 Flash",
     provider: "openrouter",
     contextWindow: 1048576,
-    pricing: usd(1.5, 1.5, 7.5),
+    pricing: usd(0.15, 1.5, 7.5),
     supportsVision: true,
     clientType: "openai",
     baseUrl: OPENROUTER_BASE_URL,
@@ -299,19 +309,20 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     modelId: "google/gemini-3.5-flash",
     displayName: "Gemini 3.5 Flash",
     provider: "openrouter",
-    contextWindow: 1000000,
+    contextWindow: 1048576,
     pricing: usd(1.5, 1.5, 9),
     supportsVision: true,
     clientType: "openai",
     baseUrl: OPENROUTER_BASE_URL,
   },
   {
-    // Same 2026-07-22 OpenRouter page reading as gemini-3.6-flash above (no cache price listed).
+    // Same published-cache-price convention as gemini-3.6-flash above (2026-07-22: $0.03/mtok
+    // cache hit, $0.30 input, $2.50 output).
     modelId: "google/gemini-3.5-flash-lite",
     displayName: "Gemini 3.5 Flash Lite",
     provider: "openrouter",
     contextWindow: 1048576,
-    pricing: usd(0.3, 0.3, 2.5),
+    pricing: usd(0.03, 0.3, 2.5),
     supportsVision: true,
     clientType: "openai",
     baseUrl: OPENROUTER_BASE_URL,

--- a/packages/core/src/state/model-catalog.ts
+++ b/packages/core/src/state/model-catalog.ts
@@ -284,11 +284,34 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     baseUrl: OPENROUTER_BASE_URL,
   },
   {
+    // Context window and list price read from the model's OpenRouter page (2026-07-22);
+    // the page publishes no cache price, so cache_read carries the standard input price.
+    modelId: "google/gemini-3.6-flash",
+    displayName: "Gemini 3.6 Flash",
+    provider: "openrouter",
+    contextWindow: 1048576,
+    pricing: usd(1.5, 1.5, 7.5),
+    supportsVision: true,
+    clientType: "openai",
+    baseUrl: OPENROUTER_BASE_URL,
+  },
+  {
     modelId: "google/gemini-3.5-flash",
     displayName: "Gemini 3.5 Flash",
     provider: "openrouter",
     contextWindow: 1000000,
     pricing: usd(1.5, 1.5, 9),
+    supportsVision: true,
+    clientType: "openai",
+    baseUrl: OPENROUTER_BASE_URL,
+  },
+  {
+    // Same 2026-07-22 OpenRouter page reading as gemini-3.6-flash above (no cache price listed).
+    modelId: "google/gemini-3.5-flash-lite",
+    displayName: "Gemini 3.5 Flash Lite",
+    provider: "openrouter",
+    contextWindow: 1048576,
+    pricing: usd(0.3, 0.3, 2.5),
     supportsVision: true,
     clientType: "openai",
     baseUrl: OPENROUTER_BASE_URL,

--- a/packages/core/test/model-catalog.test.ts
+++ b/packages/core/test/model-catalog.test.ts
@@ -69,11 +69,19 @@ describe("model-catalog", () => {
   });
 
   it("price buckets are positive (preview models without a list price omit pricing); context_window is a positive integer", () => {
+    // Models with no obtainable published price. qwen3.8-max-preview: the plan runs a
+    // quota-multiplier promotion instead of a per-token list price. The three SiliconFlow
+    // entries: AgentHub's registry publishes no pricing for them and SiliconFlow's price list
+    // is only reachable with an authenticated token, so no number can be sourced. All of them
+    // carry no pricing and their costs read as 0, same as unpriced user models.
+    const UNPRICED = new Set([
+      "qwen-token-plan\0qwen3.8-max-preview",
+      "siliconflow\0Pro/moonshotai/Kimi-K2.6",
+      "siliconflow\0Pro/zai-org/GLM-5.1",
+      "siliconflow\0Qwen/Qwen3.6-35B-A3B",
+    ]);
     for (const m of MODEL_CATALOG) {
-      if (m.provider === "qwen-token-plan" && m.modelId === "qwen3.8-max-preview") {
-        // Preview-only model: the plan runs a quota-multiplier promotion and publishes no
-        // per-token list price, so the entry carries none and costs read as 0 (same as
-        // unpriced user models).
+      if (UNPRICED.has(`${m.provider}\0${m.modelId}`)) {
         expect(m.pricing, m.modelId).toBeUndefined();
       } else if (m.modelId.endsWith(":free")) {
         // Free-tier gateway model: a genuine $0 price (not "unknown"), so costs compute to 0.
@@ -154,15 +162,18 @@ describe("model-catalog", () => {
       "google/gemini-3.5-flash-lite",
       "minimax/minimax-m3",
       "moonshotai/kimi-k3",
+      "moonshotai/kimi-k2.6",
       "nvidia/nemotron-3-ultra-550b-a55b:free",
       "openai/gpt-5.6-sol",
       "openai/gpt-5.6-terra",
       "openai/gpt-5.5",
+      "qwen/qwen3.6-35b-a3b",
       "stepfun/step-3.7-flash",
       "tencent/hy3",
       "x-ai/grok-4.5",
       "xiaomi/mimo-v2.5",
       "z-ai/glm-5.2",
+      "z-ai/glm-5.1",
     ]);
     for (const m of or) {
       expect(m.clientType).toBe("openai");
@@ -181,11 +192,16 @@ describe("model-catalog", () => {
       expect(m.baseUrl).toBe("https://api.fireworks.ai/inference/v1");
     }
     const sf = MODEL_CATALOG.filter((m) => m.provider === "siliconflow");
+    // Dictionary order is case-insensitive (as in qwen-pay-as-you-go, where ZHIPU/GLM-5.2
+    // sorts last): Pro/ and Qwen/ fall between moonshotai/ and zai-org/.
     expect(sf.map((m) => m.modelId)).toEqual([
       "deepseek-ai/DeepSeek-V4-Flash",
       "deepseek-ai/DeepSeek-V4-Pro",
       "meituan-longcat/LongCat-2.0",
       "moonshotai/Kimi-K2.7-Code",
+      "Pro/moonshotai/Kimi-K2.6",
+      "Pro/zai-org/GLM-5.1",
+      "Qwen/Qwen3.6-35B-A3B",
       "zai-org/GLM-5.2",
     ]);
     for (const m of sf) {
@@ -290,12 +306,78 @@ describe("model-catalog", () => {
     );
   });
 
+  it("direct-vendor groups: auto-routed (no client_type / base_url), newest series first", () => {
+    // These groups' ids are auto-routed by AgentHub, so they carry neither client_type nor a
+    // preset base URL — the opposite of the gateway groups above.
+    for (const id of ["google", "anthropic", "moonshot"]) {
+      for (const m of MODEL_CATALOG.filter((e) => e.provider === id)) {
+        expect(m.clientType, m.modelId).toBeUndefined();
+        expect(m.baseUrl, m.modelId).toBeUndefined();
+      }
+    }
+    // Dictionary order by tier with newer versions of a tier first (same rule the OpenRouter
+    // block follows for the identical Claude line-up).
+    expect(MODEL_CATALOG.filter((m) => m.provider === "google").map((m) => m.modelId)).toEqual([
+      "gemini-3.6-flash",
+      "gemini-3.5-flash",
+      "gemini-3.5-flash-lite",
+      "gemini-3.1-flash-lite",
+      "gemini-3.1-pro-preview",
+      "gemini-3-flash-preview",
+    ]);
+    expect(MODEL_CATALOG.filter((m) => m.provider === "anthropic").map((m) => m.modelId)).toEqual([
+      "claude-fable-5",
+      "claude-opus-4-8",
+      "claude-opus-4-7",
+      "claude-sonnet-5",
+      "claude-sonnet-4-6",
+    ]);
+    expect(MODEL_CATALOG.filter((m) => m.provider === "moonshot").map((m) => m.modelId)).toEqual([
+      "kimi-k3",
+      "kimi-k2.6",
+      "kimi-k2.5",
+    ]);
+    // Anthropic keeps its cache_write = 1.25 x input convention for the Claude 5 line too
+    // (registry input 10 and 2 -> 12.5 and 2.5), unlike every other group where cache_write
+    // repeats the input price.
+    const fable = catalogEntryFor("anthropic", "claude-fable-5")!;
+    expect([fable.pricing!.cache_read, fable.pricing!.cache_write, fable.pricing!.output]).toEqual([
+      1, 12.5, 50,
+    ]);
+    const sonnet5 = catalogEntryFor("anthropic", "claude-sonnet-5")!;
+    expect([
+      sonnet5.pricing!.cache_read,
+      sonnet5.pricing!.cache_write,
+      sonnet5.pricing!.output,
+    ]).toEqual([0.2, 2.5, 10]);
+    // The same model resold by a gateway keeps one display name across groups.
+    for (const [directProvider, directId, gatewayProvider, gatewayId] of [
+      ["anthropic", "claude-fable-5", "openrouter", "anthropic/claude-fable-5"],
+      ["anthropic", "claude-sonnet-5", "openrouter", "anthropic/claude-sonnet-5"],
+      ["google", "gemini-3.5-flash-lite", "openrouter", "google/gemini-3.5-flash-lite"],
+      ["moonshot", "kimi-k3", "openrouter", "moonshotai/kimi-k3"],
+      ["moonshot", "kimi-k2.6", "openrouter", "moonshotai/kimi-k2.6"],
+      ["moonshot", "kimi-k2.6", "siliconflow", "Pro/moonshotai/Kimi-K2.6"],
+      ["zhipu", "glm-5.1", "openrouter", "z-ai/glm-5.1"],
+      ["zhipu", "glm-5.1", "siliconflow", "Pro/zai-org/GLM-5.1"],
+    ] as const) {
+      expect(
+        catalogEntryFor(gatewayProvider, gatewayId)!.displayName,
+        `${gatewayProvider}/${gatewayId}`,
+      ).toBe(catalogEntryFor(directProvider, directId)!.displayName);
+    }
+  });
+
   it("DeepSeek and Kimi are initialized from official CNY prices (stored in USD; x7 recovers the official price)", () => {
     const cnyOf = (usdV: number) => Math.round(usdV * 7 * 1000) / 1000;
     const pro = MODEL_CATALOG.find((m) => m.modelId === "deepseek-v4-pro")!.pricing!;
     expect([cnyOf(pro.cache_read), cnyOf(pro.cache_write), cnyOf(pro.output)]).toEqual([
       0.025, 3, 6,
     ]);
+    const k3 = MODEL_CATALOG.find(
+      (m) => m.provider === "moonshot" && m.modelId === "kimi-k3",
+    )!.pricing!;
+    expect([cnyOf(k3.cache_read), cnyOf(k3.cache_write), cnyOf(k3.output)]).toEqual([2, 20, 100]);
     const k26 = MODEL_CATALOG.find((m) => m.modelId === "kimi-k2.6")!.pricing!;
     expect([cnyOf(k26.cache_read), cnyOf(k26.cache_write), cnyOf(k26.output)]).toEqual([
       1.1, 6.5, 27,
@@ -312,6 +394,14 @@ describe("resolveModelEnv (PRN-021: env fallback resolved by AgentHub routing ru
     expect(resolveModelEnv("gpt-5.5-pro")?.envKey).toBe("OPENAI_API_KEY");
     expect(resolveModelEnv("glm-5.2")?.envKey).toBe("ZAI_API_KEY");
     expect(resolveModelEnv("kimi-k2.6")?.envBaseUrlKey).toBe("MOONSHOT_BASE_URL");
+    // agenthub 0.4.1 routes these to their own clients; both read the same env pair as the
+    // family they belong to, so the id must still resolve (kimi-k3 matches no k2.x substring).
+    expect(resolveModelEnv("kimi-k3")?.envKey).toBe("MOONSHOT_API_KEY");
+    expect(resolveModelEnv("kimi-k3")?.envBaseUrlKey).toBe("MOONSHOT_BASE_URL");
+    expect(resolveModelEnv("gemini-3.6-flash")?.envKey).toBe("GEMINI_API_KEY");
+    expect(resolveModelEnv("gemini-3.5-flash-lite")?.envKey).toBe("GEMINI_API_KEY");
+    expect(resolveModelEnv("claude-fable-5")?.envKey).toBe("ANTHROPIC_API_KEY");
+    expect(resolveModelEnv("claude-sonnet-5")?.envKey).toBe("ANTHROPIC_API_KEY");
   });
 
   it("explicit client_type beats id: the openai protocol always uses OPENAI_* (independent of grouping)", () => {

--- a/packages/core/test/model-catalog.test.ts
+++ b/packages/core/test/model-catalog.test.ts
@@ -263,12 +263,13 @@ describe("model-catalog", () => {
     expect([mimo.cache_read, mimo.cache_write, mimo.output]).toEqual([0.0028, 0.14, 0.28]);
     const hy3 = MODEL_CATALOG.find((m) => m.modelId === "tencent/hy3")!.pricing!;
     expect([hy3.cache_read, hy3.cache_write, hy3.output]).toEqual([0.035, 0.14, 0.58]);
-    // Gemini 3.6 Flash and 3.5 Flash Lite: their OpenRouter pages list only in/out prices, so
-    // cache_read repeats the input price (same convention as the other google/* entries).
+    // Gemini 3.6 Flash and 3.5 Flash Lite: upstream publishes a cache-hit price, so cache_read
+    // stores the real discounted price (not the input price) — cache_read is its own billing
+    // bucket in the cost center. cache_write repeats input (no per-token cache-write fee).
     const g36 = catalogEntryFor("openrouter", "google/gemini-3.6-flash")!;
     expect([g36.contextWindow, g36.supportsVision]).toEqual([1048576, true]);
     expect([g36.pricing!.cache_read, g36.pricing!.cache_write, g36.pricing!.output]).toEqual([
-      1.5, 1.5, 7.5,
+      0.15, 1.5, 7.5,
     ]);
     const g35lite = catalogEntryFor("openrouter", "google/gemini-3.5-flash-lite")!;
     expect([g35lite.contextWindow, g35lite.supportsVision]).toEqual([1048576, true]);
@@ -276,7 +277,11 @@ describe("model-catalog", () => {
       g35lite.pricing!.cache_read,
       g35lite.pricing!.cache_write,
       g35lite.pricing!.output,
-    ]).toEqual([0.3, 0.3, 2.5]);
+    ]).toEqual([0.03, 0.3, 2.5]);
+    // The gateway row for gemini-3.5-flash reports the same context window as the
+    // direct-vendor row for that model (and as AgentHub's registry): 1048576, not 1000000.
+    expect(catalogEntryFor("openrouter", "google/gemini-3.5-flash")!.contextWindow).toBe(1048576);
+    expect(catalogEntryFor("google", "gemini-3.5-flash")!.contextWindow).toBe(1048576);
 
     // In preset entries, exactly the gateway models (and only them) inline base_url (no credentials).
     const withBaseUrl = presetModelEntries().filter((e) => e.base_url !== undefined);

--- a/packages/core/test/model-catalog.test.ts
+++ b/packages/core/test/model-catalog.test.ts
@@ -149,7 +149,9 @@ describe("model-catalog", () => {
       "anthropic/claude-sonnet-5",
       "deepseek/deepseek-v4-flash",
       "deepseek/deepseek-v4-pro",
+      "google/gemini-3.6-flash",
       "google/gemini-3.5-flash",
+      "google/gemini-3.5-flash-lite",
       "minimax/minimax-m3",
       "moonshotai/kimi-k3",
       "nvidia/nemotron-3-ultra-550b-a55b:free",
@@ -261,6 +263,20 @@ describe("model-catalog", () => {
     expect([mimo.cache_read, mimo.cache_write, mimo.output]).toEqual([0.0028, 0.14, 0.28]);
     const hy3 = MODEL_CATALOG.find((m) => m.modelId === "tencent/hy3")!.pricing!;
     expect([hy3.cache_read, hy3.cache_write, hy3.output]).toEqual([0.035, 0.14, 0.58]);
+    // Gemini 3.6 Flash and 3.5 Flash Lite: their OpenRouter pages list only in/out prices, so
+    // cache_read repeats the input price (same convention as the other google/* entries).
+    const g36 = catalogEntryFor("openrouter", "google/gemini-3.6-flash")!;
+    expect([g36.contextWindow, g36.supportsVision]).toEqual([1048576, true]);
+    expect([g36.pricing!.cache_read, g36.pricing!.cache_write, g36.pricing!.output]).toEqual([
+      1.5, 1.5, 7.5,
+    ]);
+    const g35lite = catalogEntryFor("openrouter", "google/gemini-3.5-flash-lite")!;
+    expect([g35lite.contextWindow, g35lite.supportsVision]).toEqual([1048576, true]);
+    expect([
+      g35lite.pricing!.cache_read,
+      g35lite.pricing!.cache_write,
+      g35lite.pricing!.output,
+    ]).toEqual([0.3, 0.3, 2.5]);
 
     // In preset entries, exactly the gateway models (and only them) inline base_url (no credentials).
     const withBaseUrl = presetModelEntries().filter((e) => e.base_url !== undefined);

--- a/packages/skills/skills/agenthub-models/SKILL.md
+++ b/packages/skills/skills/agenthub-models/SKILL.md
@@ -54,7 +54,8 @@ Use exact model ids. If an id is not in the table below and the user has not giv
 | Gemini 3 image   | `gemini-3.1-flash-image`, `gemini-3-pro-image-preview`                | —                                                                                                                                               |
 | Gemini 3 TTS     | `gemini-3.1-flash-tts-preview`                                        | —                                                                                                                                               |
 | Gemini embedding | `gemini-embedding-2`                                                  | —                                                                                                                                               |
-| Claude           | `claude-sonnet-4-6`, `claude-opus-4-7`, `claude-opus-4-8`             | —                                                                                                                                               |
+| Claude 5         | `claude-fable-5`, `claude-sonnet-5`                                   | OpenRouter `anthropic/claude-fable-5`, `anthropic/claude-sonnet-5`                                                                              |
+| Claude 4         | `claude-sonnet-4-6`, `claude-opus-4-7`, `claude-opus-4-8`             | OpenRouter `anthropic/claude-opus-4.8`, `anthropic/claude-opus-4.7`                                                                             |
 | GPT              | `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.5`                  | —                                                                                                                                               |
 | OpenAI embedding | `text-embedding-3-small`, `text-embedding-3-large`                    | —                                                                                                                                               |
 | Kimi K3          | `kimi-k3`                                                             | OpenRouter `moonshotai/kimi-k3`                                                                                                                 |
@@ -62,6 +63,7 @@ Use exact model ids. If an id is not in the table below and the user has not giv
 | DeepSeek V4      | `deepseek-v4-pro`, `deepseek-v4-flash`                                | OpenRouter `deepseek/deepseek-v4-pro`, `deepseek/deepseek-v4-flash`; SiliconFlow `deepseek-ai/DeepSeek-V4-Pro`, `deepseek-ai/DeepSeek-V4-Flash` |
 | GLM 5.2          | `glm-5.2`                                                             | OpenRouter `z-ai/glm-5.2`; SiliconFlow `zai-org/GLM-5.2`                                                                                        |
 | GLM 5.1          | `glm-5.1`                                                             | OpenRouter `z-ai/glm-5.1`; SiliconFlow `Pro/zai-org/GLM-5.1`                                                                                    |
+| Qwen 3.6         | —                                                                     | OpenRouter `qwen/qwen3.6-35b-a3b`; SiliconFlow `Qwen/Qwen3.6-35B-A3B`                                                                           |
 
 The image endpoint dropped its preview suffix: `gemini-3.1-flash-image-preview` is deprecated, use `gemini-3.1-flash-image`.
 

--- a/packages/skills/skills/agenthub-models/SKILL.md
+++ b/packages/skills/skills/agenthub-models/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: agenthub-models
-description: Call model APIs through @prismshadow/agenthub — streaming text generation, image generation, speech synthesis and embeddings with one client.
+description: Call model APIs through @prismshadow/agenthub — streaming text generation, image generation, speech synthesis, embeddings and the supported-model registry with one client.
 short_description: Call model APIs with one AgentHub client.
 short_description_zh: 用一个 AgentHub 客户端调用模型 API。
-version: 7
-updated: 2026-07-21T00:00:00Z
+version: 8
+updated: 2026-07-22T00:00:00Z
 ---
 
 # AgentHub Model APIs
@@ -15,7 +15,7 @@ updated: 2026-07-21T00:00:00Z
 npm install @prismshadow/agenthub
 ```
 
-The only entry point is `AutoLLMClient`:
+The main entry point is `AutoLLMClient`:
 
 ```ts
 import { AutoLLMClient } from "@prismshadow/agenthub";
@@ -23,7 +23,7 @@ import { AutoLLMClient } from "@prismshadow/agenthub";
 const client = new AutoLLMClient({ model: "<model_id>", apiKey: "<key>", baseUrl: "<url>", clientType: "<type>" });
 ```
 
-`apiKey`, `baseUrl` and `clientType` are optional (see routing below).
+`apiKey`, `baseUrl` and `clientType` are optional (see routing below). The package also exports `listSupportedModels` (the model registry) and the error classes `AgentHubError`, `UnsupportedParameterError`, `EmptyResponseError` and `ToolCallArgumentParseError`.
 
 ## Before you start
 
@@ -49,16 +49,21 @@ Use exact model ids. If an id is not in the table below and the user has not giv
 
 | Family           | Official IDs                                                          | Gateway variants                                                                                                                                |
 | ---------------- | --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Gemini 3.6       | `gemini-3.6-flash`, `gemini-3.5-flash-lite`                           | —                                                                                                                                               |
 | Gemini 3         | `gemini-3.1-pro-preview`, `gemini-3.5-flash`, `gemini-3.1-flash-lite` | —                                                                                                                                               |
-| Gemini 3 image   | `gemini-3.1-flash-image-preview`, `gemini-3-pro-image-preview`        | —                                                                                                                                               |
+| Gemini 3 image   | `gemini-3.1-flash-image`, `gemini-3-pro-image-preview`                | —                                                                                                                                               |
 | Gemini 3 TTS     | `gemini-3.1-flash-tts-preview`                                        | —                                                                                                                                               |
 | Gemini embedding | `gemini-embedding-2`                                                  | —                                                                                                                                               |
 | Claude           | `claude-sonnet-4-6`, `claude-opus-4-7`, `claude-opus-4-8`             | —                                                                                                                                               |
 | GPT              | `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.5`                  | —                                                                                                                                               |
 | OpenAI embedding | `text-embedding-3-small`, `text-embedding-3-large`                    | —                                                                                                                                               |
+| Kimi K3          | `kimi-k3`                                                             | OpenRouter `moonshotai/kimi-k3`                                                                                                                 |
 | Kimi K2.6        | `kimi-k2.6`                                                           | OpenRouter `moonshotai/kimi-k2.6`; SiliconFlow `Pro/moonshotai/Kimi-K2.6`                                                                       |
 | DeepSeek V4      | `deepseek-v4-pro`, `deepseek-v4-flash`                                | OpenRouter `deepseek/deepseek-v4-pro`, `deepseek/deepseek-v4-flash`; SiliconFlow `deepseek-ai/DeepSeek-V4-Pro`, `deepseek-ai/DeepSeek-V4-Flash` |
+| GLM 5.2          | `glm-5.2`                                                             | OpenRouter `z-ai/glm-5.2`; SiliconFlow `zai-org/GLM-5.2`                                                                                        |
 | GLM 5.1          | `glm-5.1`                                                             | OpenRouter `z-ai/glm-5.1`; SiliconFlow `Pro/zai-org/GLM-5.1`                                                                                    |
+
+The image endpoint dropped its preview suffix: `gemini-3.1-flash-image-preview` is deprecated, use `gemini-3.1-flash-image`.
 
 Gateway model lists can be queried online:
 
@@ -67,9 +72,28 @@ curl https://openrouter.ai/api/v1/models
 curl --request GET --url https://api.siliconflow.cn/v1/models --header 'Authorization: Bearer <token>'
 ```
 
+## Supported-model registry
+
+`listSupportedModels(currency?)` returns the models AgentHub itself knows how to route, so ids, endpoints, modalities, context windows and prices can be read from the package instead of being hardcoded:
+
+```ts
+import { listSupportedModels } from "@prismshadow/agenthub";
+
+for (const m of listSupportedModels()) {
+  console.log(m.model, m.base_url, m.client, m.context_window, m.pricing?.prompt_tokens);
+}
+```
+
+- Each `SupportedModel` is `{ model, base_url, client, input_modalities, output_modalities, context_window?, pricing? }`. The `(model, base_url, client)` triple maps straight onto the constructor: `new AutoLLMClient({ model, baseUrl: base_url, clientType: client })`.
+- Modalities are `"Text" | "Image" | "Video" | "Audio" | "Embed"`. Coverage includes the official vendor endpoints plus the OpenRouter and SiliconFlow gateways; `context_window` and `pricing` are omitted where the platform publishes no authoritative value (image and TTS models, for instance).
+- `pricing` is per million tokens, keyed by the same usage buckets as `usage_metadata`: `prompt_tokens` (non-cached input), `thoughts_tokens` / `response_tokens` (both the output price) and optional `cached_tokens` (cache-hit price). Values are stored in USD; pass `listSupportedModels("CNY")` to convert at 7 CNY/USD.
+
+The registry is the curated current line-up, so prefer it when picking a model or estimating cost. It is narrower than the routing rules: older ids in the table above (`gpt-5.4`, `claude-opus-4-7`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite`) still route fine but no longer appear in it.
+
 ## Routing and credentials
 
-- Without `clientType`, the client auto-routes by model id substring: `gemini-3*`, `gemini-embedding`, `claude` 4-6/4-7/4-8, `gpt-5.4`/`gpt-5.5`, `glm-5`, `kimi-k2.5`/`kimi-k2.6`, `deepseek-v4`, `openai`+`embedding` (embeddings), `openai`. Ids matching none of these throw. The gateway variants in the table above hit the same substrings, so they route to the right family — just set `baseUrl` to the gateway endpoint.
+- Without `clientType`, the client auto-routes by model id substring, in this order: `gemini-3.6` / `gemini-3.5-flash-lite`, then `gemini-3*` / `gemini-embedding`, `claude` 4-6/4-7/4-8/-5, `gpt-5.4`/`gpt-5.5`, `glm-5.2`, `glm-5`, `kimi-k3`, `kimi-k2.5`/`kimi-k2.6`, `deepseek-v4`, `openai`+`embedding` (embeddings), `openai`. Ids matching none of these throw. The gateway variants in the table above hit the same substrings, so they route to the right family — just set `baseUrl` to the gateway endpoint.
+- Exception: a Gemini id served by an OpenAI-compatible gateway (e.g. OpenRouter's `google/gemini-3.6-flash`) still matches the Gemini substring and would auto-route to the Google protocol client. Pass `clientType: "openai"` explicitly for those.
 - For any other OpenAI chat-completion compatible model (e.g. Qwen series via OpenRouter or SiliconFlow), pass `clientType: "openai"` plus `baseUrl` (embeddings endpoints use a different client type — see Embeddings below).
 - API key: constructor parameter first, then the provider environment variable — `DEEPSEEK_API_KEY`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, `ZAI_API_KEY`, `MOONSHOT_API_KEY`. Base URLs read the same names with `_BASE_URL`.
 
@@ -87,8 +111,29 @@ for await (const event of client.streamingResponseStateful({
 ```
 
 - Each `event` is a `UniEvent`: `event_type` is `start` | `delta` | `stop`, and `content_items` carry the increments.
-- `config` accepts `max_tokens`, `temperature`, `system_prompt`, `thinking_level` (the `ThinkingLevel` enum, `NONE` to `XHIGH`) and `tools`.
+- `config` accepts `max_tokens`, `temperature`, `system_prompt`, `thinking_level` (the `ThinkingLevel` enum, `NONE` to `XHIGH`), `tool_choice`, `prompt_caching` and `tools`.
 - `streamingResponseStateful` keeps conversation history inside the client; manage it with `getHistory()` / `setHistory(history)` / `clearHistory()`. The stateless variant is `streamingResponse({ messages, config })`.
+
+## Config parameters the model may reject
+
+A config value the target client cannot honour throws `UnsupportedParameterError` (an `AgentHubError` carrying `client` and `parameter`) while building the request, before anything reaches the network:
+
+```ts
+import { UnsupportedParameterError } from "@prismshadow/agenthub";
+
+try {
+  // ...
+} catch (err) {
+  if (err instanceof UnsupportedParameterError) console.error(err.parameter, err.message);
+}
+```
+
+- `thinking_level` never throws: every client maps each level onto the closest one the model supports. Kimi K3 reasons unconditionally, so `NONE` degrades to its lowest effort rather than disabling thinking; GLM-5.2 sends `reasoning_effort` alongside its `thinking` block and only `NONE` disables it.
+- `temperature` is rejected outright by Gemini 3.6 — that generation deprecated the sampling parameters, so the client refuses them instead of sending a value the API ignores. GPT-5.5, Claude 4.8/5, DeepSeek V4, Kimi K2.6 and Kimi K3 accept only the protocol default `1.0` and reject any other value. Gemini 3, Claude 4.6, GLM and the generic OpenAI client pass it through.
+- `tool_choice`: `"auto"` is safe everywhere. Claude accepts a single forced tool name; DeepSeek V4 and Kimi K2.6 allow `"auto"` / `"none"`; Kimi K3 adds `"required"` but refuses a specific tool; GLM only accepts `"auto"`.
+- `prompt_caching`: every client accepts `PromptCaching.ENABLE` and rejects the other values — caching is on by default and Kimi K3 caches context automatically.
+
+Leave a parameter unset and the protocol default applies, which is the portable choice when a script must run against several families.
 
 ## Image generation
 
@@ -97,7 +142,7 @@ Use a Gemini image model (see Model IDs) and set `config.image_config` (optional
 ```ts
 import fs from "node:fs";
 
-const client = new AutoLLMClient({ model: "gemini-3.1-flash-image-preview" });
+const client = new AutoLLMClient({ model: "gemini-3.1-flash-image" });
 for await (const event of client.streamingResponseStateful({
   message: { role: "user", content_items: [{ type: "text", text: "A penguin on a glacier" }] },
   config: { image_config: { aspect_ratio: "16:9", image_size: "2K" } },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
   packages/cli:
     dependencies:
       '@prismshadow/agenthub':
-        specifier: ^0.4.0
-        version: 0.4.0(ws@8.21.0)
+        specifier: ^0.4.1
+        version: 0.4.1(ws@8.21.0)
       '@prismshadow/penguin-core':
         specifier: workspace:*
         version: link:../core
@@ -79,8 +79,8 @@ importers:
   packages/core:
     dependencies:
       '@prismshadow/agenthub':
-        specifier: ^0.4.0
-        version: 0.4.0(ws@8.21.0)
+        specifier: ^0.4.1
+        version: 0.4.1(ws@8.21.0)
       '@prismshadow/penguin-skills':
         specifier: workspace:*
         version: link:../skills
@@ -1040,8 +1040,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@prismshadow/agenthub@0.4.0':
-    resolution: {integrity: sha512-P96fAoYEtAy+BQHsrdQ2Rw5oXbrR2IAXcN6S3SnpUUlwpVoH2kkdtbe4bTGTafys0jJeH7s1lCZDF7KRvdWOoQ==}
+  '@prismshadow/agenthub@0.4.1':
+    resolution: {integrity: sha512-YKidCwa4ZO0+BP5E+vg/p8HQAPrTvTDaFmoj5omUHi7OxXCXPMDxwodj4VPz/ntWMDsgjsePhzkZIfVmSbECkw==}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -3678,7 +3678,7 @@ snapshots:
     dependencies:
       playwright: 1.61.1
 
-  '@prismshadow/agenthub@0.4.0(ws@8.21.0)':
+  '@prismshadow/agenthub@0.4.1(ws@8.21.0)':
     dependencies:
       '@anthropic-ai/bedrock-sdk': 0.26.4
       '@anthropic-ai/sdk': 0.81.0


### PR DESCRIPTION
Bumps `@prismshadow/agenthub` from `^0.4.0` to `^0.4.1` (npm `latest`), documents the new API in the `agenthub-models` skill, and refreshes the built-in model catalog so it offers **every chat model AgentHub 0.4.1 can route** — 11 new entries across five provider groups, not just OpenRouter.

## What 0.4.1 actually changed

Verified against the package itself, not the release notes. Three pieces of evidence, retraceable with:

```bash
npm pack @prismshadow/agenthub@0.4.0 @prismshadow/agenthub@0.4.1   # then untar both
diff -rq v040/package/dist v041/package/dist
node -e 'console.log(require("@prismshadow/agenthub").listSupportedModels().length)'   # 49
```

**Type-compatible with 0.4.0.** `diff -rq` reports `dist/types.d.ts`, `dist/autoClient.d.ts` and `dist/baseClient.d.ts` identical between the two tarballs: `UniConfig`, `ThinkingLevel`, `UniEvent`/`UniMessage`, the content-item union and the `AutoLLMClient` surface are all unchanged. `packages/core/src/llm/generative-model.ts` needed no adaptation, and `pnpm typecheck` passed on this repo before any source change.

New public surface, all additive in `dist/index.d.ts`:

- **`listSupportedModels(currency?: "USD" | "CNY"): SupportedModel[]`** — a 49-entry supported-model registry. Each entry is `{ model, base_url, client, input_modalities, output_modalities, context_window?, pricing? }`; the `(model, base_url, client)` triple maps straight onto the `AutoLLMClient` constructor. `pricing` is per million tokens keyed by AgentHub's usage buckets (`prompt_tokens`, `thoughts_tokens`, `response_tokens`, optional `cached_tokens`), stored in USD and converted at 7 CNY/USD on request. Coverage is the official vendor endpoints plus OpenRouter and SiliconFlow. New exported types: `Currency`, `Modality`, `ModelPricing`, `SupportedModel`. *Evidence: signature and doc comments from `dist/registry.d.ts` (a "Only in v041" file in the diff); the entry count, modality vocabulary, currency conversion and every price in this PR come from running it.*
- **`UnsupportedParameterError`** (extends `AgentHubError`, carries `client` and `parameter`) — every client's bare `throw new Error(...)` for a rejected `temperature` / `tool_choice` / `prompt_caching` value became this typed error. Thinking levels never raise: each client maps a `ThinkingLevel` onto the closest one the model supports. *Evidence: `dist/errors.d.ts` and `dist/index.d.ts` diffs; the per-client rules from grepping every `dist/*/client.js` for `UnsupportedParameterError` and reading each guard (`!== undefined` for Gemini 3.6 vs `!== undefined && !== 1.0` for the rest).*
- **Three new protocol clients** wired into `AutoLLMClient._createClientForModel`: `gemini3_6` (matched *before* the broader `gemini-3` prefix, covering `gemini-3.6-*` and `gemini-3.5-flash-lite`, rejecting `temperature` outright), `glm5_2` (sends `reasoning_effort` alongside its `thinking` block), `kimi_k3` (maps `ThinkingLevel` onto `reasoning_effort` low/high/max, always reasons, allows `tool_choice: "required"`, caches context automatically). *Evidence: `dist/gemini3_6/`, `dist/glm5_2/`, `dist/kimi_k3/` are "Only in v041"; precedence from the `dist/autoClient.js` diff.*
- The deprecated image endpoint `gemini-3.1-flash-image-preview` is now `gemini-3.1-flash-image`. *Evidence: the id `listSupportedModels()` returns. Caveat: `dist/integration/playground.js` still hardcodes the old `-preview` id, unchanged from 0.4.0 — an upstream inconsistency nothing here depends on.*

No impact on this repo's request path: `buildUniConfig` only ever sets `tools`, `system_prompt`, `max_tokens` and `thinking_level`, never `temperature` / `tool_choice` / `prompt_caching`, so `UnsupportedParameterError` is unreachable from PenguinHarness today.

`packages/cli/package.json` also declared `@prismshadow/agenthub` and was bumped alongside core.

## Model catalog: 59 -> 70 entries

Method: dump `listSupportedModels("USD")` from the installed 0.4.1 inside `packages/core`, map each `base_url` to a provider group, and set-difference against `MODEL_CATALOG`. That found 11 routable chat models with no catalog entry. Every row below was then re-checked field by field against the registry (a scripted comparison of context window, `input_modalities` and all three price buckets) — no row was hand-transcribed.

| Group | Model id | Display name | Context | `usd`/`cny` triple (cache_read, cache_write, output) | Vision |
| --- | --- | --- | --- | --- | --- |
| `google` | `gemini-3.6-flash` | Gemini 3.6 Flash | 1,048,576 | `usd(0.15, 1.5, 7.5)` | yes |
| `google` | `gemini-3.5-flash-lite` | Gemini 3.5 Flash-Lite | 1,048,576 | `usd(0.03, 0.3, 2.5)` | yes |
| `anthropic` | `claude-fable-5` | Claude Fable 5 | 1,000,000 | `usd(1, 12.5, 50)` | yes |
| `anthropic` | `claude-sonnet-5` | Claude Sonnet 5 | 1,000,000 | `usd(0.2, 2.5, 10)` | yes |
| `moonshot` | `kimi-k3` | Kimi K3 | 1,048,576 | `cny(2, 20, 100)` | yes |
| `openrouter` | `google/gemini-3.6-flash` | Gemini 3.6 Flash | 1,048,576 | `usd(0.15, 1.5, 7.5)` | yes |
| `openrouter` | `google/gemini-3.5-flash-lite` | Gemini 3.5 Flash-Lite | 1,048,576 | `usd(0.03, 0.3, 2.5)` | yes |
| `openrouter` | `moonshotai/kimi-k2.6` | Kimi K2.6 | 262,144 | `usd(0.144, 0.684, 3.42)` | yes |
| `openrouter` | `qwen/qwen3.6-35b-a3b` | Qwen 3.6 35B A3B | 262,144 | `usd(0.14, 0.14, 1)` | yes |
| `openrouter` | `z-ai/glm-5.1` | GLM-5.1 | 204,800 | `usd(0.1794, 0.966, 3.036)` | no |
| `siliconflow` | `Pro/moonshotai/Kimi-K2.6` | Kimi K2.6 | 262,144 | *(none — see below)* | yes |
| `siliconflow` | `Pro/zai-org/GLM-5.1` | GLM-5.1 | 200,000 | *(none — see below)* | no |
| `siliconflow` | `Qwen/Qwen3.6-35B-A3B` | Qwen 3.6 35B A3B | 262,144 | *(none — see below)* | yes |

`vision` is `input_modalities.includes("Image")` from the registry, never a guess — that is why `z-ai/glm-5.1` and `Pro/zai-org/GLM-5.1` are text-only while the Qwen 3.6 rows are multimodal.

### Judgement calls

- **Anthropic keeps `cache_write = 1.25 x input`.** The registry's `prompt_tokens` maps to `cache_write` in every other group, but the `anthropic` block documents and uses Anthropic's 1.25x cache-write surcharge (`claude-opus-4-8` stores `usd(0.5, 6.25, 25)` against a registry input of 5). The two new Claude rows follow the neighbours: input 10 -> 12.5 and input 2 -> 2.5. Pinned by a test.
- **Moonshot stays on `cny()`.** The `moonshot` block stores official CNY prices. `cny(2, 20, 100)` divides to exactly the registry's `0.285714 / 2.857143 / 14.285714`, and matches the `kimi/kimi-k3` row already under Qwen Pay-As-You-Go.
- **`clientType`** follows each block: unset for the auto-routed direct-vendor groups (`google`, `anthropic`, `moonshot`), `"openai"` plus the preset gateway base URL for `openrouter` and `siliconflow`. A test now asserts the direct-vendor groups carry neither `clientType` nor `baseUrl`.
- **`qwen/qwen3.6-35b-a3b` has no published cache price** in either the registry or the OpenRouter API, so `cache_read` repeats the input price — the block's documented fallback.
- **Three SiliconFlow rows ship unpriced.** The registry publishes no pricing for them, `https://api.siliconflow.cn/v1/models` returns 401 without a token, and the console model page is client-rendered with no price in the HTML. No number could be sourced, so rather than invent one the entries omit `pricing`, exactly like `qwen3.8-max-preview`. Their cost reads as 0 until a published rate exists; the code comment and the test's `UNPRICED` set both say so.
- **Ordering** follows the documented rule (dictionary order, newer versions of a series first). SiliconFlow's dictionary order is case-insensitive — `Pro/` and `Qwen/` sort between `moonshotai/` and `zai-org/`, matching how `ZHIPU/GLM-5.2` sorts last under Qwen Pay-As-You-Go. The ordered-id tests pin all of it.
- **No duplicates introduced.** The pre-existing cross-group repeats are `deepseek-v4-pro`, `glm-5.2`, `qwen3.7-max` and `qwen3.7-plus`; none of the 11 new ids collides within its own group, which is the catalog's real key.
- **Display names are shared across groups** for the same model (`Kimi K2.6` under `moonshot`, `openrouter` and `siliconflow`; `GLM-5.1` under `zhipu`, `openrouter` and `siliconflow`). This also renamed the OpenRouter Gemini Lite row from "Gemini 3.5 Flash Lite" to **"Gemini 3.5 Flash-Lite"**, matching the existing `gemini-3.1-flash-lite` entry. A test pins the cross-group equality.

### Excluded: non-chat models

Six registry rows are deliberately not added — `gemini-3.1-flash-image`, `gemini-3.1-flash-tts-preview`, `gemini-embedding-2`, `text-embedding-3-large`, `qwen/qwen3-embedding-4b`, `Qwen/Qwen3-Embedding-8B`. This is not a new decision: the catalog's own header comment already scopes it to chat models ("excludes ... non-chat models (embedding / image generation / TTS)"), and the catalog drives chat-model selection and cost reporting. Detected mechanically as `output_modalities != ["Text"]`, so nothing was judged by name.

### Also fixed

- **`cache_read` now stores the published cache-hit price** for the Gemini rows (review finding). Upstream does publish one — $0.15 and $0.03, agreed by the OpenRouter models API and the 0.4.1 registry — and `cache_read` is billed as its own bucket in the cost center, so repeating the input price would overstate cache-heavy spend 10x and "sync presets" would push that into existing Projects. The direct-vendor rows already set this precedent.
- **`google/gemini-3.5-flash`'s context window: 1000000 -> 1048576**, matching the direct-vendor row for the same model and both upstream sources.
- **`resolveModelEnv` learned `kimi-k3`.** It mirrors AgentHub's routing but was written against v0.3.3; `kimi-k3` matches none of the `kimi-k2.x` substrings, so the id resolved to no env pair at all. AgentHub 0.4.1's `KimiK3Client` reads `MOONSHOT_API_KEY` / `MOONSHOT_BASE_URL` (verified in `dist/kimi_k3/client.js`), so the new branch returns the same pair. Without it the catalog-invariant test would fail on the new `kimi-k3` row.

### Follow-up (deliberately not in this PR)

14 pre-existing OpenRouter rows disagree with the 0.4.1 registry — all of them added before this branch, none touched here. The full list, produced by a scripted comparison:

- `cache_read` still repeats the input price where a real cache price exists: `anthropic/claude-fable-5` (10 vs 1), `anthropic/claude-opus-4.8` and `4.7` (5 vs 0.5), `anthropic/claude-sonnet-5` (2 vs 0.2), `moonshotai/kimi-k3` (3 vs 0.3), `openai/gpt-5.6-sol` (5 vs 0.5), `openai/gpt-5.6-terra` (2.5 vs 0.25), `openai/gpt-5.5` (5 vs 0.5), `x-ai/grok-4.5` (2 vs 0.3), `deepseek/deepseek-v4-pro` (0.435 vs 0.003625).
- Stale context windows: `deepseek/deepseek-v4-flash` and `-pro` (1000000 vs 1048576), `openai/gpt-5.6-sol` / `-terra` / `gpt-5.5` (1000000 vs 1050000), `stepfun/step-3.7-flash` (256000 vs 262144), `xiaomi/mimo-v2.5` (1048576 vs 1050000), `z-ai/glm-5.2` (1000000 vs 1048576), `moonshotai/kimi-k3` (1000000 vs 1048576).
- Full price drift: `deepseek/deepseek-v4-flash` (0.09/0.09/0.18 vs 0.0196/0.098/0.196) and `z-ai/glm-5.2` (0.93/0.93/3 vs 0.15236/0.8204/2.5784).

Correcting those changes money reporting for models people are already using, so it deserves its own reviewed pass rather than riding along here. The block comment now records the split and says to treat those `cache_read` values as an upper bound until then.

## Skill: `agenthub-models` (version 7 -> 8, `updated: 2026-07-22T00:00:00Z`)

- New **Supported-model registry** section: `listSupportedModels`, the `SupportedModel` shape, the usage-bucket pricing keys and the USD/CNY switch, with a note that the registry is narrower than the routing rules (older ids like `gpt-5.4` still route but are no longer listed).
- New **Config parameters the model may reject** section: `UnsupportedParameterError`, which clients reject `temperature` (Gemini 3.6 any value; GPT-5.5, Claude 4.8/5, DeepSeek V4, Kimi K2.6/K3 only `1.0`), the per-family `tool_choice` limits, and `prompt_caching` needing `ENABLE`.
- Model-ID table gains `Gemini 3.6`, `Kimi K3`, `GLM 5.2` and `Qwen 3.6` rows, splits Claude into a `Claude 5` row (`claude-fable-5`, `claude-sonnet-5`) and a `Claude 4` row, and fills in gateway variants; the image id is corrected to `gemini-3.1-flash-image` in the table and the example.
- Routing section lists the real 0.4.1 branch order, including the `gemini-3.6` precedence rule and a warning that a Gemini id on an OpenAI-compatible gateway must pass `clientType: "openai"` explicitly.

## README: curated to the latest generation per family

The tables were drifting toward a mirror of the catalog. They are now explicitly a shortlist, with the full preset list left to the app.

**Rule applied uniformly:** one row per vendor family, naming the newest generation the catalog carries. Where that generation ships several tiers the row names the generation; a single-model generation keeps its own name.

| Model | Providers |
| --- | --- |
| DeepSeek V4 | DeepSeek, OpenRouter, Fireworks AI, SiliconFlow, Qwen Token Plan |
| Kimi K3 | Moonshot AI, OpenRouter, Qwen Pay-As-You-Go |
| GLM 5.2 | Z.AI, OpenRouter, Fireworks AI, SiliconFlow, Qwen Token Plan, Qwen Pay-As-You-Go |
| Hunyuan 3 | OpenRouter |
| Qwen 3.8 Max | Qwen Token Plan (preview) |
| GPT 5.6 | OpenRouter |
| Gemini 3.6 Flash | Google Gemini, OpenRouter |
| Claude 5 | Anthropic, OpenRouter |

Consequences of applying the rule to rows nobody named:

- `Kimi K2.6` and `Gemini 3.5 Flash` dropped, as requested. `Gemini 3.6 Flash` now carries the Gemini row and lists both Google Gemini and OpenRouter, which it only can because of the catalog additions above.
- `GPT 5.5` -> **`GPT 5.6`**. The newest GPT generation in the catalog is `openai/gpt-5.6-sol` / `-terra`, which exist only on OpenRouter, so the providers column honestly reads "OpenRouter" and the direct OpenAI group (`gpt-5.5`, `gpt-5.5-pro`, `gpt-5.4*`) is no longer visible in the README. That is the rule working as intended — the app's Models page is where the full picture lives.
- `Claude Opus 4.8` -> **`Claude 5`**, the multi-tier generation name (`claude-fable-5` + `claude-sonnet-5`), available on both Anthropic and OpenRouter.
- Families the table never listed (MiniMax, Nemotron, Step, Grok, MiMo, LongCat) stay out — this is a shortlist, not an index.

Every providers column was regenerated from `MODEL_CATALOG` after the additions, so e.g. Kimi K3 now correctly shows the Moonshot official endpoint alongside OpenRouter and Qwen Pay-As-You-Go.

The sentence under each table now points at the app's **Models** page for the complete preset list, keeping the existing "any OpenAI-protocol endpoint / 1000+ online and local models" point. Both READMEs stay structurally 1:1; the first column returns to its original 16-character width, and since `*.md` is in `.prettierignore` the padding is by hand.

**Other places that list models, checked:**

- The landing site does **not** enumerate supported models — `packages/landing/src/lib/benchmark-data.ts` names the three models used in a published benchmark comparison (historical measurements, not a support list) and `strings.ts` carries a one-line news banner. Neither is a catalog mirror, so neither follows this curation and neither was touched.
- `packages/landing/content/blog/introducing-penguinharness.{en,zh}.md` does carry a copy of the old table, but it is a dated launch announcement and is deliberately left unchanged.
- `packages/docs/content/models.{en,zh}.md` lists a handful of ids explicitly labelled "not exhaustive"; still accurate, so unchanged.

## Lockfile

Minimal: `pnpm install` (no `--frozen-lockfile`) touched only the four agenthub lines — the two importer specifier/version pairs, the resolution integrity hash and the snapshot key. No transitive dependency moved.

## Verification

- `pnpm -r build` — all 7 packages OK
- `pnpm typecheck` — all 7 packages OK
- `pnpm test` — **1260 passed, 2 skipped, 0 failed** (skills 16, docs 11, landing 26, core 407 + 2 skipped, server 302, cli 121, web 377). Core gained one case, a new `direct-vendor groups` test; the existing catalog tests were extended in place (ordered-id arrays for `openrouter` and `siliconflow`, the `UNPRICED` set, the Kimi K3 CNY round-trip, the Anthropic 1.25x convention, cross-group display-name equality, and `resolveModelEnv` for `kimi-k3` / `gemini-3.6-flash` / `gemini-3.5-flash-lite` / the Claude 5 ids).
- `pnpm format` then `pnpm format:check` — clean
- Playwright e2e not run: no web behaviour changed.

Changelog: covered by PR #30 (commit `a7a9271`) — its Models/core entry covers the 0.4.1 bump and the catalog rows, its Skills entry covers the `agenthub-models` v7 -> v8 rewrite, and both index lines are updated. This PR deliberately adds no changelog file of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
