### PR TITLE
fix(core): a request whose upstream ignores its AbortSignal can no longer wedge the Session

### DIFF
--- a/packages/core/src/llm/generative-model.ts
+++ b/packages/core/src/llm/generative-model.ts
@@ -1133,6 +1133,26 @@ export class GenerativeModel implements LLMInterface {
       }, this.requestTimeoutMs);
     };
 
+    /**
+     * Settles as soon as the run must stop, whatever upstream is doing: the user aborted, or
+     * the idle timer fired (both go through `ac`). `it.next()` is raced against this because
+     * an upstream that does not honour its AbortSignal leaves that promise pending **forever**
+     * — and once `ac` is aborted the idle timer's own `ac.abort()` is a no-op, so nothing is
+     * left to unwedge the loop. Observed against Kimi: pressing Stop mid-request left the
+     * Session running with no way to send, compact or interrupt it again, short of a restart.
+     *
+     * The pre-loop `userSignal?.aborted` check below covers the *other* half of this (aborting
+     * while suspended at a `yield`); it cannot help here, since the loop never gets back to it.
+     */
+    const STOPPED = Symbol("stopped");
+    const stopped: Promise<typeof STOPPED> = new Promise((resolve) => {
+      if (ac.signal.aborted) {
+        resolve(STOPPED);
+        return;
+      }
+      ac.signal.addEventListener("abort", () => resolve(STOPPED), { once: true });
+    });
+
     // Terminal-state classification: timeout (timed out/network drop) / malformed (response
     // parse error) / aborted (user) / failed (other). null means it ended normally.
     let outcome: LLMOutcome | null = null;
