### PR TITLE
fix(server): give the mid-stream fake session the skipReconnectWait member

### DIFF
--- a/packages/server/test/messages-live.test.ts
+++ b/packages/server/test/messages-live.test.ts
@@ -37,6 +37,7 @@ function midStreamFakeSession(sessionId: string): RuntimeSession {
     generateTitle: async () => ({ title: null, usage: null }),
     compactability: () => "ok" as const,
     steer: () => false,
+    skipReconnectWait: () => false,
     async *run(_input: OmniMessage[], opts: { approve: ApproveFn; signal: AbortSignal }) {
       yield partialThinking("start");
       yield partialThinking("delta", "let me think");


### PR DESCRIPTION
Main's typecheck broke on 094ebd6: #77's `messages-live.test.ts` builds a fake `RuntimeSession` written before #82 made `skipReconnectWait` a required member — each PR was green on its own base, the squash combination was not. One-line fixture completion; no behavior change.

## Verification

- `pnpm build`, server `typecheck` clean, server tests 364/364, `pnpm format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQX3ye1wELm1SRMku5cdni