### PR TITLE
fix(server): harden test cleanup and deadlines for Windows runners

### DIFF
--- a/packages/server/test/helpers.ts
+++ b/packages/server/test/helpers.ts
@@ -66,7 +66,11 @@ export async function createTestApp(options: TestAppOptions = {}): Promise<TestA
     cleanup: async () => {
       deps.channels.dispose();
       deps.db.close();
-      await fs.rm(root, { recursive: true, force: true });
+      // maxRetries: Windows can report ENOTEMPTY/EBUSY while handles from the test's own
+      // just-closed files (SQLite, trace writers) are still being released — Node's rm
+      // retries these codes with a delay. A plain rm was the top cause of ci-windows
+      // cascades (cleanup throws → hook timeout → "database is not open" in later files).
+      await fs.rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
     },
   };
 }

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -1,0 +1,19 @@
+/**
+ * Vitest config for the server. Mirrors core's platform-aware deadline rationale: these
+ * tests build full app instances over real SQLite files and Agent State trees, and the
+ * Windows CI runners' I/O variance (Defender first-touch scans, slow handle release)
+ * pushes individually fast tests and cleanup hooks past the 5s/10s defaults — a
+ * different file on each run. Larger deadlines change nothing for passing tests; POSIX
+ * keeps the defaults to fail fast during local development. The hook timeout matters
+ * here specifically: `cleanup()` removes the whole test root, and on win32 that rm can
+ * legitimately take retries (see helpers.ts).
+ */
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    testTimeout: process.platform === "win32" ? 30_000 : 5_000,
+    hookTimeout: process.platform === "win32" ? 30_000 : 10_000,
+  },
+});


### PR DESCRIPTION
Main's `ci-windows` failed on f192db3 with a broad server-suite cascade. Root cause is test infra, not #73's semantics: the shared `cleanup()` did a plain recursive `rm`, and on win32 the test's own just-released handles (SQLite, trace writers) intermittently yield `ENOTEMPTY`/`EBUSY` — one failed cleanup then cascades (hook timeout in 10s, "database is not open" in later files). Same failure class #79 already hardened in core, never applied to the server suite.

- `helpers.ts` cleanup: `fs.rm` with `maxRetries: 10, retryDelay: 100`.
- New `packages/server/vitest.config.ts` mirroring core's platform-aware deadlines, plus `hookTimeout` (the cleanup runs under it).

No product code changed.

## Verification

- Server suite green locally (368/368); typecheck + format clean. The real proof is this PR's own `ci-windows` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQX3ye1wELm1SRMku5cdni