### PR TITLE
fix(core): size the win32 test deadline to the runners' cold-spawn tail, pin loop latency-additivity

### DIFF
--- a/packages/core/test/engine.test.ts
+++ b/packages/core/test/engine.test.ts
@@ -10,7 +10,7 @@
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   assistantText,
   emptyTokenCounts,
@@ -177,6 +177,68 @@ describe("ContextEngine ReAct loop (mock LLM, approve callback)", () => {
     expect(recordedTypes).toContain("tool_call");
     expect(recordedTypes).toContain("tool_call_output");
     expect(recordedTypes.some((t) => t?.startsWith("partial_"))).toBe(false);
+  });
+
+  it("a slow tool delays the run only by its own latency: the loop adds no waits, timers, or dropped wakes", async () => {
+    // Regression pin for the ci-windows timeout of the test above (goal-mode PR #66's
+    // merge-ref run): on one cold Windows runner the suite-start burst of first Git-Bash
+    // spawns ran ~28-36s and the test crossed the then-30s platform deadline, which looked
+    // like a goal-mode hang in the run loop. The loop's actual contract, pinned here with
+    // virtual tool latency instead of a real spawn (platform-neutral, deterministic): tool
+    // latency flows through 1:1 — wall time ≈ latency + ε. An engine-side wait inserted
+    // between turns would blow the upper bound, a dropped continuation wake would hang this
+    // test into its own deadline, and a timer armed alongside the tool would trip the spies
+    // (the engine's only setTimeout is the reconnect backoff, a failure-path affair).
+    const TOOL_LATENCY_MS = 300;
+    const EPSILON_MS = 1_000;
+    const realSetTimeout = globalThis.setTimeout.bind(globalThis);
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const intervalSpy = vi.spyOn(globalThis, "setInterval");
+    try {
+      const llm = new FakeLLM();
+      const environment: EnvironmentInterface = {
+        async listTools() {
+          return [];
+        },
+        async *executeTool({ toolCall: tc }) {
+          // The injected "slow spawn" (through the pre-spy setTimeout, invisible to the spies).
+          await new Promise<void>((resolve) => realSetTimeout(resolve, TOOL_LATENCY_MS));
+          yield toolCallOutput({ output: "wrote hello.txt", toolCallId: tc.payload.tool_call_id });
+        },
+        toolPermission() {
+          return "rw";
+        },
+      };
+      const engine = new ContextEngine({ llm, environment });
+
+      const start = performance.now();
+      const collected = await collectRun(
+        engine,
+        [userText("Create hello.txt saying Hello, Penguin")],
+        allowAll,
+      );
+      const elapsed = performance.now() - start;
+      const timersArmed = timeoutSpy.mock.calls.length + intervalSpy.mock.calls.length;
+
+      // The flow completed both turns, with the slow tool's output fed back and paired.
+      expect(llm.calls).toBe(2);
+      expect(
+        llm.receivedSecondInput!.some(
+          (m) => (m.payload as { type?: string }).type === "tool_call_output",
+        ),
+      ).toBe(true);
+      expect(collected.map((m) => (m.payload as { type?: string }).type)).toContain(
+        "tool_call_output",
+      );
+      // Latency-additive: the tool's own wait, plus scheduling slack — nothing multiplied.
+      expect(elapsed).toBeGreaterThanOrEqual(TOOL_LATENCY_MS - 5);
+      expect(elapsed).toBeLessThan(TOOL_LATENCY_MS + EPSILON_MS);
+      // And no engine-armed wall-clock wait rode along.
+      expect(timersArmed).toBe(0);
+    } finally {
+      timeoutSpy.mockRestore();
+      intervalSpy.mockRestore();
+    }
   });
 
   it("streams origin-tagged nested messages to the consumer but keeps them out of trace and the next-turn input", async () => {

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -3,14 +3,30 @@
  * many core tests spawn a real shell (Git-Bash on the Windows CI runners) or write the
  * full Agent State layout, and Windows runner I/O variance (cold shell spawns, Defender
  * first-touch scans, slow-disk moments) has pushed individually fast tests past vitest's
- * 5s default — a different test on each run. A larger failure deadline changes nothing
- * for passing tests; POSIX keeps the 5s default to fail fast during local development.
+ * 5s default — a different test on each run.
+ *
+ * The deadline's first sizing (30s) turned out to be inside that variance tail: on one
+ * cold runner (PR #66's merge-ref run) the suite-start burst of first spawns across
+ * parallel workers put environment.test.ts's single-spawn write at 28.1s PASSING and
+ * engine.test.ts's first test at 35.7s FAILING, while runs of the same code minutes
+ * before and after finished the failing test in ~1.4s. The slowdown tracked OS work
+ * only — pure-JS test files stayed at normal speed in the same run — so the flow
+ * terminates and merely waits on the OS. Amplification confirms it: injecting spawn
+ * latency into the same test (a PENGUIN_SHELL shim sleeping before bash) reproduces the
+ * failure exactly at 30s injected vs the old 30s deadline, with the flow completing
+ * ~70ms after the spawn at every magnitude tried — tool latency flows through 1:1, the
+ * loop adds no waits of its own (pinned platform-neutrally by the "slow tool delays the
+ * run only by its own latency" test in test/engine.test.ts). 120s clears the observed
+ * tail with headroom while still bounding a genuinely hung test.
+ *
+ * A larger failure deadline changes nothing for passing tests; POSIX keeps the 5s
+ * default to fail fast during local development.
  */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
     environment: "node",
-    testTimeout: process.platform === "win32" ? 30_000 : 5_000,
+    testTimeout: process.platform === "win32" ? 120_000 : 5_000,
   },
 });


### PR DESCRIPTION
## Root cause

PR #66's merge-ref `ci-windows` failed `engine.test.ts > "approves a tool call, writes the file, returns the final answer, traces it"` — **Test timed out in 30000ms** (the win32-extended deadline), at 35.7s. The working hypothesis was a goal-mode race in the changed run loop. The evidence says otherwise:

- **The failing run's code is the green run's code.** The failed merge-ref run (`30278517401`, head `ec16c69`) differs from the green run 8 minutes earlier (`30277895133`, head `894461d`) by exactly one comment-only commit (`git diff --stat`: 2 lines of docstring in context-engine.ts). Any code race would exist identically in both.
- **The slowdown was machine-wide, not code-path-wide.** In the failed run, every OS-heavy core test file slowed 10–25x at suite start: `state.test.ts` 1.7s → 39.5s (pure fs/yaml — executes zero #66 code), `environment.test.ts` 5.8s → 38.6s (its own single-spawn write test **passed at 28.1s**, 1.9s under the same deadline), `compaction.test.ts` 0.3s → 6.5s. Pure-JS files stayed at normal speed in the same run (`llm.test` 166ms, `markers.test` 14ms). A JS race in the engine cannot slow `state.test.ts`.
- **The failing test's runtime path through #66 is a no-op.** The engine diff on that path is `pendingCarryOver.map(downgradeCarriedGoalInput)` — a map over an empty array for a fresh engine. The goal loop (`Session.runGoal`/`runGoalLoop`) never runs: the test constructs `ContextEngine` directly.
- **Same-code green runs bracket the failure**: the prior PR run (test at 1415ms), post-merge main `bbcc424` ci-windows (1194ms, suite 22.36s), and PR #87's merge-ref (green, contains 46463be).

Mechanism: a cold/contended `windows-latest` runner where the suite-start burst of first Git-Bash spawns and first-touch I/O across parallel vitest workers cost ~25–40s per operation. The first engine test performs one real spawn; on that runner it crossed 30s. The vitest config's own comment records that 30s was sized for exactly this variance ("cold shell spawns, Defender first-touch scans... a different test on each run") — the tail is just wider than 30s.

**Amplification (the intermittency test).** Since a green run on identical code had suggested "intermittent race", I amplified per that theory's own prescription, on Linux:
- Tight loop of the exact failing test: **60/60 green**, constant time.
- Real spawn latency injected via a `PENGUIN_SHELL` shim (`sleep $DELAY; exec bash "$@"`), sweeping 0.5s/2s/5s/**30s**: test time = **delay + ~70ms at every magnitude** (571ms/2.07s/5.07s/30.07s). Strictly latency-additive, no cliff, no wedge — and the 30s injection **reproduces the CI failure exactly** against the old 30s deadline, with the flow completing right after.
- 4 parallel full `engine.test.ts` instances with 1s-slow spawns: 4×43 tests green, wall 12.6s.
- Goal-mode loop (`session.run(..., { goal })`) driving real Tasks through slow spawns: terminates `complete` in 2 rounds, elapsed additive (2 spawns × delay + ~150ms), watchdog silent.

So "what timing makes it pass?" — any first-spawn latency under ~29s; the failed runner drew ~30–36s. The flow terminates at every timing; the deadline was the only failing component. There is no race to fix in the engine or the goal loop (MergeQueue's single-consumer wake is installed synchronously between emptiness checks — no missed-wake window exists in single-threaded JS — and #66 didn't touch it).

## Why ubuntu passed

POSIX spawns are cheap and unscanned: the whole core suite runs in ~5s wall (the failing test in 74ms), orders of magnitude under any deadline. The pathology is specific to Windows runner first-spawn latency under parallel load.

## Fix layer

Harness (test infra), two parts:

- `packages/core/vitest.config.ts`: win32 `testTimeout` 30s → **120s**, comment rewritten with the sizing evidence. Justified as the task rules require for a deadline change: termination is proven (identical-code green runs; a 28.1s passing sibling spawn in the failed run itself; latency-additivity at 30s injected). Passing tests are unaffected; POSIX keeps 5s; a genuine hang still fails in 2 minutes.
- `packages/core/test/engine.test.ts`: new platform-neutral regression test **"a slow tool delays the run only by its own latency"** — the amplified timing, pinned deterministically: virtual tool latency (300ms) through a fake environment, asserting wall ≈ latency + ε, tool output paired into turn 2, and zero engine-armed timers (spies on `setTimeout`/`setInterval`; the engine's only timer is the reconnect backoff, failure-path only). It fails if the suspected bug class ever appears: verified by temporarily injecting a between-turns `setTimeout` wait into the engine — the test failed at 3327ms vs the 1300ms bound (and the spies trip for sub-ε timers). A dropped continuation wake would hang it into its own deadline.

## Verification

- Full gates green locally: `pnpm build` / `typecheck` / `test` (1636 tests) / `format` + `format:check`.
- Bug-class injection check: simulated between-turns idle wait → new test fails deterministically; reverted.
- **This PR's `ci-windows` job: green** ([run](https://github.com/Prism-Shadow/penguin-harness/actions/runs/30283024902/job/90033860268), 3m0s) — the previously-failing test at 1152ms, the new regression test at 357ms (300ms injected latency + 57ms ε: additivity holds on a real Windows runner too), core suite 22.78s.

### Confidence: mechanistic, not statistical

One green run is weak evidence for an intermittent failure — the failure needed a pathological runner draw, and most draws are healthy. The confidence here does not rest on the green run:

- **The failure is closed by construction.** The failure condition was `first-spawn latency > deadline`. The latency-injection experiment established the run's wall time is `spawn latency + ~70ms` — additive at 0.5s/2s/5s/30s, on the exact failing test, through the real spawn path — and the CI failure reproduces exactly when injected latency (30s) meets the old deadline (30s). With the deadline at 120s, failure requires a single first spawn to exceed ~119s: ~4x the worst latency ever observed on these runners (28.1-39.5s, and that during a 4-worker cold-start burst).
- **There is no race window to reopen.** The suspected alternative — a wake dropped when a slow tool completes at an unlucky moment — cannot occur by construction: MergeQueue has a single consumer whose wake is installed synchronously between the emptiness/producer checks (Promise executors run synchronously; producers only run while the consumer is suspended at the `await`), so in single-threaded JS there is no instant where a push can land unobserved. That property was probed empirically at many timings (60x tight loop, sweep, 4-way contention, goal rounds over slow spawns: zero anomalies) and is now pinned by the regression test, which hangs into its own deadline on a dropped wake and fails the additivity bound on any inserted wait (demonstrated: a simulated between-turns wait made it fail at 3327ms vs the 1300ms bound).
- **The residual intermittency lives in the runner, not the code**, and the deadline now sits far outside its observed distribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQX3ye1wELm1SRMku5cdni
