### PR TITLE
fix(web): keep import controls inside their scroller, so the document stops scrolling

### DIFF
--- a/packages/web/e2e/layout.spec.mjs
+++ b/packages/web/e2e/layout.spec.mjs
@@ -15,6 +15,10 @@
  *   ~34px off-screen left, the skills menu ~92px off-screen right — with its autofocused
  *   search box then horizontally scrolling the whole draft page — and the workspace menu
  *   ~143px off-screen right when the ownership pills share one row);
+ * - no page grows the **document**: the app shell is height-constrained and each page scrolls
+ *   inside its own container, so a second scrollbar means an absolutely positioned descendant
+ *   escaped its scroller (the Traces tree and the Agent settings page both had one, visible
+ *   only with a second Agent below a long list);
  * - the sidebar's "New chat" button has no background fill (same gray-scale style as nav items);
  * - the collapsed rail shows, in product-specified order, last conversation / new chat /
  *   Agents / Skills / Models / Costs / Traces / Benchmark with localized (en + zh) hover
@@ -644,6 +648,78 @@ test("layout: mobile chat dropdowns stay inside the viewport", async ({ page }) 
     await deniedHeader.evaluate((el) => el.clientHeight),
     "denied card header stays single-line @390",
   ).toBeLessThanOrEqual(40);
