### PR TITLE
feat(web): add provider-themed model group headers

### DIFF
--- a/packages/web/src/components/ui/provider-logo.tsx
+++ b/packages/web/src/components/ui/provider-logo.tsx
@@ -1,6 +1,7 @@
 /**
  * Provider logo icons (24x24 viewBox, colored via currentColor, legible in both
- * light and dark themes).
+ * light and dark themes). The optional tile variant adds a soft provider-themed
+ * background and theme-aware ink while keeping the default flat glyph unchanged.
  *
  * Anthropic / OpenAI / Google Gemini / DeepSeek / Moonshot AI / OpenRouter /
  * SiliconFlow / Qwen Token Plan / Qwen Pay-As-You-Go / Fireworks AI use each
@@ -20,6 +21,7 @@
 import type { CSSProperties, ReactNode } from "react";
 
 import { avatarInitial, avatarTile } from "../../lib/avatar";
+import { providerTheme } from "./provider-theme";
 
 interface Glyph {
   /** Solid marks (brand mark) use fill; line art uses stroke. */
@@ -114,7 +116,14 @@ const GLYPHS: Record<string, Glyph> = {
   },
 };
 
-export function ProviderLogo({ provider, className }: { provider: string; className?: string }) {
+interface ProviderLogoProps {
+  provider: string;
+  className?: string;
+  /** Flat glyph by default; tile adds a padded, provider-themed background. */
+  variant?: "plain" | "tile";
+}
+
+export function ProviderLogo({ provider, className, variant = "plain" }: ProviderLogoProps) {
   const glyph = GLYPHS[provider];
   // User-defined group (only the preset `custom` id keeps the generic cube): letter tile.
   // SVG text scales with the viewBox, staying crisp at every call-site size; the ink is
@@ -137,10 +146,46 @@ export function ProviderLogo({ provider, className }: { provider: string; classN
           dominantBaseline="central"
           fontSize="13"
           fontWeight="700"
-          className="[fill:var(--tile-fg)] dark:[fill:var(--tile-fg-dark)]"
+          className="fill-(--tile-fg) dark:fill-(--tile-fg-dark)"
         >
           {avatarInitial(provider)}
         </text>
+      </svg>
+    );
+  }
+  const theme = variant === "tile" ? providerTheme(provider) : undefined;
+  if (theme) {
+    return (
+      <svg
+        viewBox="0 0 24 24"
+        className={`${className ?? ""} text-(--provider-logo-fg) dark:text-(--provider-logo-fg-dark)`}
+        style={
+          {
+            "--provider-logo-bg": `color-mix(in srgb, ${theme.gradientFrom} 16%, transparent)`,
+            "--provider-logo-fg": theme.fg,
+            "--provider-logo-fg-dark": theme.fgDark,
+          } as CSSProperties
+        }
+        aria-hidden
+      >
+        <rect width="24" height="24" rx="5" fill="var(--provider-logo-bg)" />
+        <svg
+          x="4"
+          y="4"
+          width="16"
+          height="16"
+          viewBox={glyph.viewBox ?? "0 0 24 24"}
+          {...(glyph.stroke
+            ? {
+                fill: "none",
+                stroke: "currentColor",
+                strokeWidth: 1.8,
+                strokeLinejoin: "round" as const,
+              }
+            : { fill: "currentColor" })}
+        >
+          {glyph.path}
+        </svg>
       </svg>
     );
   }

--- a/packages/web/src/components/ui/provider-theme.ts
+++ b/packages/web/src/components/ui/provider-theme.ts
@@ -1,0 +1,89 @@
+/**
+ * Soft visual accents shared by the provider logo tile and Models group header.
+ *
+ * Logo backgrounds deliberately use translucent recognizable accent hues instead of fully
+ * saturated brand swatches. Header gradients reuse the same visual family with two solid color
+ * stops; styles.css controls their light/dark opacity so dense model lists remain easy to scan.
+ */
+export interface ProviderTheme {
+  fg: string;
+  fgDark: string;
+  gradientFrom: string;
+  gradientTo: string;
+}
+
+const QWEN_THEME: ProviderTheme = {
+  fg: "#5b43bc",
+  fgDark: "#c5b8ff",
+  gradientFrom: "#7c5cff",
+  gradientTo: "#38bdf8",
+};
+
+export const PROVIDER_THEMES: Readonly<Record<string, ProviderTheme>> = {
+  deepseek: {
+    fg: "#3852c7",
+    fgDark: "#aeb9ff",
+    gradientFrom: "#4d6bfe",
+    gradientTo: "#91a0ff",
+  },
+  openrouter: {
+    fg: "#4f46b8",
+    fgDark: "#b8b9ff",
+    gradientFrom: "#6366f1",
+    gradientTo: "#b473ff",
+  },
+  fireworks: {
+    fg: "#b8321b",
+    fgDark: "#ff9f8c",
+    gradientFrom: "#ff5b40",
+    gradientTo: "#ffb46e",
+  },
+  siliconflow: {
+    fg: "#0f766e",
+    fgDark: "#78ded2",
+    gradientFrom: "#14b8a6",
+    gradientTo: "#44d3b4",
+  },
+  "qwen-token-plan": QWEN_THEME,
+  "qwen-pay-as-you-go": QWEN_THEME,
+  google: {
+    fg: "#1967d2",
+    fgDark: "#8ab4f8",
+    gradientFrom: "#4285f4",
+    gradientTo: "#9867ff",
+  },
+  anthropic: {
+    fg: "#9f4d32",
+    fgDark: "#f0a184",
+    gradientFrom: "#d97757",
+    gradientTo: "#f4a66f",
+  },
+  openai: {
+    fg: "#08785f",
+    fgDark: "#72d6b9",
+    gradientFrom: "#10a37f",
+    gradientTo: "#5eead4",
+  },
+  zhipu: {
+    fg: "#3150ad",
+    fgDark: "#9eb2ff",
+    gradientFrom: "#3959d6",
+    gradientTo: "#5ea5fa",
+  },
+  moonshot: {
+    fg: "#334155",
+    fgDark: "#c5d2e3",
+    gradientFrom: "#475569",
+    gradientTo: "#7da0dc",
+  },
+  custom: {
+    fg: "#475569",
+    fgDark: "#cbd5e1",
+    gradientFrom: "#64748b",
+    gradientTo: "#94a3b8",
+  },
+};
+
+export function providerTheme(provider: string): ProviderTheme | undefined {
+  return PROVIDER_THEMES[provider];
+}

--- a/packages/web/src/features/models/models-page.tsx
+++ b/packages/web/src/features/models/models-page.tsx
@@ -30,6 +30,7 @@
  * means keep the existing value); only the owner can edit.
  */
 import { useCallback, useEffect, useMemo, useState } from "react";
+import type { CSSProperties } from "react";
 import type {
   CredentialInfo,
   ModelRefDto,
@@ -59,6 +60,7 @@ import { Badge } from "../../components/ui/badge";
 import { Chevron } from "../../components/ui/chevron";
 import { GlyphIcon } from "../../components/ui/glyph-icon";
 import { ProviderLogo } from "../../components/ui/provider-logo";
+import { providerTheme } from "../../components/ui/provider-theme";
 import { SkeletonList } from "../../components/ui/skeleton";
 import { EmptyState } from "../../components/ui/empty-state";
 import { formatDateTime, humanizeTokens } from "../../lib/format";
@@ -574,6 +576,13 @@ export function ModelsPage() {
           <div className="space-y-3">
             {groups.map((group) => {
               const open = !collapsed.has(group.provider.id);
+              const theme = providerTheme(group.provider.id);
+              const headerStyle = theme
+                ? ({
+                    "--provider-gradient-from": theme.gradientFrom,
+                    "--provider-gradient-to": theme.gradientTo,
+                  } as CSSProperties)
+                : undefined;
               return (
                 <section
                   key={group.provider.id}
@@ -584,7 +593,10 @@ export function ModelsPage() {
                       separate elements — can't be nested inside the collapse button (buttons
                       can't nest). The hover highlight applies to the whole header row (not
                       individual buttons) so the header reads as a single unit. */}
-                  <div className="flex items-center gap-2 bg-gray-50 pr-2 transition-colors duration-150 hover:bg-gray-100 dark:bg-gray-900/60 dark:hover:bg-gray-800/60">
+                  <div
+                    className="model-provider-group-header flex items-center gap-2 pr-2 transition-colors duration-150"
+                    style={headerStyle}
+                  >
                     <button
                       type="button"
                       aria-expanded={open}
@@ -593,7 +605,8 @@ export function ModelsPage() {
                     >
                       <ProviderLogo
                         provider={group.provider.id}
-                        className="h-5 w-5 shrink-0 text-gray-700 dark:text-gray-300"
+                        variant="tile"
+                        className="h-6 w-6 shrink-0"
                       />
                       {/* Vendor name can truncate (min-w-0): the actions on the right must not
                           shrink, otherwise on narrow screens it would get pushed out of the
@@ -1389,10 +1402,7 @@ function ModelDialog({
             the form body — it's a property of the model, not an input). */}
         {!isNew && (
           <div className="flex items-center gap-2.5 rounded-md bg-gray-50 px-3 py-2 dark:bg-gray-800/60">
-            <ProviderLogo
-              provider={form.provider}
-              className="h-6 w-6 shrink-0 text-gray-700 dark:text-gray-300"
-            />
+            <ProviderLogo provider={form.provider} variant="tile" className="h-7 w-7 shrink-0" />
             <div className="flex min-w-0 flex-1 flex-col">
               <span className="flex flex-wrap items-center gap-1.5 text-sm font-medium">
                 {form.displayName ?? form.modelId}

--- a/packages/web/src/styles.css
+++ b/packages/web/src/styles.css
@@ -1,8 +1,8 @@
 /**
  * Global styles: single-file Tailwind CSS 4 entry point.
- * Visual tone: GitHub-style simplicity — solid white background + 1px borders + a single brand blue accent,
- * no glassmorphism/gradients; the login page background is a circuit-trace animation (.login-trace, see
- * login-circuit.tsx). Dark theme is toggled via the html.dark class.
+ * Visual tone: GitHub-style simplicity — solid surfaces + 1px borders + a single brand blue accent;
+ * provider model-group headers use restrained brand-inspired gradients, while the login page background is
+ * a circuit-trace animation (.login-trace, see login-circuit.tsx). Dark theme is toggled via html.dark.
  *
  * Stacking-context convention (to avoid contexts masking each other): chrome (top bar/navigation) does not
  * create a stacking context; dropdown/user menus use z-40; modal and drawer overlays use z-50.
@@ -130,6 +130,61 @@
   .no-scrollbar::-webkit-scrollbar {
     display: none;
   }
+}
+
+/* Models provider header: a quiet two-color brand wash over the normal row surface. The gradient
+   remains intentionally translucent so the vendor name and right-side actions keep their normal
+   contrast; hover increases both the neutral surface and the wash slightly. Unknown providers use
+   the neutral fallback colors below. */
+.model-provider-group-header {
+  --provider-header-surface: #f9fafb;
+  --provider-header-hover-surface: #f3f4f6;
+  --provider-gradient-from-opacity: 14%;
+  --provider-gradient-to-opacity: 10%;
+  --provider-gradient-tail-opacity: 4%;
+  background-color: var(--provider-header-surface);
+  background-image: linear-gradient(
+    108deg,
+    color-mix(
+        in srgb,
+        var(--provider-gradient-from, #9ca3af) var(--provider-gradient-from-opacity),
+        transparent
+      )
+      0%,
+    color-mix(
+        in srgb,
+        var(--provider-gradient-to, #d1d5db) var(--provider-gradient-to-opacity),
+        transparent
+      )
+      48%,
+    color-mix(
+        in srgb,
+        var(--provider-gradient-from, #9ca3af) var(--provider-gradient-tail-opacity),
+        transparent
+      )
+      100%
+  );
+}
+
+.model-provider-group-header:hover {
+  --provider-gradient-from-opacity: 19%;
+  --provider-gradient-to-opacity: 14%;
+  --provider-gradient-tail-opacity: 6%;
+  background-color: var(--provider-header-hover-surface);
+}
+
+.dark .model-provider-group-header {
+  --provider-header-surface: rgb(13 13 13 / 0.6);
+  --provider-header-hover-surface: rgb(31 31 31 / 0.6);
+  --provider-gradient-from-opacity: 19%;
+  --provider-gradient-to-opacity: 13%;
+  --provider-gradient-tail-opacity: 5%;
+}
+
+.dark .model-provider-group-header:hover {
+  --provider-gradient-from-opacity: 24%;
+  --provider-gradient-to-opacity: 17%;
+  --provider-gradient-tail-opacity: 8%;
 }
 
 /* ---------- Animations (EmaPowerbank style: 160-280ms ease, slight entrance offset + subtle scale) ---------- */

--- a/packages/web/test/provider-theme.test.ts
+++ b/packages/web/test/provider-theme.test.ts
@@ -1,0 +1,29 @@
+/** Provider visual-theme coverage for every built-in model group and unknown-group fallback. */
+import { describe, expect, it } from "vitest";
+import { MODEL_PROVIDERS } from "@prismshadow/penguin-core/model-catalog";
+import { PROVIDER_THEMES, providerTheme } from "../src/components/ui/provider-theme";
+
+describe("providerTheme", () => {
+  it("covers every built-in model provider", () => {
+    const missing = MODEL_PROVIDERS.map((provider) => provider.id).filter(
+      (provider) => providerTheme(provider) === undefined,
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it("uses one visual family for the two Qwen billing groups", () => {
+    expect(PROVIDER_THEMES["qwen-token-plan"]).toEqual(PROVIDER_THEMES["qwen-pay-as-you-go"]);
+  });
+
+  it("defines two valid gradient stops for every built-in provider", () => {
+    for (const provider of MODEL_PROVIDERS) {
+      const theme = providerTheme(provider.id)!;
+      expect(theme.gradientFrom).toMatch(/^#[0-9a-f]{6}$/i);
+      expect(theme.gradientTo).toMatch(/^#[0-9a-f]{6}$/i);
+    }
+  });
+
+  it("leaves unknown providers to the neutral header and letter-tile fallbacks", () => {
+    expect(providerTheme("team-proxy")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Add centralized visual themes for every built-in model provider.
- Render provider logos as theme-aware tiles on the Models page while preserving plain logos elsewhere.
- Add subtle provider-inspired group-header gradients with light, dark, hover, custom, and unknown-provider fallbacks.
- Cover provider theme completeness and gradient tokens with unit tests.

## Validation

- pnpm --filter @prismshadow/penguin-web test (35 files, 455 tests)
- pnpm --filter @prismshadow/penguin-web typecheck
- pnpm --filter @prismshadow/penguin-web build
- Prettier check and git diff --check
