### PR TITLE
chore(changelog): collect unreleased entries in changelog/unreleased/

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,10 +1,10 @@
 # Changelog Details
 
-The root [../CHANGELOG.md](../CHANGELOG.md) keeps one brief line per release. Each release owns a folder here:
+The root [../CHANGELOG.md](../CHANGELOG.md) keeps one brief line per release. Work in progress lives in [`unreleased/`](unreleased/); each shipped release owns a numbered folder here:
 
-- `<version>/README.md` — the release summary: one brief line per change, each linking its detail file, e.g. `- [YYYY-MM-DD] Brief description. ([details](YYYY-MM-DD-short-slug.md))`
-- `<version>/YYYY-MM-DD-short-slug.md` — one detail file per entry, named by the entry date: an H1 title, then what changed and why, using `##` sections once the entry covers more than one thing.
+- `<folder>/README.md` — the summary: one brief line per change, each linking its detail file, e.g. `- [YYYY-MM-DD] Brief description. ([details](YYYY-MM-DD-short-slug.md))`
+- `<folder>/YYYY-MM-DD-short-slug.md` — one detail file per entry, named by the entry date: an H1 title, then what changed and why, using `##` sections once the entry covers more than one thing.
 - Entries are grouped by the surface they change — Models, Web App, landing site, skills, docs, tooling — rather than one file per commit. A related change extends the existing file and its summary line instead of opening a new one.
-- Changes not yet released go into the upcoming version's folder; during release preparation, rename the folder if the number changed and add the release line to the root file. Released folders are frozen.
+- Unreleased changes go in `unreleased/`, never in a numbered folder: the next version number is not knowable while the work is being written — the batch that accumulated as `0.2.0/` shipped as 0.1.1 — so a guessed number only creates a rename to get wrong later. At release, rename `unreleased/` to the version actually shipped, swap its `# Unreleased` heading for `# Version X.Y.Z` plus a `Released on <date>.` line, add the release line to the root file, and create a fresh empty `unreleased/`. Released folders are frozen.
 
 Written in English. History starts after the v0.0.1 release (2026-07-19); earlier changes are not backfilled.

--- a/changelog/unreleased/README.md
+++ b/changelog/unreleased/README.md
@@ -1,0 +1,3 @@
+# Unreleased
+
+Changes since v0.1.1. The version number is assigned at release, when this folder is renamed.


### PR DESCRIPTION
Migrates the tracked changelog docs to the `unreleased/` convention.

## What this changes

Two tracked docs still described the **old** rule — put entries in the upcoming version's numbered folder and rename it if the number changed:

- `changelog/README.md` (the layout doc)
- `CONTRIBUTING.md` (the contributor guide)

That guess isn't knowable when an entry is written: the batch that accumulated as `0.2.0/` shipped as **0.1.1**, so a numbered folder only ever created a rename to get wrong later. Both now describe the `unreleased/` flow — work in progress lives in `changelog/unreleased/`; at release it's renamed to the shipped version, its `# Unreleased` heading becomes `# Version X.Y.Z` + `Released on <date>.`, the root `CHANGELOG.md` line is added, and a fresh `unreleased/` is started.

## Scope note (the original description was stale)

The original write-up predated the 0.1.1 release and no longer matched the diff: there is **no `changelog/0.2.0/` folder to move** (that batch already shipped as `0.1.1/`, renamed at release — exactly the failure this convention prevents), so nothing is renamed here. This is purely the tracked-doc migration.

The `changelog/unreleased/` folder itself is seeded by the first pending entry — **#46** creates it with the `# Unreleased` heading and its first line — so this PR no longer adds an empty `unreleased/README.md` (which would have collided with #46 on merge).

> Merge **before #48**: both touch `changelog/README.md`. There's no longer any contradiction (this PR owns the release-flow paragraph; #48 only adds the `RELEASE.md` bullets), but expect a trivial adjacent-line merge.