+});
+
+/**
+ * The app shell is height-constrained: every page scrolls inside its own container and the
+ * document itself must never scroll. What breaks that is an absolutely positioned descendant
+ * whose containing block is the initial containing block — nothing between it and the root
+ * clips it, so its static position past the fold grows the **document**, producing a second
+ * scrollbar that drags the whole shell up. The Traces tree and the Agent settings page both
+ * had one (the `sr-only` file inputs of their import controls), visible only once a second
+ * Agent sat below a long list. This sweep is the general guard: with the data that exposes it,
+ * no page may grow the document.
+ */
+test("layout: no page grows the document (absolute descendants stay in their scroller)", async ({
+  page,
+}) => {
+  await provisionAndLogin(page.request, "layoutheight", P);
+  const projects = await (await page.request.get(`${BASE}/api/projects`)).json();
+  const projectId = projects.projects[0].projectId;
+  const put = await page.request.put(`${BASE}/api/projects/${projectId}/models`, {
+    data: {
+      defaultModel: { provider: "custom", modelId: "claude-4-8" },
+      models: [
+        {
+          provider: "custom",
+          modelId: "claude-4-8",
+          apiKey: "sk-mock",
+          baseUrl: MOCK,
+          contextWindow: 200000,
+        },
+      ],
+    },
+  });
+  expect(put.ok(), "put models").toBeTruthy();
+  // A second Agent is what moves an import control below the fold; the Traces tree only lists
+  // Sessions that have a Trace file, so each one has to actually run a Task.
+  const second = await page.request.post(`${BASE}/api/projects/${projectId}/agents`, {
+    data: { agentId: "agent_two", name: "Agent Two" },
+  });
+  // 409 = the Agent survives from an earlier run of this spec against the same data root
+  // (provisioning is idempotent by convention here, so a spec can be rerun on its own).
+  expect([201, 409], "create second agent").toContain(second.status());
+  for (const agentId of ["default_agent", "agent_two"]) {
+    for (let i = 0; i < (agentId === "default_agent" ? 14 : 2); i += 1) {
+      const created = await (
+        await page.request.post(`${BASE}/api/projects/${projectId}/agents/${agentId}/sessions`, {
+          data: { provider: "custom", modelId: "claude-4-8" },
+        })
+      ).json();
+      await page.request.post(`${BASE}/api/sessions/${created.session.sessionId}/tasks`, {
+        data: { input: [{ type: "text", text: "hi" }] },
+      });
+    }
+  }
+
+  // A short viewport puts the second Agent's node below the fold with a handful of Sessions
+  // instead of dozens — the same geometry a full-height window reaches with a longer list.
+  // Not shorter than 420: below ~412px the sidebar's own fixed chrome (project switcher, the
+  // eight nav entries, the user row) no longer fits, which grows the document for its own
+  // unrelated reason and would mask what this test is after.
+  await page.setViewportSize({ width: 1440, height: 420 });
+  const paths = ["/traces", "/chat", "/agents", "/agents/default_agent", "/skills", "/models"];
+  const overflowing = [];
+  for (const path of paths) {
+    await page.goto(`${BASE}${path}`);
+    await page.waitForTimeout(1200);
+    const grew = await page.evaluate(() => {
+      const de = document.documentElement;
+      return de.scrollHeight - de.clientHeight;
+    });
+    if (grew > 0) overflowing.push(`${path} (+${grew}px)`);
+  }
+  expect(overflowing, "pages whose document scrolls").toEqual([]);
 });
 
 test("layout: login — blank start, non-crossing traces, lang/theme controls", async ({ page }) => {

--- a/packages/web/src/components/ui/hidden-file-input.tsx
+++ b/packages/web/src/components/ui/hidden-file-input.tsx
@@ -1,0 +1,25 @@
+/**
+ * File input that is visually hidden but still Tab-focusable — the picker every "upload" /
+ * "import" control in the app wraps in its own `<label>`.
+ *
+ * `display: none` would drop it out of the focus order, so the box has to be visually hidden
+ * the `sr-only` way, which means `position: absolute`. That is exactly the shape that used to
+ * escape its scroller and stretch the document (see the scroll-container invariant in
+ * styles.css): dropped into a `static` ancestor chain, its containing block became the
+ * initial containing block, so a control sitting past the fold added document-level
+ * scrollable overflow and a second scrollbar.
+ *
+ * Hence the wrapper: it is `relative`, so the containing block travels **with the control**
+ * instead of depending on whichever ancestor happens to be positioned. The wrapper is
+ * `contents`-free on purpose — it is a real box, but an empty inline one with an absolutely
+ * positioned child, so it contributes no width and no height to the label around it.
+ */
+import type { InputHTMLAttributes } from "react";
+
+export function HiddenFileInput(props: Omit<InputHTMLAttributes<HTMLInputElement>, "type">) {
+  return (
+    <span className="relative">
+      <input type="file" className="sr-only" {...props} />
+    </span>
+  );
+}

--- a/packages/web/src/features/agents/agent-settings-page.tsx
+++ b/packages/web/src/features/agents/agent-settings-page.tsx
@@ -27,6 +27,7 @@ import { useProject } from "../../state/project";
 import { Tabs } from "../../components/ui/tabs";
 import { Button } from "../../components/ui/button";
 import { toastError, toastInfo, toastSuccess } from "../../components/ui/toast";
+import { HiddenFileInput } from "../../components/ui/hidden-file-input";
 import { Input, Textarea } from "../../components/ui/input";
 import { OptionMenu, type OptionMenuChoice } from "../../components/ui/option-menu";
 import { Switch } from "../../components/ui/switch";
@@ -156,11 +157,8 @@ export function AgentSettingsPage() {
   }
 
   return (
-    /* relative: this page's scroller is its own containing block, so the snapshot-import
-       control's `sr-only` file input (position:absolute) anchors and scrolls inside it. Left
-       static, that input anchored to the initial containing block instead — past the fold it
-       sat at a document-level offset nothing clips, growing the document and adding a second
-       scrollbar (same failure as the Traces tree and the sidebar session list). */
+    /* relative: a scroller is its own containing block (see the invariant in styles.css) —
+       this page's snapshot-import control used to grow the document from below the fold. */
     <div className="no-scrollbar relative h-full overflow-y-auto p-4 md:p-6">
       <div className="mx-auto max-w-3xl">
         <Button
@@ -356,14 +354,7 @@ function OverviewTab({
             <label
               className={`${TRANSFER_BUTTON_CLASS} ${importing ? "pointer-events-none opacity-60" : ""}`}
             >
-              {/* sr-only rather than hidden: keeps it keyboard-Tab-focusable (same as the workspace-browser upload). */}
-              <input
-                type="file"
-                accept=".tar.gz,.tgz"
-                className="sr-only"
-                disabled={importing}
-                onChange={onPickFile}
-              />
+              <HiddenFileInput accept=".tar.gz,.tgz" disabled={importing} onChange={onPickFile} />
               {importing ? S.agent.importing : S.agent.importSnapshot}
             </label>
           )}

--- a/packages/web/src/features/agents/agent-settings-page.tsx
+++ b/packages/web/src/features/agents/agent-settings-page.tsx
@@ -156,7 +156,12 @@ export function AgentSettingsPage() {
   }
 
   return (
-    <div className="no-scrollbar h-full overflow-y-auto p-4 md:p-6">
+    /* relative: this page's scroller is its own containing block, so the snapshot-import
+       control's `sr-only` file input (position:absolute) anchors and scrolls inside it. Left
+       static, that input anchored to the initial containing block instead — past the fold it
+       sat at a document-level offset nothing clips, growing the document and adding a second
+       scrollbar (same failure as the Traces tree and the sidebar session list). */
+    <div className="no-scrollbar relative h-full overflow-y-auto p-4 md:p-6">
       <div className="mx-auto max-w-3xl">
         <Button
           variant="ghost"

--- a/packages/web/src/features/chat/workspace-browser.tsx
+++ b/packages/web/src/features/chat/workspace-browser.tsx
@@ -27,6 +27,7 @@ import { Button } from "../../components/ui/button";
 import { ConfirmModal } from "../../components/ui/confirm-modal";
 import { toastError, toastSuccess } from "../../components/ui/toast";
 import { Dropdown } from "../../components/ui/dropdown";
+import { HiddenFileInput } from "../../components/ui/hidden-file-input";
 import { SkeletonList } from "../../components/ui/skeleton";
 import { CodeBlock } from "./code-block";
 
@@ -745,14 +746,7 @@ export function WorkspaceBrowser({
         </Button>
         {/* Matches the same visual style and font size (sm = text-xs) as the adjacent ghost Buttons (Details/Refresh): no border, light background on hover. */}
         <label className="inline-flex cursor-pointer items-center rounded-md border border-transparent bg-transparent px-2.5 py-1 text-xs font-medium text-gray-600 transition-colors duration-150 focus-within:ring-2 focus-within:ring-gray-400/30 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-gray-100">
-          {/* sr-only rather than hidden: keyboard users can still Tab-focus it (display:none would remove it from the focus order). */}
-          <input
-            type="file"
-            multiple
-            className="sr-only"
-            onChange={onUpload}
-            disabled={uploading}
-          />
+          <HiddenFileInput multiple onChange={onUpload} disabled={uploading} />
           {uploading ? S.common.saving : S.files.upload}
         </label>
       </div>

--- a/packages/web/src/features/traces/traces-page.tsx
+++ b/packages/web/src/features/traces/traces-page.tsx
@@ -297,8 +297,15 @@ export function TracesPage() {
 
   return (
     <div className="flex h-full flex-col md:flex-row">
-      {/* Directory tree: Agent → Session title (≥md left column; <md top collapsible area) */}
-      <aside className="max-h-52 shrink-0 overflow-y-auto border-b border-gray-200 bg-gray-50 px-1 py-2 md:max-h-none md:w-72 md:border-b-0 md:border-r dark:border-gray-800 dark:bg-gray-900">
+      {/* Directory tree: Agent → Session title (≥md left column; <md top collapsible area).
+          relative: the tree scroller must be its own containing block. Each Agent node carries
+          an import control whose file input and label are `sr-only`, i.e. position:absolute —
+          anchored to the initial containing block instead, a node sitting past the fold (the
+          second Agent, below a long session list) placed those boxes at a document-level
+          offset that neither this overflow-y-auto nor main's overflow-hidden clips, stretching
+          the **document** and putting a second scrollbar on the page (same failure the sidebar
+          session list fixed, see sidebar.tsx). */}
+      <aside className="relative max-h-52 shrink-0 overflow-y-auto border-b border-gray-200 bg-gray-50 px-1 py-2 md:max-h-none md:w-72 md:border-b-0 md:border-r dark:border-gray-800 dark:bg-gray-900">
         <p className="px-3 pb-1 text-xs font-bold uppercase tracking-wide text-gray-500">
           {S.traces.title}
         </p>

--- a/packages/web/src/features/traces/traces-page.tsx
+++ b/packages/web/src/features/traces/traces-page.tsx
@@ -17,6 +17,7 @@ import { formatBytes } from "../../lib/format";
 import { agentDisplayName, useProject } from "../../state/project";
 import { AgentAvatar } from "../../components/ui/agent-avatar";
 import { Chevron } from "../../components/ui/chevron";
+import { HiddenFileInput } from "../../components/ui/hidden-file-input";
 import { DownloadIcon, UploadIcon } from "../../components/ui/icons";
 import { toastError } from "../../components/ui/toast";
 import { Truncated } from "../../components/ui/truncated";
@@ -197,14 +198,7 @@ function AgentNode({
               importing ? "pointer-events-none opacity-60" : ""
             }`}
           >
-            {/* sr-only rather than hidden: keeps it keyboard-Tab-focusable (same as the snapshot import). */}
-            <input
-              type="file"
-              accept=".jsonl"
-              className="sr-only"
-              disabled={importing}
-              onChange={onPickFile}
-            />
+            <HiddenFileInput accept=".jsonl" disabled={importing} onChange={onPickFile} />
             <UploadIcon size={13} />
             <span className="sr-only">{importing ? S.traces.importing : S.traces.importTrace}</span>
           </label>
@@ -298,13 +292,10 @@ export function TracesPage() {
   return (
     <div className="flex h-full flex-col md:flex-row">
       {/* Directory tree: Agent → Session title (≥md left column; <md top collapsible area).
-          relative: the tree scroller must be its own containing block. Each Agent node carries
-          an import control whose file input and label are `sr-only`, i.e. position:absolute —
-          anchored to the initial containing block instead, a node sitting past the fold (the
-          second Agent, below a long session list) placed those boxes at a document-level
-          offset that neither this overflow-y-auto nor main's overflow-hidden clips, stretching
-          the **document** and putting a second scrollbar on the page (same failure the sidebar
-          session list fixed, see sidebar.tsx). */}
+          relative: a scroller is its own containing block — the invariant and the failure it
+          prevents are documented in styles.css; this is where it first bit (an Agent node past
+          the fold put its import control's absolutely positioned box at a document-level
+          offset, growing the document). */}
       <aside className="relative max-h-52 shrink-0 overflow-y-auto border-b border-gray-200 bg-gray-50 px-1 py-2 md:max-h-none md:w-72 md:border-b-0 md:border-r dark:border-gray-800 dark:bg-gray-900">
         <p className="px-3 pb-1 text-xs font-bold uppercase tracking-wide text-gray-500">
           {S.traces.title}

--- a/packages/web/src/styles.css
+++ b/packages/web/src/styles.css
@@ -76,6 +76,29 @@
   #root {
     height: 100%;
   }
+  /* Every scroll container is its own containing block.
+     The shell is height-constrained (the three rules above) and each page scrolls inside its
+     own container, so the document must never scroll. What breaks that is an absolutely
+     positioned descendant of a scroller that is itself `static`: its containing block is then
+     the initial containing block, which nothing clips — not the scroller's own overflow, not
+     an `overflow-hidden` ancestor — so its static position past the fold becomes the
+     *document's* scrollable overflow, and a second scrollbar appears that drags the whole
+     shell. That bug shipped three times (sidebar session list, Traces tree, Agent settings),
+     every time through a visually-hidden-but-focusable control, so the invariant is set here
+     once instead of being remembered per scroller.
+     Scoped to the scrollable utilities on purpose: `overflow-hidden` is also used as a plain
+     clipping box (the docked panels' clipping windows), where forcing a containing block is
+     more likely to surprise than to help. Declared in `base`, so an explicit
+     absolute/fixed/sticky utility on the same element still wins; `position: relative` at
+     `z-index: auto` creates no stacking context, so the convention in the file header holds. */
+  .overflow-auto,
+  .overflow-x-auto,
+  .overflow-y-auto,
+  .overflow-scroll,
+  .overflow-x-scroll,
+  .overflow-y-scroll {
+    position: relative;
+  }
   body {
     @apply bg-white text-gray-900 antialiased dark:bg-gray-950 dark:text-gray-100;
     font-family:


### PR DESCRIPTION
Reported as: with two Agents and many sessions, the Traces page gets a second scrollbar, and dragging it scrolls the entire page up, leaving blank space at the top.

## What happens

The Traces tree and the Agent settings page each carry an import control whose file input and label are `sr-only` — deliberately, so keyboard users can still Tab to them. `sr-only` is `position: absolute`.

Neither scroller was positioned, and neither was anything between them and the root, so those boxes took the **initial containing block** as their containing block. Nothing clips a box whose containing block is the root: not the tree's own `overflow-y-auto`, not `main`'s `overflow-hidden`. Their static position — for the second Agent's node, below the first Agent's entire session list — therefore lands at a document-level offset and becomes the document's scrollable overflow.

Measured before the fix (1440x420, two Agents, ~30 trace-bearing sessions): `documentElement.scrollHeight` 2061 against a 420px viewport, with the escaping boxes identified as the `sr-only` input and label of the second Agent's import button at y≈2047.

One Agent hides it entirely: that control sits at the top of the tree, so its static position is above the fold.

## Fix

Both scrollers become their own containing block (`relative`), so the boxes anchor and scroll inside them and are clipped by them. This is the same fix — and the same failure — the sidebar session list already carries, where the rationale is documented; the comments here point at it.

`relative` on a `static` block changes nothing visually: the only absolutely positioned descendants involved are the `sr-only` boxes, which are invisible by design.

## Verification

- Repro measured and re-measured in a real browser: `scrollHeight` 2061 → 420 (equal to the viewport) on `/traces`; the sweep below then found `/agents/:id` failing the same way (+286px) and clean after the same change.
- New e2e guard in `layout.spec.mjs`: two Agents, a session list long enough to push the second one past the fold, and a sweep of `/traces`, `/chat`, `/agents`, `/agents/:id`, `/skills`, `/models` asserting no page grows the document. It fails on both pre-fix pages.
- `pnpm -r build`, `pnpm typecheck`, `pnpm test` (1686 passed / 2 skipped), `pnpm format:check` — green.
- Full `layout.spec.mjs`: 4 passed, 1 failed — `mobile chat dropdowns`, which fails identically on pristine `main` (verified earlier by rebuilding from a stashed tree).

## Noted, not fixed

Below roughly 412px of viewport height the sidebar's own fixed chrome (project switcher, the eight nav entries, the user row) no longer fits and grows the document by itself — a different, pre-existing floor, unrelated to the Agent count. The new test sits at 420px and says so, rather than silently depending on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUMcjn2UJ7SSqjhEyvCeN6

---

## Follow-up in this PR: the rule moves out of the components

The two `relative` fixes above stop this instance. Three scrollers have now shipped the same defect, always through a visually-hidden-but-focusable control, so the rule is now declared once instead of being remembered per scroller:

- **`styles.css`** — every scrollable utility (`overflow-auto` / `overflow-x-auto` / `overflow-y-auto` and the `scroll` variants) is its own containing block, with the failure it prevents written down next to it. Scoped to the *scrollable* utilities on purpose: `overflow-hidden` also serves as a plain clipping box (the docked panels' clipping windows), where forcing a containing block is more likely to surprise than to help. Declared in `base`, so an explicit `absolute`/`fixed`/`sticky` utility on the same element still wins, and `position: relative` at `z-index: auto` creates no stacking context, so the file's stacking convention holds.
- **`HiddenFileInput`** — replaces the three hand-rolled `sr-only` file inputs (Traces import, Agent snapshot import, Workspace upload). Its wrapper carries the containing block, so the control is safe wherever it is dropped, and the three copies of "sr-only rather than hidden, to keep it Tab-focusable" collapse into one.

The two scrollers keep their explicit `relative`: the intent stays visible at the call site (matching the sidebar), with the reasoning pointing at `styles.css` rather than repeated.

Extra verification for the follow-up: both import controls still open a file picker in a real browser and the input is still focus-reachable; the full web e2e suite is 22 passed / 5 failed, the five being the known pre-existing ones (`draft-user-scope`, `paging`, `skills`, `layout`'s mobile dropdowns, and `subagent`'s task-scoped lifecycle — the last passes on a rerun and was reported flaky independently of this branch).

Design doc updated in sync: penguin-harness-design#9 records the invariant in specs/06「设计风格」.
