### PR TITLE
fix(core,cli): strip ANSI from command output

### DIFF
--- a/changelog/unreleased/2026-08-03-clean-command-output.md
+++ b/changelog/unreleased/2026-08-03-clean-command-output.md
@@ -1,0 +1,9 @@
+# Clean command output in non-interactive sessions
+
+Command output no longer carries terminal color/control sequences into tool results, Traces, or model context.
+
+## Details
+
+- Command sessions remove inherited `FORCE_COLOR` settings and enforce the existing non-interactive color policy.
+- A streaming VT parser strips control sequences even when an escape is split across `exec_command` and `input_command` output chunks.
+- The CLI emits presentation colors only for a terminal and honors `NO_COLOR` and `TERM=dumb` when its output is redirected.

--- a/changelog/unreleased/README.md
+++ b/changelog/unreleased/README.md
@@ -2,6 +2,8 @@
 
 Changes since v0.1.5. The version number is assigned at release, when this folder is renamed.
 
+- [2026-08-03] Core/CLI: command sessions strip terminal controls before they reach tool results, and redirected CLI output no longer emits presentation colors. ([details](2026-08-03-clean-command-output.md))
+
 - [2026-07-31] Evaluation Center: Case details separate Target Agent task materials from project-member-visible scoring rubrics, Score charts use a padded dynamic axis without discarding stored values, and the benchmark Skills write YAML-safe Scoreboard summaries. ([details](2026-07-31-evaluation-center-case-details.md))
 
 - [2026-07-30] Web App: the main conversation's file summary moves to the completed Task boundary — one card per Task scanning all of its assistant text, nested agent conversations keep their per-message summaries, and file-existence caching stops retaining negative results so a later Task can surface a newly created path. ([details](2026-07-30-file-summary-task-boundary.md))

--- a/packages/cli/src/render.ts
+++ b/packages/cli/src/render.ts
@@ -71,8 +71,22 @@ const CYAN = "\x1b[36m";
 const MAGENTA = "\x1b[35m";
 const RESET = "\x1b[0m";
 
