### PR TITLE
docs(changelog): record the #136–#140 fix batch

### DIFF
--- a/changelog/unreleased/2026-08-02-file-tool-missing-path-diagnostics.md
+++ b/changelog/unreleased/2026-08-02-file-tool-missing-path-diagnostics.md
@@ -1,0 +1,9 @@
+# File tools diagnose missing paths instead of implying absolute paths are rejected
+
+`read_file` / `edit_file` accepted absolute paths all along, but their "File not found" message mentioned only workspace-relative resolution — so a genuinely missing file (typically a dropped `agent_state/` segment) read as "absolute paths are unsupported", and the model retried path forms instead of questioning the path (#138).
+
+## Details
+
+- Both tools now state that absolute paths are supported and append a diagnostic: the deepest existing ancestor directory, the first missing segment, and the ancestor's entries ranked by name similarity to the missing one (capped at 8, directories marked with a trailing slash) — for the reported case the hint names `agent_state/` directly.
+- ENOTDIR (a path segment that is a file, not a directory) gets the same diagnosis instead of a raw errno message.
+- The agent-creation Skill now spells out that `AGENTS.md` lives under `agent_state/`, not at the agent directory root — the likely source of the dropped segment (skill version 7).

--- a/changelog/unreleased/2026-08-02-web-app-steering-and-session-list.md
+++ b/changelog/unreleased/2026-08-02-web-app-steering-and-session-list.md
@@ -1,0 +1,21 @@
+# Steering survives reloads and carries files; session list scales
+
+Steering messages no longer vanish on refresh or come back as duplicate-prone drafts, file attachments steer like images do, tool-card subtitles stop jittering while arguments stream, and the sidebar stays fast and scannable with many agents, workspaces, and CLI sessions.
+
+## Steering across reloads, with visible content (#136, #140)
+
+- The server now mirrors each running session's undelivered steering queue (text plus image/file counts) and broadcasts it on every `task_state` event and the SSE subscribe snapshot. The composer's "steering queued" hint shows each queued message's content and survives reloads; entries retire as their `[user_steering]` message reaches the stream, and the mirror drops when the run exits.
+- A successful steer discards the localStorage draft, like a normal send — previously the sent text was resurrected as a draft on reload, and re-sending it duplicated the steering message. Draft discard also clears the text ref so a later skill/chip flush cannot bring already-sent text back.
+- File attachments now ride steering exactly like images: written to the session scratchpad under the task-attachment rules and delivered as `[attached file: <path>]` lines on the steering text. A file-only draft steers instead of silently falling into the follow-up queue with the other channel's hint; a 409 cleans the written files up.
+- New e2e spec: steer during a slow tool run → reload → hint with content, empty composer, exactly-once delivery.
+
+## Tool-card subtitles render once, fully formed (#137)
+
+The collapsed tool row's subtitle (the model-written call description, or the shortened file path) no longer re-renders on every streamed fragment — a growing description re-solved the header's flex line ~8×/s and `shortenPath` on a still-growing path rewrote non-monotonically. A field now renders only once its closing quote has arrived (the gate lifts when argument streaming settles, so aborted calls still show what they have), and a complete description wins over the file path when a user-edited schema enables one on a file tool — the rule the CLI already applied.
+
+## Session list: DB-served by default, CLI sessions opt-in, groups page (#139)
+
+- The sessions index gains DB-only `client` ('web' / 'cli'; NULL = legacy row, treated as web) and `has_trace` columns; existing `web.db` files are upgraded in place by an idempotent ALTER guard on open.
+- The default list serves web sessions straight from the DB (SQL-ordered under a new index) with no Trace-directory scanning in steady state; `cli=1` opts into Trace discovery + adoption, and adopted CLI rows stay excluded from the default list while remaining individually reachable (deep links).
+- New per-user "Show CLI sessions" switch (default off) in the sidebar user menu, persisted in `ui_prefs`; toggling refetches the list under the new filter.
+- Both sidebar grouping modes page the groups themselves: 10 groups initially, "More groups (N)" reveals 10 more — a pure render cap, reset per Project and on a mode switch.

--- a/changelog/unreleased/README.md
+++ b/changelog/unreleased/README.md
@@ -2,6 +2,10 @@
 
 Changes since v0.1.5. The version number is assigned at release, when this folder is renamed.
 
+- [2026-08-02] Web App: steering messages survive reloads with their content visible and can carry file attachments, tool-card subtitles render once fully formed instead of jittering, and the session list is DB-served by default with an opt-in CLI-session toggle and paged sidebar groups. ([details](2026-08-02-web-app-steering-and-session-list.md))
+
+- [2026-08-02] File tools: `read_file` / `edit_file` diagnose a missing path — deepest existing ancestor, first missing segment, nearest-named entries — instead of a bare "File not found" that read as absolute paths being rejected; the agent-creation Skill spells out `agent_state/AGENTS.md`. ([details](2026-08-02-file-tool-missing-path-diagnostics.md))
+
 - [2026-08-02] Web App: the manual "Check for updates" row reports every outcome — busy spinner while checking, success toasts for both up-to-date and update-found (naming the release, with the row itself becoming the update entry), and the existing failure/disabled notices — via a unit-tested outcome classifier. ([details](2026-08-02-update-check-feedback.md))
 
 - [2026-07-31] Tooling: each Release now attaches exactly one artifact per target — a flat installer bundle sealing the native installer, the program payload and its checksum — serving online and offline installation from the same file, with mandatory checksums at both layers, no more raw archives or `*-offline` wrappers, and hermetic installer tests in CI; in-place upgrades survive filesystems that pin in-use directories (the `penguin update` overlayfs `Device or resource busy` failure), the Windows payload drops its policy-blocked `penguin.ps1` launcher, and the installer broadcasts the user-Path change so new terminal windows find `penguin`. ([details](2026-07-31-unified-installer-artifact.md))


### PR DESCRIPTION
Changelog batch PR (kept out of the feature PRs per the working rules), covering:

- #155 (#138 — file-tool missing-path diagnostics, Models/skills surface)
- #156 (#137), #157 (#136 + #140), #158 (#139) — Web App surface

Two `changelog/unreleased/` entries grouped by surface, registered in the folder index newest-first. Best merged after the four feature PRs land; if any of them is dropped or reworked, the corresponding entry lines should be trimmed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018XknBddK9ycnt8A8yJQT48