### PR TITLE
chore(ci): upgrade pnpm/action-setup to v6 and action-gh-release to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v5
 
       # pnpm version comes from package.json's packageManager field.
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v5
         with:
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@v5
 
       # pnpm version comes from package.json's packageManager field.
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v5
         with:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v5
 
       # pnpm version comes from package.json's packageManager field.
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || '' }}
 
       # pnpm version comes from package.json's packageManager field.
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v5
         with:
@@ -271,7 +271,7 @@ jobs:
       # An empty body_path is falsy for the action and simply ignored (it never tries to read it), so the
       # fallback branch cleanly leaves generate_release_notes to compose the body on its own.
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
           body_path: ${{ steps.notes.outputs.body_path }}
@@ -300,7 +300,7 @@ jobs:
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || '' }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v5
         with:


### PR DESCRIPTION
## Summary

The v0.1.5 release run emitted Node 20 deprecation warnings for two actions still targeting the deprecated runtime. This upgrades both to their Node 24 lines:

- `pnpm/action-setup@v4` → `@v6` (5 call sites: ci.yml ×2, pages.yml, release.yml ×2). v5.0.0 is the Node 24 retarget; v6.0.0 adds official pnpm v11 support — we are on pnpm 11.18.0. All call sites are bare `uses:` with the version resolved from `package.json`'s `packageManager`, so no inputs are affected.
- `softprops/action-gh-release@v2` → `@v3` (release.yml, Publish GitHub Release step). v3.0.0 is a pure runtime move to Node 24 for GitHub-hosted runners; the inputs we pass (`tag_name`, `body_path`, `generate_release_notes`, `files`) are unchanged.

## Verification

- `pnpm format:check` — pass; workflow YAML parses.
- This PR's own CI (`ci`, `ci-windows`) runs on `pnpm/action-setup@v6`, exercising the bump end to end.
- `action-gh-release@v3` only runs on tag pushes — verified against its v3.0.0 release notes (runtime-only change); the next release run is the live check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)