### PR TITLE
fix(core): preserve committed responses after stop

### DIFF
--- a/packages/core/src/llm/generative-model.ts
+++ b/packages/core/src/llm/generative-model.ts
@@ -1188,9 +1188,13 @@ export class GenerativeModel implements LLMInterface {
         if (res === STOPPED) {
           // Upstream never settled after the abort. Abandon it rather than await it: ask it to
           // close (best effort — a stream that ignored the signal may ignore this too, so the
-          // rejection is swallowed and the promise is not awaited) and classify by trigger.
+          // rejection is swallowed and the promise is not awaited). A received finish_reason
+          // means AgentHub already committed the response, so preserve normal completion;
+          // otherwise classify the interrupted request by its trigger.
           void Promise.resolve(it.return?.(undefined)).catch(() => undefined);
-          outcome = userSignal?.aborted ? { status: "aborted" } : { status: "timeout" };
+          if (!translator.sawFinishReason()) {
+            outcome = userSignal?.aborted ? { status: "aborted" } : { status: "timeout" };
+          }
           break;
         }
         if (res.done) break;

--- a/packages/core/test/llm.test.ts
+++ b/packages/core/test/llm.test.ts
@@ -1429,6 +1429,23 @@ describe("GenerativeModel.streamGenerate outcome classification (PRN-013)", () =
     await new Promise(() => {}); // never settles, never observes the signal
   }
 
+  /** A committed terminal tool-call event whose transport never closes afterward. */
+  async function* committedThenDeaf(): AsyncGenerator<UniEvent> {
+    yield ev({
+      event_type: "stop",
+      finish_reason: "tool_call",
+      content_items: [
+        {
+          type: "tool_call",
+          name: "exec_command",
+          arguments: { cmd: "echo done" },
+          tool_call_id: "committed-call",
+        },
+      ],
+    });
+    await new Promise(() => {}); // response committed, but the transport never closes
+  }
+
   /** Fails the test loudly instead of letting a regression hang the whole suite. */
   function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
     return Promise.race([
@@ -1624,6 +1641,30 @@ describe("GenerativeModel.streamGenerate outcome classification (PRN-013)", () =
       2000,
     );
     expect(outcome.status).toBe("timeout");
+  });
+
+  it("a user abort after finish_reason preserves the committed response when upstream never settles", async () => {
+    const model = new SeamModel(() => committedThenDeaf());
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 20);
+    const { messages, outcome } = await withTimeout(
+      drain(model.streamGenerate({ newMessages: [userText("go")], signal: controller.signal })),
+      2000,
+    );
+    expect(messages.map(typeOf)).toContain("tool_call");
+    expect(messages.map(typeOf)).toContain("token_usage");
+    expect(outcome.status).toBe("completed");
+  });
+
+  it("an idle timeout after finish_reason preserves the committed response when upstream never settles", async () => {
+    const model = new SeamModel(() => committedThenDeaf(), 50);
+    const { messages, outcome } = await withTimeout(
+      drain(model.streamGenerate({ newMessages: [userText("go")] })),
+      2000,
+    );
+    expect(messages.map(typeOf)).toContain("tool_call");
+    expect(messages.map(typeOf)).toContain("token_usage");
+    expect(outcome.status).toBe("completed");
   });
 
   it("classifies a credentials failure as its own terminal status auth; params stay failed", async () => {


### PR DESCRIPTION
## Problem

PR #107 guarantees that `streamGenerate` exits when an upstream iterator ignores its `AbortSignal`, but its new `STOPPED` branch classified every abort race as `aborted` or `timeout`.

If AgentHub had already delivered `finish_reason`, the response was committed even when the transport failed to close afterward. Downgrading that response could send ContextEngine down the incomplete-turn cleanup or reconnect path, risking broken tool-call/output pairing or duplicate work.

## Fix

- Preserve normal completion when `STOPPED` wins after `finish_reason` was already observed.
- Keep the existing `aborted` and `timeout` classification when no terminal event was received.
- Add deterministic regressions for both a user Stop and idle timeout after a committed terminal tool-call event whose upstream iterator never settles.

## Changelog

Intentionally omitted here; this change will be recorded in a separate batched changelog PR alongside #111 and #113.

## Validation

- Independent read-only agent review: no actionable or blocking findings.
- `pnpm --filter @prismshadow/penguin-core exec vitest run test/llm.test.ts` — 87 passed.
- `pnpm --filter @prismshadow/penguin-core typecheck` — passed.
- `pnpm format:check` — passed.
- Full core suite attempted: 571 passed, 4 skipped; 4 unrelated Windows-host failures remain (one symlink-privilege `EPERM` case and three long-running command-session timing cases).