-export function dim(text: string): string {
-  return `${DIM}${text}${RESET}`;
+/** Terminal color policy: explicit NO_COLOR/TERM=dumb wins; otherwise only a TTY is colored. */
+export function colorsEnabled(
+  out: NodeJS.WritableStream = process.stdout,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (env.NO_COLOR !== undefined || env.TERM === "dumb") return false;
+  if (env.FORCE_COLOR !== undefined) return env.FORCE_COLOR !== "0";
+  return (out as NodeJS.WritableStream & { isTTY?: boolean }).isTTY === true;
+}
+
+function paint(code: string, text: string, out: NodeJS.WritableStream): string {
+  return colorsEnabled(out) ? `${code}${text}${RESET}` : text;
+}
+
+export function dim(text: string, out: NodeJS.WritableStream = process.stdout): string {
+  return paint(DIM, text, out);
 }
 
 /** The two file tools whose outputs carry git-style diffs; their `+`/`-`/`@@` lines get colored. */
@@ -87,8 +101,8 @@ function diffLineColor(firstChar: string | undefined): string | null {
 }
 
 /** Colors a tool call line cyan, distinguishing it from body text/thinking (review comment #5). */
-function cyan(text: string): string {
-  return `${CYAN}${text}${RESET}`;
+function cyan(text: string, out: NodeJS.WritableStream): string {
+  return paint(CYAN, text, out);
 }
 
 /** Takes the last 3 characters of an id as the on-screen pairing number. */
@@ -140,8 +154,12 @@ function humanizeDuration(ms: number): string {
   return `${Math.floor(whole / 60)}m${whole % 60}s`;
 }
 
-export function formatAbort(p: AbortPayload, t: Messages): string {
-  return dim(t.abortLabel(p.reason ?? undefined));
+export function formatAbort(
+  p: AbortPayload,
+  t: Messages,
+  out: NodeJS.WritableStream = process.stdout,
+): string {
+  return dim(t.abortLabel(p.reason ?? undefined), out);
 }
 
 /**
@@ -172,7 +190,7 @@ export function renderHistory(
   for (const msg of messages) {
     if (isEventMessage(msg)) {
       const p = msg.payload as { type?: string } & AbortPayload;
-      if (p.type === "abort") out.write(`${formatAbort(p, t)}\n`);
+      if (p.type === "abort") out.write(`${formatAbort(p, t, out)}\n`);
       continue;
     }
     if (!isModelMessage(msg)) continue;
@@ -188,7 +206,8 @@ export function renderHistory(
       tool_call_id?: string;
       stop_reason?: string;
     };
-    const marker = p.stop_reason && p.stop_reason !== "completed" ? dim(` [${p.stop_reason}]`) : "";
+    const marker =
+      p.stop_reason && p.stop_reason !== "completed" ? dim(` [${p.stop_reason}]`, out) : "";
     switch (p.type) {
       case "text":
         if (p.role === "user") {
@@ -205,17 +224,17 @@ export function renderHistory(
         }
         break;
       case "image_url":
-        out.write(`\n> ${dim("[image]")}\n`);
+        out.write(`\n> ${dim("[image]", out)}\n`);
         break;
       case "thinking":
-        out.write(`${dim(p.thinking ?? "")}${marker}\n`);
+        out.write(`${dim(p.thinking ?? "", out)}${marker}\n`);
         break;
       case "tool_call": {
         if (p.name) toolNames.set(nameKey(msg, p.tool_call_id ?? ""), p.name);
         const preview =
           renderPartialToolCall(p.name ?? "", p.arguments ?? "", { final: true }) ??
           `${p.name} ${p.arguments}`;
-        out.write(`${cyan(`[${callTag(p.tool_call_id ?? "")}] ${preview}`)}${marker}\n`);
+        out.write(`${cyan(`[${callTag(p.tool_call_id ?? "")}] ${preview}`, out)}${marker}\n`);
         break;
       }
       case "tool_call_output": {
@@ -227,15 +246,12 @@ export function renderHistory(
         const colorDiff = name !== undefined && DIFF_OUTPUT_TOOLS.has(name);
         for (const line of (p.output ?? "").split("\n")) {
           const color = colorDiff ? diffLineColor(line[0]) : null;
-          out.write(
-            color
-              ? `${DIM}${label} -> ${RESET}${color}${line}${RESET}\n`
-              : `${DIM}${label} -> ${RESET}${line}\n`,
-          );
+          const prefix = dim(`${label} -> `, out);
+          out.write(`${prefix}${color ? paint(color, line, out) : line}\n`);
         }
         // Attached images aren't rendered by the terminal; print one placeholder line per image.
         for (const _ of p.images ?? []) {
-          out.write(`${DIM}${label} -> [image]${RESET}\n`);
+          out.write(`${dim(`${label} -> [image]`, out)}\n`);
         }
         break;
       }
@@ -248,7 +264,7 @@ export function renderHistory(
 /** Writes a steering message's lines with the colored user prefix (shared by history rendering and the streaming renderer). */
 function writeSteeringLines(out: NodeJS.WritableStream, text: string, t: Messages): void {
   for (const line of text.split("\n")) {
-    out.write(`${MAGENTA}${t.steerLinePrefix()}${line}${RESET}\n`);
+    out.write(`${paint(MAGENTA, `${t.steerLinePrefix()}${line}`, out)}\n`);
   }
 }
 
@@ -260,6 +276,7 @@ function writeSteeringLines(out: NodeJS.WritableStream, text: string, t: Message
 export class StreamRenderer {
   private readonly out: NodeJS.WritableStream;
   private readonly t: Messages;
+  private readonly color: boolean;
 
   /** Pending render queue: while the screen is held (a streaming segment is in progress / awaiting user input), messages queue up here. */
   private pending: OmniMessage[] = [];
@@ -383,9 +400,26 @@ export class StreamRenderer {
   /** Number of retries already initiated (increments on consecutive failures, reset once a request completes normally). */
   private reconnectRun = 0;
 
-  constructor(out: NodeJS.WritableStream = process.stdout, t: Messages = defaultMessages()) {
+  constructor(
+    out: NodeJS.WritableStream = process.stdout,
+    t: Messages = defaultMessages(),
+    color: boolean = colorsEnabled(out),
+  ) {
     this.out = out;
     this.t = t;
+    this.color = color;
+  }
+
+  private paint(code: string, text: string): string {
+    return this.color ? `${code}${text}${RESET}` : text;
+  }
+
+  private dim(text: string): string {
+    return this.paint(DIM, text);
+  }
+
+  private cyan(text: string): string {
+    return this.paint(CYAN, text);
   }
 
   handle(msg: OmniMessage): void {
@@ -414,7 +448,7 @@ export class StreamRenderer {
         toolCall.payload.arguments,
       );
       if (payload !== null) {
-        for (const line of payload.split("\n")) this.out.write(`${dim(line)}\n`);
+        for (const line of payload.split("\n")) this.out.write(`${this.dim(line)}\n`);
         // lastLineKey stays on the call's key: the payload lines belong to this call, so
         // the later noteApprovalDecision must not re-render the call line as "not adjacent".
       }
@@ -449,7 +483,7 @@ export class StreamRenderer {
     this.renderedDecisions.add(key);
     this.ensureAdjacentCallLine(toolCall);
     this.finishLine();
-    this.out.write(`${dim(this.t.approvalDecision(decision))}\n`);
+    this.out.write(`${this.dim(this.t.approvalDecision(decision))}\n`);
     this.lastLineKey = null;
   }
 
@@ -491,7 +525,7 @@ export class StreamRenderer {
     const preview =
       renderPartialToolCall(p.name, p.arguments, { final: true }) ?? `${p.name} ${p.arguments}`;
     this.finishLine();
-    this.out.write(`${cyan(`[${callTag(p.tool_call_id, origin)}] ${preview}`)}\n`);
+    this.out.write(`${this.cyan(`[${callTag(p.tool_call_id, origin)}] ${preview}`)}\n`);
     this.lastLineKey = key;
   }
 
@@ -683,14 +717,16 @@ export class StreamRenderer {
         const p = payload as ApprovalDecisionPayload;
         if (this.renderedDecisions.delete(this.callLineKey(p.tool_call_id))) return;
         this.finishLine();
-        this.out.write(`${dim(this.t.approvalDecision(p.decision))}\n`);
+        this.out.write(`${this.dim(this.t.approvalDecision(p.decision))}\n`);
         this.lastLineKey = null;
       } else if (payload.type === "abort") {
         // Run ended (user interrupt / retries exhausted): clear any pending retry state so the next run doesn't mistakenly print a retry line.
         this.pendingRetry = null;
         this.reconnectRun = 0;
         this.finishLine();
-        this.out.write(`${formatAbort(payload as AbortPayload, this.t)}\n`);
+        this.out.write(
+          `${this.dim(this.t.abortLabel((payload as AbortPayload).reason ?? undefined))}\n`,
+        );
         this.lastLineKey = null;
       } else if (payload.type === "request_begin") {
         // The previous request ended in a retryable status -> this request is a retry
@@ -700,7 +736,9 @@ export class StreamRenderer {
         if (this.pendingRetry) {
           this.reconnectRun += 1;
           this.finishLine();
-          this.out.write(`${dim(this.t.reconnectLabel(this.pendingRetry, this.reconnectRun))}\n`);
+          this.out.write(
+            `${this.dim(this.t.reconnectLabel(this.pendingRetry, this.reconnectRun))}\n`,
+          );
           this.lastLineKey = null;
           this.pendingRetry = null;
         }
@@ -735,7 +773,7 @@ export class StreamRenderer {
         this.finishLine();
         this.compactionActive = true;
         this.compactionTokens = 0;
-        this.out.write(`${dim(this.t.compactionStart(p.mode, p.reason))}\n`);
+        this.out.write(`${this.dim(this.t.compactionStart(p.mode, p.reason))}\n`);
         this.lastLineKey = null;
       } else if (payload.type === "compaction_end") {
         // end signals the result and shows the tokens consumed by the compaction request (if any).
@@ -751,7 +789,7 @@ export class StreamRenderer {
               }
             : undefined;
         this.compactionTokens = 0;
-        this.out.write(`${dim(this.t.compactionStop(p.mode, p.status, tokens))}\n`);
+        this.out.write(`${this.dim(this.t.compactionStop(p.mode, p.status, tokens))}\n`);
         this.lastLineKey = null;
       }
       return;
@@ -807,7 +845,7 @@ export class StreamRenderer {
           return;
         }
         this.finishLine();
-        this.out.write(`${dim(this.t.approvalDecision(p.decision))}\n`);
+        this.out.write(`${this.dim(this.t.approvalDecision(p.decision))}\n`);
         this.lastLineKey = null;
       } else if (msg.payload.type === "token_usage") {
         // Child-session usage counts toward this task's Token delta and the Session total (parent and child use the same accounting); context still follows parent-session accounting.
@@ -839,7 +877,7 @@ export class StreamRenderer {
       return;
     }
     if (!this.inDim) {
-      this.out.write(DIM);
+      if (this.color) this.out.write(DIM);
       this.inDim = true;
     }
     if (p.thinking) {
@@ -864,7 +902,7 @@ export class StreamRenderer {
     const preview = renderPartialToolCall(partial.name, partial.arguments, { final: true });
     if (preview === null) return;
     this.finishLine();
-    this.out.write(`${cyan(`[${callTag(toolCallId)}] ${preview}`)}\n`);
+    this.out.write(`${this.cyan(`[${callTag(toolCallId)}] ${preview}`)}\n`);
     this.lastLineKey = key;
   }
 
@@ -909,14 +947,14 @@ export class StreamRenderer {
     if (this.partialToolCallLineId !== p.tool_call_id) {
       this.finishLine();
       this.partialToolCallLineId = p.tool_call_id;
-      this.out.write(cyan(`[${callTag(p.tool_call_id)}] ${preview}`));
+      this.out.write(this.cyan(`[${callTag(p.tool_call_id)}] ${preview}`));
     } else if (preview.startsWith(partial.lastPreview)) {
-      this.out.write(cyan(preview.slice(partial.lastPreview.length)));
+      this.out.write(this.cyan(preview.slice(partial.lastPreview.length)));
     } else {
       // The preview usually grows monotonically with the arguments; if escaping/folding makes it non-appendable, start a new line with the current readable state.
       this.finishLine();
       this.partialToolCallLineId = p.tool_call_id;
-      this.out.write(cyan(`[${callTag(p.tool_call_id)}] ${preview}`));
+      this.out.write(this.cyan(`[${callTag(p.tool_call_id)}] ${preview}`));
     }
     partial.lastPreview = preview;
     this.inLine = true;
@@ -939,7 +977,7 @@ export class StreamRenderer {
     if (p.images && p.images.length > 0) {
       this.finishLine();
       for (const _ of p.images) {
-        this.out.write(`${DIM}${label} -> [image]${RESET}\n`);
+        this.out.write(`${this.dim(`${label} -> [image]`)}\n`);
       }
       this.lastLineKey = null;
     }
@@ -964,7 +1002,7 @@ export class StreamRenderer {
     while (i < chunk.length) {
       let lineColor: string | null = null;
       if (this.toolOutLineStart) {
-        this.out.write(`${DIM}${label} -> ${RESET}`);
+        this.out.write(this.dim(`${label} -> `));
         this.toolOutLineStart = false;
         this.inLine = true;
         // Diff coloring keys off the line's first character. File-tool outputs arrive as
@@ -976,7 +1014,7 @@ export class StreamRenderer {
       const end = nl === -1 ? chunk.length : nl;
       const segment = chunk.slice(i, end);
       if (segment) {
-        this.out.write(lineColor ? `${lineColor}${segment}${RESET}` : segment);
+        this.out.write(lineColor ? this.paint(lineColor, segment) : segment);
       }
       if (nl === -1) {
         i = chunk.length;
@@ -1023,7 +1061,7 @@ export class StreamRenderer {
     if (this.hasUsage) {
       const contextDelta = this.contextNow - this.contextAtTaskStart;
       this.out.write(
-        `${dim(
+        `${this.dim(
           this.t.taskStats({
             context: humanizeTokens(this.contextNow),
             contextDelta: signedDelta(humanizeTokens(contextDelta)),
@@ -1075,7 +1113,7 @@ export class StreamRenderer {
 
   private closeDim(): void {
     if (this.inDim) {
-      this.out.write(RESET);
+      if (this.color) this.out.write(RESET);
       this.inDim = false;
     }
   }

--- a/packages/cli/test/render.test.ts
+++ b/packages/cli/test/render.test.ts
@@ -21,12 +21,18 @@ import {
   withOrigin,
 } from "@prismshadow/penguin-core";
 import type { MessageOrigin } from "@prismshadow/penguin-core";
-import { StreamRenderer, formatAbort, humanizeTokens, renderHistory } from "../src/render.js";
+import {
+  StreamRenderer,
+  colorsEnabled,
+  formatAbort,
+  humanizeTokens,
+  renderHistory,
+} from "../src/render.js";
 import { getMessages } from "../src/i18n.js";
 
 const t = getMessages("en");
 
-function collector(): { stream: Writable; text: () => string } {
+function collector(isTTY = false): { stream: Writable; text: () => string } {
   let buf = "";
   const stream = new Writable({
     write(chunk, _enc, cb) {
@@ -34,6 +40,7 @@ function collector(): { stream: Writable; text: () => string } {
       cb();
     },
   });
+  (stream as Writable & { isTTY?: boolean }).isTTY = isTTY;
   return { stream, text: () => buf };
 }
 
@@ -67,6 +74,16 @@ describe("humanizeTokens", () => {
 });
 
 describe("pure formatters", () => {
+  it("enables colors only for terminals, with NO_COLOR taking precedence", () => {
+    const tty = collector(true).stream;
+    const pipe = collector(false).stream;
+    expect(colorsEnabled(tty, { TERM: "xterm-256color" })).toBe(true);
+    expect(colorsEnabled(pipe, { TERM: "xterm-256color" })).toBe(false);
+    expect(colorsEnabled(pipe, { FORCE_COLOR: "1" })).toBe(true);
+    expect(colorsEnabled(tty, { FORCE_COLOR: "1", NO_COLOR: "1" })).toBe(false);
+    expect(colorsEnabled(tty, { TERM: "dumb" })).toBe(false);
+  });
+
   it("formatAbort includes the reason", () => {
     expect(stripAnsi(formatAbort({ type: "abort", reason: "ctrl-c" }, t))).toContain("ctrl-c");
   });
@@ -226,8 +243,8 @@ describe("StreamRenderer", () => {
   });
 
   it("colors edit_file diff output lines green/red and dims hunk headers", () => {
-    const { stream, text } = collector();
-    const r = new StreamRenderer(stream, t);
+    const { stream, text } = collector(true);
+    const r = new StreamRenderer(stream, t, true);
     r.handle(partialToolCall({ eventType: "start", name: "edit_file", toolCallId: "d1" }));
     r.handle(
       partialToolCall({

--- a/packages/core/src/environment/tools/command/ansi.ts
+++ b/packages/core/src/environment/tools/command/ansi.ts
@@ -1,0 +1,72 @@
+/**
+ * Incremental ANSI/VT control-sequence stripper for piped command output.
+ *
+ * A command session publishes stdout/stderr as soon as each pipe chunk arrives, so a normal
+ * one-shot regular expression is insufficient: an escape can be split between `exec_command`
+ * and a later `input_command` poll. This small state machine keeps only parser state (never
+ * command text) between chunks and removes CSI color/control sequences plus the OSC/DCS-style
+ * string controls used for terminal titles, hyperlinks, and similar metadata.
+ */
+export class AnsiStripper {
+  private state: "text" | "escape" | "escape-intermediate" | "csi" | "string" | "string-escape" =
+    "text";
+
+  strip(chunk: string): string {
+    let out = "";
+    for (const ch of chunk) {
+      const code = ch.codePointAt(0)!;
+      switch (this.state) {
+        case "text":
+          if (ch === "\u001b") {
+            this.state = "escape";
+          } else if (code === 0x9b) {
+            this.state = "csi";
+          } else if (
+            code === 0x90 ||
+            code === 0x98 ||
+            code === 0x9d ||
+            code === 0x9e ||
+            code === 0x9f
+          ) {
+            this.state = "string";
+          } else if (code < 0x80 || code > 0x9f) {
+            out += ch;
+          }
+          break;
+        case "escape":
+          if (ch === "[") {
+            this.state = "csi";
+          } else if (ch === "]" || ch === "P" || ch === "X" || ch === "^" || ch === "_") {
+            this.state = "string";
+          } else if (code >= 0x20 && code <= 0x2f) {
+            this.state = "escape-intermediate";
+          } else {
+            // A two-byte escape ends here. Invalid/incomplete terminal metadata is discarded
+            // as well: leaking its tail would recreate the visible `[36m` corruption.
+            this.state = "text";
+          }
+          break;
+        case "escape-intermediate":
+          if (code >= 0x30 && code <= 0x7e) this.state = "text";
+          else if (code < 0x20 || code > 0x2f) this.state = "text";
+          break;
+        case "csi":
+          // ECMA-48 CSI final byte. Parameters/intermediates before it stay suppressed even
+          // when every byte arrived in a different stream chunk.
+          if (code >= 0x40 && code <= 0x7e) this.state = "text";
+          break;
+        case "string":
+          if (ch === "\u0007" || code === 0x9c)
+            this.state = "text"; // BEL / 8-bit ST
+          else if (ch === "\u001b") this.state = "string-escape";
+          break;
+        case "string-escape":
+          if (ch === "\\")
+            this.state = "text"; // 7-bit ST (ESC \\)
+          else if (ch !== "\u001b") this.state = "string";
+          break;
+      }
+    }
+    return out;
+  }
+}

--- a/packages/core/src/environment/tools/command/session-manager.ts
+++ b/packages/core/src/environment/tools/command/session-manager.ts
@@ -61,7 +61,16 @@ const HARDENED_ENV: NodeJS.ProcessEnv = {
  * self-development case may legitimately want the same data root — sharing state is a config
  * decision, whereas serving a deployment's code from a workspace checkout never is.
  */
-const STRIPPED_ENV_KEYS = new Set(["PORT", "HOST", "PENGUIN_CLI_ENTRY", "PENGUIN_WEB_DIST"]);
+const STRIPPED_ENV_KEYS = new Set([
+  "PORT",
+  "HOST",
+  "PENGUIN_CLI_ENTRY",
+  "PENGUIN_WEB_DIST",
+  // `FORCE_COLOR` wins over NO_COLOR in Node and several popular color libraries. A host or
+  // vault value must not force terminal escapes into these deliberately piped sessions.
+  "FORCE_COLOR",
+  "FORCE_COLORS",
+]);
 
 /** The host environment minus {@link STRIPPED_ENV_KEYS}. */
 function hostEnvForChild(): NodeJS.ProcessEnv {
@@ -94,6 +103,13 @@ export class CommandSessionManager {
     if (this.registry.isDisposed) {
       throw new Error("command session manager disposed");
     }
+    const env = { ...hostEnvForChild(), ...this.vault, ...HARDENED_ENV };
+    // Vault entries normally override the host, but terminal hardening is non-overridable.
+    // Delete case-insensitively for Windows, where environment names are case-insensitive.
+    for (const key of Object.keys(env)) {
+      const normalized = key.toUpperCase();
+      if (normalized === "FORCE_COLOR" || normalized === "FORCE_COLORS") delete env[key];
+    }
     return new ManagedSession({
       cmd: opts.cmd,
       cwd: opts.cwd,
@@ -102,7 +118,7 @@ export class CommandSessionManager {
       // interactive hangs) must never be overridable by vault. The host side is stripped of
       // the harness's own variables first (see STRIPPED_ENV_KEYS); the vault still wins, so a
       // user who genuinely wants PORT in commands can set it there.
-      env: { ...hostEnvForChild(), ...this.vault, ...HARDENED_ENV },
+      env,
     });
   }
 

--- a/packages/core/src/environment/tools/command/session.ts
+++ b/packages/core/src/environment/tools/command/session.ts
@@ -28,6 +28,7 @@
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import type { ToolResult } from "../types.js";
 import { CappedTextBuffer, WakeSignal } from "../background/index.js";
+import { AnsiStripper } from "./ansi.js";
 import { sessionShell } from "./shell.js";
 
 /** Process-group semantics are available on POSIX; Windows falls back to signaling the child process directly. */
@@ -77,6 +78,8 @@ export class ManagedSession {
 
   private readonly child: ChildProcess;
   private readonly buffer = new CappedTextBuffer(OUTPUT_BUFFER_CAP, "earlier output");
+  /** Stateful because an escape sequence may be split across stdout/stderr pipe chunks or polls. */
+  private readonly ansi = new AnsiStripper();
   private exited = false;
   private exitInfo: ProcessExit | null = null;
   private spawnError: Error | null = null;
@@ -158,8 +161,11 @@ export class ManagedSession {
   }
 
   private handleData(chunk: string): void {
-    this.buffer.append(chunk);
-    this.wakeSignal.notify();
+    const text = this.ansi.strip(chunk);
+    if (text) {
+      this.buffer.append(text);
+      this.wakeSignal.notify();
+    }
   }
   private handleExit(exit: ProcessExit): void {
     if (this.exited) return;

--- a/packages/core/test/ansi.test.ts
+++ b/packages/core/test/ansi.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { AnsiStripper } from "../src/environment/tools/command/ansi.js";
+
+describe("AnsiStripper", () => {
+  it("removes CSI colors even when every fragment arrives in a separate chunk", () => {
+    const s = new AnsiStripper();
+    expect(s.strip("before\u001b[")).toBe("before");
+    expect(s.strip("36")).toBe("");
+    expect(s.strip("mcyan\u001b")).toBe("cyan");
+    expect(s.strip("[0m after")).toBe(" after");
+  });
+
+  it("removes OSC hyperlinks and titles terminated by BEL or ST", () => {
+    const s = new AnsiStripper();
+    expect(s.strip("a\u001b]8;;https://example.com\u001b\\link\u001b]8;;\u0007b")).toBe("alinkb");
+  });
+
+  it("preserves ordinary Unicode, newlines, tabs, and carriage-return progress output", () => {
+    const s = new AnsiStripper();
+    expect(s.strip("企鹅\t10%\r20%\n")).toBe("企鹅\t10%\r20%\n");
+  });
+});

--- a/packages/core/test/exec-session.test.ts
+++ b/packages/core/test/exec-session.test.ts
@@ -247,6 +247,16 @@ describe("exec_command — long-running command sessions", () => {
     expect(res.stopReason).toBe("completed");
   });
 
+  it("removes terminal control sequences before they reach tool output", async () => {
+    const res = await runTool(env, "exec_command", {
+      cmd: `node -e "process.stdout.write('plain\\x1b[36mcyan\\x1b[0m\\x1b]0;title\\x07 end')"`,
+      yield_time_ms: 3000,
+    });
+    expect(res.output).toContain("plaincyan end");
+    expect(res.output).not.toContain("\u001b");
+    expect(res.output).not.toContain("[36m");
+  });
+
   it("hardens the child env against interactive hangs (editor/credentials/pager)", async () => {
     const res = await runTool(env, "exec_command", {
       cmd: 'echo "$GIT_EDITOR|$GIT_TERMINAL_PROMPT|$PAGER|$TERM"',
@@ -367,6 +377,26 @@ describe("harness environment variables never reach a spawned command", () => {
       expect(res.output).toContain("PORT=[3000]");
     } finally {
       vaultEnv.dispose();
+    }
+  });
+
+  it("FORCE_COLOR is removed from both host and vault while NO_COLOR stays enforced", async () => {
+    const previous = process.env.FORCE_COLOR;
+    process.env.FORCE_COLOR = "3";
+    const hardened = new Environment({
+      workspaceDir: tmp,
+      toolConfig: sessionConfig(),
+      vault: { FORCE_COLORS: "true" },
+    });
+    try {
+      const res = await runTool(hardened, "exec_command", {
+        cmd: `node -e "console.log(JSON.stringify({ force: process.env.FORCE_COLOR, forces: process.env.FORCE_COLORS, no: process.env.NO_COLOR }))"`,
+      });
+      expect(res.output).toContain('{"no":"1"}');
+    } finally {
+      hardened.dispose();
+      if (previous === undefined) delete process.env.FORCE_COLOR;
+      else process.env.FORCE_COLOR = previous;
     }
   });
 });


### PR DESCRIPTION
## Summary

- strip terminal control sequences at the command-session boundary with a stateful parser, including ANSI sequences split across output chunks
- stop inherited or Vault-provided `FORCE_COLOR` values from reaching child commands while preserving `NO_COLOR=1` and `TERM=dumb`
- make CLI history and streaming colors depend on the actual output TTY, with deterministic coverage for redirected output

## Root cause

Command sessions could inherit forced-color environment variables, and raw PTY/process output was buffered without sanitization. That let ANSI CSI/OSC bytes leak into Web output, CLI output, traces, and model-visible tool results. A chunk-local replacement would still miss escape sequences split by streaming boundaries, so the sanitizer keeps parser state per command session.

## Validation

- `pnpm -r build`
- `pnpm typecheck`
- `pnpm test` (core 603 passed, CLI 207 passed, all workspace unit suites green)
- `pnpm format:check`

Closes #102
