### PR TITLE
fix(tooling): separate the dev data root from the installed one

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,11 @@ core) with back-to-back builds deduped: starting `dev:server` and `dev:web` at t
 time (or just `pnpm dev`) installs and builds exactly once. `dev:docs` / `dev:landing`
 run the install check only (`--install-only`).
 
+Dev entry points that touch data (`pnpm dev`, `pnpm dev:server`, `pnpm penguin`) default
+to a separate data root, `~/.penguin/dev-data`, kept apart from the installed CLI/server's
+`~/.penguin/data` — hacking on the repo never mixes state with your real agents. Export
+`PENGUIN_HOME` to point them anywhere else; an explicit value always wins.
+
 Copy `.env.example` to `.env` for model credentials in development.
 
 ## Repo layout

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:e2e": "pnpm --filter @prismshadow/penguin-core test:e2e",
     "build": "pnpm -r build && pnpm link:cli",
     "link:cli": "pnpm --dir packages/cli link --global || echo '[link:cli] pnpm global directory not configured; skipping the global penguin link (run pnpm setup once first)'",
-    "penguin": "tsx packages/cli/src/index.ts",
+    "penguin": "PENGUIN_HOME=\"${PENGUIN_HOME:-$HOME/.penguin/dev-data}\" tsx packages/cli/src/index.ts",
     "dev": "concurrently -n server,web -c cyan,magenta \"pnpm dev:server\" \"pnpm dev:web\"",
     "dev:server": "pnpm --filter @prismshadow/penguin-server dev",
     "dev:web": "node scripts/dev-prebuild.mjs && pnpm --filter @prismshadow/penguin-web dev",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,7 +19,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "test": "vitest run --passWithNoTests",
     "build": "tsup",
-    "penguin": "tsx src/index.ts"
+    "penguin": "PENGUIN_HOME=\"${PENGUIN_HOME:-$HOME/.penguin/dev-data}\" tsx src/index.ts"
   },
   "dependencies": {
     "@prismshadow/agenthub": "^0.4.1",

--- a/packages/docs/content/installation.en.md
+++ b/packages/docs/content/installation.en.md
@@ -60,7 +60,7 @@ cd penguin-harness
 pnpm install && pnpm build
 ```
 
-After the build, run `pnpm penguin <args>` inside the repo as the dev runner, or use the globally linked `penguin` command.
+After the build, run `pnpm penguin <args>` inside the repo as the dev runner, or use the globally linked `penguin` command. Dev entry points (`pnpm penguin`, `pnpm dev`) default to a separate data root `~/.penguin/dev-data`, while the linked/installed `penguin` keeps `~/.penguin/data`; export `PENGUIN_HOME` to override.
 
 ## Published npm packages
 

--- a/packages/docs/content/installation.zh.md
+++ b/packages/docs/content/installation.zh.md
@@ -60,7 +60,7 @@ cd penguin-harness
 pnpm install && pnpm build
 ```
 
-构建完成后，在仓库内用 `pnpm penguin <args>` 作为开发入口运行，或使用全局链接的 `penguin` 命令。
+构建完成后，在仓库内用 `pnpm penguin <args>` 作为开发入口运行，或使用全局链接的 `penguin` 命令。开发入口（`pnpm penguin`、`pnpm dev`）默认使用独立数据根目录 `~/.penguin/dev-data`，全局链接或安装的 `penguin` 仍使用 `~/.penguin/data`；可通过环境变量 `PENGUIN_HOME` 覆盖。
 
 ## 已发布的 npm 包
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -25,7 +25,7 @@
     "node": ">=24"
   },
   "scripts": {
-    "dev": "node ../../scripts/dev-prebuild.mjs && tsx watch src/index.ts",
+    "dev": "node ../../scripts/dev-prebuild.mjs && PENGUIN_HOME=\"${PENGUIN_HOME:-$HOME/.penguin/dev-data}\" tsx watch src/index.ts",
     "start": "node --disable-warning=ExperimentalWarning dist/index.js",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "test": "vitest run --passWithNoTests",


### PR DESCRIPTION
## Problem

Development entry points that run the server or CLI from source shared the same data root as the production install: core's `resolveRoot()` returns `PENGUIN_HOME ?? ~/.penguin/data`, and the server derives its SQLite `web.db` from that root. So `pnpm dev` / `pnpm dev:server` / `pnpm penguin` operated on the very same agents, sessions, and `web.db` as the user's real installed penguin, causing state conflicts while hacking on the repo.

## Fix (scripts-only)

Prefix the data-touching dev scripts with `PENGUIN_HOME="${PENGUIN_HOME:-$HOME/.penguin/dev-data}"` (POSIX `${VAR:-default}` substitution; pnpm runs scripts via `sh`, and the repo is POSIX-only):

- `packages/server/package.json` `dev` — covers `pnpm dev` and `pnpm dev:server` (both delegate here)
- root `package.json` `penguin` — the CLI-from-source runner
- `packages/cli/package.json` `penguin` — the same runner at package level

Semantics: dev entry points default to a separate root `~/.penguin/dev-data`, and an explicitly exported `PENGUIN_HOME` still wins. `dev:web` / `dev:docs` / `dev:landing` are Vite-only and untouched.

Docs: CONTRIBUTING.md's development-commands section explains the dev data root, and the installation page (en/zh) notes it in the from-source section.

## What stays unchanged

- Product code defaults: `resolveRoot()` (`PENGUIN_HOME ?? ~/.penguin/data`), server config, CLI `--root` semantics
- The globally linked / npm-installed `penguin` binary and installed server keep `~/.penguin/data`
- The "single data directory" architecture wording (it describes the product default, still true)

## Verification

- `pnpm install --frozen-lockfile`, `pnpm -r build`, `pnpm typecheck`, `pnpm test` (all suites pass), `pnpm format` + `pnpm format:check` — all green (Node 24)
- Substitution smoke test: `sh -c 'PENGUIN_HOME="${PENGUIN_HOME:-$HOME/.penguin/dev-data}" node -e "console.log(process.env.PENGUIN_HOME)"'` prints `$HOME/.penguin/dev-data` with the variable unset and `/tmp/x` with `PENGUIN_HOME=/tmp/x` exported
- `pnpm penguin config model list --root /tmp/does-not-matter-$$` still starts the CLI from source and lists models
- Checked for tests asserting the exact script strings (none) and README dev sections (no data-root claims; they defer to CONTRIBUTING.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)