### PR TITLE
fix(core): close case and symlink bypasses in read_file's secret guard

### DIFF
--- a/packages/core/src/environment/tools/read-file.ts
+++ b/packages/core/src/environment/tools/read-file.ts
@@ -28,7 +28,7 @@
  * Docs: /docs/tools § "File tools".
  */
 import path from "node:path";
-import { open, stat } from "node:fs/promises";
+import { open, realpath, stat } from "node:fs/promises";
 import { partialToolCallOutput } from "../../omnimessage/index.js";
 import type { OmniMessage } from "../../omnimessage/index.js";
 import type { ToolDefinitionConfig } from "../../interfaces.js";
@@ -64,6 +64,29 @@ const DEFAULT_OUTPUT_BUDGET = 64000;
  * makes it auto-approved under read-only approval (the shell tool stays rw-gated).
  */
 const SECRET_BASENAMES = new Set([".vault.toml", ".project_config.toml"]);
+
+/**
+ * The secret-store name a path hits, or null. Checks the LOWERCASED basename of both the
+ * lexical path and its realpath: a case-insensitive filesystem (macOS/Windows) opens
+ * ".VAULT.TOML" as .vault.toml, and a symlink's own name says nothing about what it
+ * dereferences to — either would slip past a plain case-sensitive basename check. On a
+ * case-sensitive filesystem the lowercase compare can refuse a differently-cased sibling
+ * that is NOT the secret store; for a guard, that false positive is the right trade.
+ */
+async function secretStoreHit(resolved: string): Promise<string | null> {
+  let target = resolved;
+  try {
+    target = await realpath(resolved);
+  } catch {
+    // Missing file / permission error: the lexical name is still checked below, and the
+    // read path reports the real error afterwards.
+  }
+  for (const name of [path.basename(resolved), path.basename(target)]) {
+    const lower = name.toLowerCase();
+    if (SECRET_BASENAMES.has(lower)) return lower;
+  }
+  return null;
+}
 
 /** Renders one `cat -n` style line: 6-column right-aligned line number, tab, content. */
 export function numberedLine(lineNo: number, content: string): string {
@@ -251,9 +274,13 @@ export function createReadFileTool(definition: ToolDefinitionConfig): BuiltinToo
       const resolved = path.resolve(ctx.workspaceDir, filePath);
       // Secret stores are refused by name: read_file is auto-approved under read-only
       // approval, so it needs its own guard (aligned with the system prompt's ban).
-      if (SECRET_BASENAMES.has(path.basename(resolved))) {
+      // secretStoreHit resolves symlinks and compares case-insensitively — the lexical
+      // basename alone is bypassable via ".VAULT.TOML" (case-insensitive filesystems) or
+      // a symlink pointing at the store.
+      const secretHit = await secretStoreHit(resolved);
+      if (secretHit !== null) {
         yield delta(
-          `Refusing to read "${filePath}": ${path.basename(resolved)} holds the user's secrets and must never enter the conversation.`,
+          `Refusing to read "${filePath}": ${secretHit} holds the user's secrets and must never enter the conversation.`,
         );
         return { stopReason: "failed" };
       }

--- a/packages/core/test/file-tools.test.ts
+++ b/packages/core/test/file-tools.test.ts
@@ -6,7 +6,17 @@
  * read-image.test.ts); Environment-side framing is covered by environment.test.ts.
  */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { chmod, mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
@@ -383,6 +393,32 @@ describe("read_file — argument coercion, CRLF, secret guard", () => {
     const cfg = await run(tool(), { file_path: "sub/.project_config.toml" }, tmp);
     expect(cfg.result?.stopReason).toBe("failed");
     expect(cfg.text).toContain("Refusing to read");
+  });
+
+  it("refuses case-variant names and symlinks that dereference to a secret store", async () => {
+    await writeFile(path.join(tmp, ".vault.toml"), "SECRET=1\n");
+    // Case variant: a case-insensitive filesystem (macOS/Windows) opens ".VAULT.TOML" as
+    // the store itself; on a case-sensitive one refusing the name is a harmless false positive.
+    const upper = await run(tool(), { file_path: ".VAULT.TOML" }, tmp);
+    expect(upper.result?.stopReason).toBe("failed");
+    expect(upper.text).toContain("Refusing to read");
+    // Symlink: the link's own basename says nothing about what it dereferences to.
+    await symlink(path.join(tmp, ".vault.toml"), path.join(tmp, "notes.txt"));
+    const linked = await run(tool(), { file_path: "notes.txt" }, tmp);
+    expect(linked.result?.stopReason).toBe("failed");
+    expect(linked.text).toContain("Refusing to read");
+    expect(linked.text).not.toContain("SECRET=1");
+    // A symlink NAMED like a store but pointing elsewhere is refused on the lexical name —
+    // an acceptable false positive for a guard.
+    await writeFile(path.join(tmp, "plain.txt"), "hello\n");
+    await symlink(path.join(tmp, "plain.txt"), path.join(tmp, ".project_config.toml"));
+    const named = await run(tool(), { file_path: ".project_config.toml" }, tmp);
+    expect(named.result?.stopReason).toBe("failed");
+    // An ordinary symlink to an ordinary file still reads.
+    await symlink(path.join(tmp, "plain.txt"), path.join(tmp, "alias.txt"));
+    const ok = await run(tool(), { file_path: "alias.txt" }, tmp);
+    expect(ok.result?.stopReason).toBeUndefined();
+    expect(ok.text).toContain("hello");
   });
 });
 


### PR DESCRIPTION
## Summary

`read_file` refuses the secret stores (`.vault.toml` / `.project_config.toml`) by basename — it has to, being the one read primitive that is **auto-approved** under read-only approval. The check compared the lexical basename case-sensitively, which leaves two bypasses (both reproduced against isolated fake files):

- **Case**: on a case-insensitive filesystem (macOS/Windows), `read_file(".VAULT.TOML")` opens the real `.vault.toml` but misses the name set.
- **Symlink**: `notes.txt → .vault.toml` passes the name check on the link's own basename while the read follows the link.

Either way the secrets land in the conversation with no approval prompt.

The guard now resolves symlinks first (`realpath`, lexical fallback on ENOENT) and compares the **lowercased** basename of both the lexical and the resolved path. On a case-sensitive filesystem the lowercase compare can refuse a differently-cased sibling that isn't the store — an acceptable false positive for a guard. A symlink *named* like a store but pointing elsewhere is likewise refused on the lexical name.

Scope check: `read_image` / `describe_image` are the only other auto-approved (`r`) tools; their magic-number sniffing already rejects non-image bytes, so nothing else can dump the stores' content without an approval.

## Verification

- `pnpm --filter core typecheck` ✓ · core tests ✓ (493 — new case: uppercase variant refused, symlink-to-store refused with content asserted absent, store-named symlink refused, ordinary symlink still reads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
