### PR TITLE
fix(web): queue follow-ups across steer races

### DIFF
--- a/changelog/unreleased/2026-08-03-reloaded-followup-race.md
+++ b/changelog/unreleased/2026-08-03-reloaded-followup-race.md
@@ -1,0 +1,5 @@
+# Reloaded follow-ups survive the steering completion race
+
+When a reloaded page still showed a Session as running, the composer first tried the steering endpoint. If the core run ended in that narrow window, `/steer` returned `not_running` and the Web App retried the draft as a plain Task. That second request could arrive before the server runtime completed its own idle transition, return `task_in_progress`, and leave the draft unsent.
+
+The fallback now submits the complete, untouched draft through the existing `queueIfBusy` Task path. The server starts it immediately if the Session is already idle or queues it behind the final part of the old run otherwise. A Playwright regression reloads a Session with a parked Task, forces the stale steering response, and verifies both the accepted queued response and the follow-up's eventual model output.

--- a/changelog/unreleased/README.md
+++ b/changelog/unreleased/README.md
@@ -2,6 +2,8 @@
 
 Changes since v0.1.5. The version number is assigned at release, when this folder is renamed.
 
+- [2026-08-03] Web App: a steering completion race now submits the untouched draft through the server-side follow-up queue, so a reloaded Session cannot strand a message between `/steer` and a new Task. ([details](2026-08-03-reloaded-followup-race.md))
+
 - [2026-07-31] Evaluation Center: Case details separate Target Agent task materials from project-member-visible scoring rubrics, Score charts use a padded dynamic axis without discarding stored values, and the benchmark Skills write YAML-safe Scoreboard summaries. ([details](2026-07-31-evaluation-center-case-details.md))
 
 - [2026-07-30] Web App: the main conversation's file summary moves to the completed Task boundary — one card per Task scanning all of its assistant text, nested agent conversations keep their per-message summaries, and file-existence caching stops retaining negative results so a later Task can surface a newly created path. ([details](2026-07-30-file-summary-task-boundary.md))

