### PR TITLE
docs(readme): add a Contributors avatar wall after Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,14 @@ pnpm dev                     # backend + web app together (prefixed logs, deps b
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workspace guide: dev commands, quality gates, repo layout, and the changelog rule.
 
+## Contributors
+
+Thanks to everyone who has contributed to PenguinHarness!
+
+<p align="center">
+  <a href="https://github.com/Prism-Shadow/penguin-harness/graphs/contributors"><img src="https://contrib.rocks/image?repo=Prism-Shadow/penguin-harness" alt="PenguinHarness contributors" /></a>
+</p>
+
 ## Citation
 
 If you use PenguinHarness in your research, please cite:

--- a/README.zh.md
+++ b/README.zh.md
@@ -166,6 +166,14 @@ pnpm dev                     # 服务端 + Web 一起启动（带前缀日志，
 
 完整工作区指南见 [CONTRIBUTING.md](CONTRIBUTING.md)：开发命令、质量门禁、仓库结构与 changelog 规则。
 
+## 贡献者
+
+感谢每一位为 PenguinHarness 作出贡献的开发者！
+
+<p align="center">
+  <a href="https://github.com/Prism-Shadow/penguin-harness/graphs/contributors"><img src="https://contrib.rocks/image?repo=Prism-Shadow/penguin-harness" alt="PenguinHarness 贡献者" /></a>
+</p>
+
 ## 引用
 
 如果 PenguinHarness 对你的研究有帮助，请引用：


### PR DESCRIPTION
## What

A **Contributors** section in both READMEs, sitting between Development and Citation, showing the contributor avatars the way most open-source projects do:

```markdown
<p align="center">
  <a href="https://github.com/Prism-Shadow/penguin-harness/graphs/contributors"><img src="https://contrib.rocks/image?repo=Prism-Shadow/penguin-harness" alt="PenguinHarness contributors" /></a>
</p>
```

Centered in a `<p align="center">` block to match the badge and logo blocks the README already uses, and linked to the repo's contributors graph so the avatars are clickable through to the real list.

## Why this shape

`contrib.rocks` renders the wall server-side from the GitHub contributors API and refreshes on its own, so the section stays current with no generated file in the tree, no bot commits, and no CI step to maintain. The alternative — all-contributors — needs a committed `.all-contributorsrc`, a bot, and a per-person PR, which is a lot of machinery for what was asked.

Both language READMEs get it (`Contributors` / `贡献者`), keeping the two in sync as usual.

## Verification

- The image URL resolves: `HTTP 200`, `image/svg+xml`, ~23KB.
- `pnpm format && pnpm format:check` — "All matched files use Prettier code style!"
- `pnpm -r build`, `pnpm typecheck`, `pnpm test` — all pass (core 568/2 skipped, server 398, cli 200, web 417, landing 36, skills 16, docs 11). Nothing consumes the root README at build time; the landing package's `capture-readme-demo.mjs` / `render-benchmark-svg.mjs` only *produce* assets the README embeds.

## Worth knowing

The avatars are hotlinked from `contrib.rocks`, so the section depends on that third party staying up — GitHub proxies it through camo, so there is no tracking concern for readers, but a service outage would show a broken image. If you would rather not take that dependency, the alternative is committing a generated SVG and refreshing it on a schedule; say the word and I will switch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)