### PR TITLE
fix(server): assert the version endpoint against core's constants, not a literal null

### DIFF
--- a/packages/server/test/version.test.ts
+++ b/packages/server/test/version.test.ts
@@ -7,7 +7,7 @@
  * classifier and the "not launched via the CLI" early exit.
  */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { VERSION } from "@prismshadow/penguin-core";
+import { BUILD_DATE, VERSION } from "@prismshadow/penguin-core";
 import type { UpdateCheckResponse, UpdateRunResponse, VersionResponse } from "../src/api/types.js";
 import {
   FAILURE_TTL_MS,
@@ -58,7 +58,11 @@ describe("GET /api/version", () => {
     const res = await apiClient(t.app, admin.cookie).get("/api/version");
     expect(res.status).toBe(200);
     const body = (await res.json()) as VersionResponse;
-    expect(body).toEqual({ version: VERSION, buildDate: null });
+    // Both values come from core's constants, which the release workflow STAMPS before it
+    // builds and tests (VERSION from the tag, BUILD_DATE with the run's UTC date). Asserting
+    // a literal null passed everywhere except the one job that matters — the npm publish —
+    // where it failed the release. Compare against the constants themselves.
+    expect(body).toEqual({ version: VERSION, buildDate: BUILD_DATE });
   });
 });
 


### PR DESCRIPTION
v0.1.3's npm packages did not publish. The GitHub Release is complete (all 15 assets, including the first `penguin-win32-x64.zip`), but the `Publish npm packages` job failed its own build-and-test step:

```
AssertionError: expected { version: '0.1.3', buildDate: '2026-07-27' }
                to deeply equal { version: '0.1.3', buildDate: null }
  ❯ test/version.test.ts:61:18
```

`version.test.ts` hardcoded `buildDate: null`. That is true in every environment except the one that matters: the publish job stamps `VERSION` and `BUILD_DATE` from the tag **before** it builds and tests. So the assertion passed on every PR and on main, and could only ever fail during a release — which is exactly what it did, after the release job had already uploaded the artifacts.

The test now compares against `BUILD_DATE` itself, which is the invariant that was meant all along: the endpoint echoes core's constants.

## Verification

- Unstamped (normal): `pnpm --filter @prismshadow/penguin-server test` → 44 files / 398 tests green.
- Stamped (simulating the publish job): set `BUILD_DATE = "2026-07-27"` in core, rebuild core, re-run — **reproduces the failure before this change, passes after**. Constant restored.
- `pnpm build`, `pnpm typecheck`, `pnpm format:check` clean.

Note on getting 0.1.3 onto npm: the publish job checks out the **tag** on `workflow_dispatch`, so this fix has to be inside the tag for a re-run to succeed — the release owner decides between moving the `v0.1.3` tag onto this commit (the Release and its assets are already published and are not rebuilt: `check-release` skips that job) or shipping the fix in the next version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQX3ye1wELm1SRMku5cdni