@@ -1159,11 +1179,19 @@ export class GenerativeModel implements LLMInterface {
         // time), measuring upstream idleness — this avoids a slow consumer (e.g. a slow Trace
         // sink) falsely triggering the timeout.
         armTimer();
-        let res: IteratorResult<UniEvent>;
+        let res: IteratorResult<UniEvent> | typeof STOPPED;
         try {
-          res = await it.next();
+          res = await Promise.race([it.next(), stopped]);
         } finally {
           clearTimer();
+        }
+        if (res === STOPPED) {
+          // Upstream never settled after the abort. Abandon it rather than await it: ask it to
+          // close (best effort — a stream that ignored the signal may ignore this too, so the
+          // rejection is swallowed and the promise is not awaited) and classify by trigger.
+          void Promise.resolve(it.return?.(undefined)).catch(() => undefined);
+          outcome = userSignal?.aborted ? { status: "aborted" } : { status: "timeout" };
+          break;
         }
         if (res.done) break;
         if (userSignal?.aborted) {

--- a/packages/core/test/llm.test.ts
+++ b/packages/core/test/llm.test.ts
@@ -1418,6 +1418,27 @@ describe("GenerativeModel.streamGenerate outcome classification (PRN-013)", () =
 
   const abortError = (): Error => Object.assign(new Error("aborted"), { name: "AbortError" });
 
+  /**
+   * An upstream that IGNORES its AbortSignal: it never yields and never rejects, whatever
+   * happens to the signal. This is the shape that wedged real Sessions (observed with Kimi):
+   * the SDK's stream promise simply never settles, so `await it.next()` hangs forever and the
+   * idle timer cannot rescue it either, because by then `ac` is already aborted and its
+   * `ac.abort()` is a no-op.
+   */
+  async function* deaf(): AsyncGenerator<UniEvent> {
+    await new Promise(() => {}); // never settles, never observes the signal
+  }
+
+  /** Fails the test loudly instead of letting a regression hang the whole suite. */
+  function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+    return Promise.race([
+      p,
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error(`streamGenerate did not settle within ${ms}ms`)), ms),
+      ),
+    ]);
+  }
+
   // Never yields any event, and only ends with an AbortError once the signal aborts
   // (simulates idle/hanging).
   async function* hang(signal: AbortSignal): AsyncGenerator<UniEvent> {
@@ -1582,6 +1603,27 @@ describe("GenerativeModel.streamGenerate outcome classification (PRN-013)", () =
       model2.streamGenerate({ newMessages: [userText("go")] }),
     );
     expect(outcome2.status).toBe("malformed");
+  });
+
+  it("a user abort ends the run even when upstream ignores the signal and never settles", async () => {
+    const model = new SeamModel(() => deaf());
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 20); // the user presses Stop mid-request
+    // Without the race this never settles and the Session stays "running" forever.
+    const { outcome } = await withTimeout(
+      drain(model.streamGenerate({ newMessages: [userText("go")], signal: controller.signal })),
+      2000,
+    );
+    expect(outcome.status).toBe("aborted");
+  });
+
+  it("the idle timeout still ends the run when upstream ignores the signal", async () => {
+    const model = new SeamModel(() => deaf(), 50); // 50ms idle budget
+    const { outcome } = await withTimeout(
+      drain(model.streamGenerate({ newMessages: [userText("go")] })),
+      2000,
+    );
+    expect(outcome.status).toBe("timeout");
   });
 
   it("classifies a credentials failure as its own terminal status auth; params stay failed", async () => {


### PR DESCRIPTION
## The bug

Pressing Stop mid-request left the Session running forever — no sending, no compaction, no second interrupt — when the provider's stream neither yielded nor rejected after the abort.

The loop's own comment already describes this failure exactly (`generative-model.ts:1144-1153`), but only **half** of it was guarded:

- Aborting while suspended at a `yield` → caught by the `userSignal?.aborted` check before the next pull. ✅
- Aborting while **blocked inside `await it.next()`** → nothing. That promise never settles, and the idle timer cannot rescue it either: by then `ac` is already aborted, so the timer's `ac.abort()` is a no-op. Nothing was left to unwedge the loop. ❌

## The fix

`it.next()` is raced against a promise that settles the moment `ac` aborts — whether that came from the user or from the idle timer:

```ts
const stopped: Promise<typeof STOPPED> = new Promise((resolve) => {
  if (ac.signal.aborted) { resolve(STOPPED); return; }
  ac.signal.addEventListener("abort", () => resolve(STOPPED), { once: true });
});
...
res = await Promise.race([it.next(), stopped]);
```

The abandoned iterator is asked to close on a best-effort basis and deliberately not awaited (a stream that ignored the signal may ignore `return()` too). The outcome is classified by which trigger fired, so Stop still reads `aborted` and an idle stall still reads `timeout`.

Provider-agnostic on purpose: the guarantee that `streamGenerate` terminates when its signal fires should not depend on any SDK honouring it.

## Verification

Two tests drive an upstream that **ignores its signal entirely** — never yields, never rejects — which is the shape that wedged real Sessions. Both are wrapped in a `withTimeout` so a regression fails loudly instead of hanging the suite.

Confirmed non-vacuous by reverting the race to a plain `await it.next()`:

```
× a user abort ends the run even when upstream ignores the signal and never settles
  → streamGenerate did not settle within 2000ms
× the idle timeout still ends the run when upstream ignores the signal
  → streamGenerate did not settle within 2000ms
```

Node 24, from the worktree root: `pnpm -r build`, `pnpm typecheck` pass; `pnpm test` passes (core 571 / 2 skipped, server 398, cli 200, web 451, landing 39, skills 16, docs 11); `pnpm format:check` clean.

## On the base URLs — no change needed

I checked both providers against AgentHub rather than hardcoding anything, and the requested behaviour is **already what the code does**:

- The `moonshot` and `zhipu` catalog entries carry **no `baseUrl` and no `clientType`** (`model-catalog.ts`), unlike the gateway entries which set both.
- `clientType` falls back to the model id (`autoClient.js:57-59`), so `kimi-k3` selects `KimiK3Client` and `glm-5.2` selects `GLM5_2Client`.
- Those clients then default the URL themselves — `options.baseUrl || process.env.MOONSHOT_BASE_URL || "https://api.moonshot.cn/v1"` (`kimi_k3/client.js:70-72`) and `… || process.env.ZAI_BASE_URL || "https://api.z.ai/api/paas/v4/"` (`glm5_2/client.js:36-38`).

So PenguinHarness already sets nothing and rides AgentHub's default, which is the preferred option. Hardcoding a URL here would only take the override away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)