--- a/packages/web/e2e/reloaded-followup.spec.mjs
+++ b/packages/web/e2e/reloaded-followup.spec.mjs
@@ -1,0 +1,93 @@
+/** Regression for #89: a Task posted after reloading a completed Session must execute. */
+import { test, expect } from "@playwright/test";
+import { provisionAndLogin } from "./auth.mjs";
+
+const BASE = process.env.BASE_URL;
+const MOCK = process.env.MOCK_URL;
+const PASSWORD = "password123";
+
+async function provisionSession(page, username) {
+  await provisionAndLogin(page.request, username, PASSWORD);
+  const projects = await (await page.request.get(`${BASE}/api/projects`)).json();
+  const projectId = projects.projects[0].projectId;
+  const models = await page.request.put(`${BASE}/api/projects/${projectId}/models`, {
+    data: {
+      defaultModel: { provider: "custom", modelId: "claude-4-8" },
+      models: [
+        {
+          provider: "custom",
+          modelId: "claude-4-8",
+          apiKey: "sk-mock",
+          baseUrl: MOCK,
+          contextWindow: 200000,
+        },
+      ],
+    },
+  });
+  expect(models.ok(), "put models").toBeTruthy();
+  const session = await page.request.post(
+    `${BASE}/api/projects/${projectId}/agents/default_agent/sessions`,
+    {
+      data: {
+        provider: "custom",
+        modelId: "claude-4-8",
+        approvalMode: "always-ask",
+      },
+    },
+  );
+  expect(session.ok(), `create session: ${await session.text()}`).toBeTruthy();
+  return (await session.json()).session.sessionId;
+}
+
+test("a stale steer response after reload queues the follow-up instead of stranding it", async ({
+  page,
+}, testInfo) => {
+  const sessionId = await provisionSession(page, `reloadfollowup${testInfo.repeatEachIndex}`);
+  await page.goto(`${BASE}/chat/${sessionId}`);
+  const composer = page.locator("textarea");
+  await composer.waitFor();
+
+  await composer.fill("first task before reload");
+  const firstPost = page.waitForResponse((response) =>
+    response.url().endsWith(`/sessions/${sessionId}/tasks`),
+  );
+  await page.getByRole("button", { name: "发送" }).click();
+  expect((await firstPost).status()).toBe(202);
+
+  // Reproduce the post-reload stale-state seam deterministically: the client still sees a
+  // running Task, but /steer reports that the run just ended. The fallback must use the
+  // server's queue-if-busy path, which is safe on both sides of that completion race.
+  await expect(page.getByRole("button", { name: "允许" })).toBeVisible();
+  await page.route(`**/api/sessions/${sessionId}/steer`, (route) =>
+    route.fulfill({
+      status: 409,
+      contentType: "application/json",
+      body: JSON.stringify({
+        error: {
+          code: "not_running",
+          message: "This Session has no Task in progress; send a new task instead.",
+        },
+      }),
+    }),
+  );
+  await page.reload();
+  await composer.waitFor();
+  await expect(page.getByRole("button", { name: "停止" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "允许" })).toBeVisible();
+
+  await composer.fill("hello after reload");
+  const followUpPost = page.waitForResponse((response) =>
+    response.url().endsWith(`/sessions/${sessionId}/tasks`),
+  );
+  await page.getByRole("button", { name: "发送给运行中的 Agent" }).click();
+  const response = await followUpPost;
+  expect(response.status()).toBe(202);
+  expect(await response.json()).toMatchObject({ queued: true });
+
+  // The first task completes, then the accepted follow-up actually reaches the LLM and
+  // produces a second answer instead of remaining an inert 202 response.
+  await page.getByRole("button", { name: "允许" }).click();
+  await expect(page.getByText("Command finished; the result looks as expected.")).toHaveCount(2, {
+    timeout: 30_000,
+  });
+});

--- a/packages/web/src/features/chat/chat-input.tsx
+++ b/packages/web/src/features/chat/chat-input.tsx
@@ -1998,10 +1998,13 @@ export function ChatInput({
         setBusy(false);
         textareaRef.current?.focus();
       }
-      // Completion race (server: no Task running anymore): deliver the whole draft — skills
-      // and all — through the full normal send path. The draft is untouched in this branch
-      // (nothing was cleared), so the images go out with it.
-      if (res === "not_running") await sendNormal();
+      // Completion race: the SSE snapshot can still say running after /steer reports that the
+      // core run has ended. Deliver the untouched whole draft — skills and all — through the
+      // queue-if-busy path. That endpoint is atomic across both sides of the server's own
+      // completion seam: it starts immediately when idle, or queues behind the last sliver of
+      // the old run. A plain Task POST could race the manager's idle flip and return 409,
+      // stranding the draft on a reloaded page (#89).
+      if (res === "not_running") await sendNormal(onQueueFollowUp ?? onSend);
       return;
     }
     if (!canSend) return;


### PR DESCRIPTION
## Summary

- route the Web composer's `not_running` steering fallback through the server's existing `queueIfBusy` Task path
- keep the complete draft intact across the fallback, including skills and attachments
- add a Playwright regression that reloads a running Session, forces the stale steering response, verifies `202 queued`, and waits for the follow-up's model output

## Root cause

After a reload, the SSE snapshot can briefly leave the composer in running/steer mode while the core run is ending. If `/steer` returns `not_running`, retrying with a plain Task POST can reach the runtime before its idle transition and return `task_in_progress`, stranding the draft. `queueIfBusy` is safe on both sides of that boundary: it starts immediately when idle or queues behind the last part of the old run.

## Validation

- `pnpm -r build`
- `pnpm typecheck`
- `pnpm test` (all workspace unit suites green)
- `pnpm format:check`
- `playwright e2e/reloaded-followup.spec.mjs` (passed with a real server and mock LLM)

Closes #89
