### PR TITLE
feat(models): add OpenRouter qwen/qwen3.8-max to the preset catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Four Skill groups ship in the box ([docs](https://penguin.ooo/docs/skills)); age
 | Kimi K3          | Moonshot AI, OpenRouter, Qwen Pay-As-You-Go                                      |
 | GLM 5.2          | Z.AI, OpenRouter, Fireworks AI, SiliconFlow, Qwen Token Plan, Qwen Pay-As-You-Go |
 | Hunyuan 3        | OpenRouter                                                                       |
-| Qwen 3.8 Max     | Qwen Token Plan, Qwen Pay-As-You-Go                                              |
+| Qwen 3.8 Max     | Qwen Token Plan, Qwen Pay-As-You-Go, OpenRouter                                  |
 | GPT 5.6          | OpenRouter                                                                       |
 | Gemini 3.6 Flash | Google Gemini, OpenRouter                                                        |
 | Claude 5         | Anthropic, OpenRouter                                                            |

--- a/README.zh.md
+++ b/README.zh.md
@@ -90,7 +90,7 @@ https://github.com/user-attachments/assets/aec49ae9-b743-467b-b247-37bedfeaa36e
 | Kimi K3          | Moonshot AI, OpenRouter, Qwen Pay-As-You-Go                                      |
 | GLM 5.2          | Z.AI, OpenRouter, Fireworks AI, SiliconFlow, Qwen Token Plan, Qwen Pay-As-You-Go |
 | Hunyuan 3        | OpenRouter                                                                       |
-| Qwen 3.8 Max     | Qwen Token Plan, Qwen Pay-As-You-Go                                              |
+| Qwen 3.8 Max     | Qwen Token Plan, Qwen Pay-As-You-Go, OpenRouter                                  |
 | GPT 5.6          | OpenRouter                                                                       |
 | Gemini 3.6 Flash | Google Gemini, OpenRouter                                                        |
 | Claude 5         | Anthropic, OpenRouter                                                            |

--- a/packages/core/src/state/model-catalog.ts
+++ b/packages/core/src/state/model-catalog.ts
@@ -223,7 +223,8 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
   // one pass on 2026-08-03 from the models API (/api/v1/models): cache_read stores the
   // published input_cache_read (falling back to the input price for the few rows without
   // one — qwen3.6-35b-a3b and the :free rows); cache_write stores input_cache_write only
-  // when it is a genuine per-token write premium (the Anthropic and GPT rows, 1.25x input) —
+  // when it is a genuine per-token write premium (the Anthropic, GPT and qwen3.8-max rows,
+  // 1.25x input) —
   // Gemini's field is an hourly cache-STORAGE rate, not a per-token price, so those rows
   // keep the input price — and otherwise also carries the input price. The :free tier and
   // the openrouter/free Free Models Router store a genuine $0 price (not "unknown"), so
@@ -456,6 +457,16 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     contextWindow: 128000,
     pricing: usd(0, 0, 0),
     supportsVision: false,
+    clientType: "openai",
+    baseUrl: OPENROUTER_BASE_URL,
+  },
+  {
+    modelId: "qwen/qwen3.8-max",
+    displayName: "Qwen 3.8 Max",
+    provider: "openrouter",
+    contextWindow: 1000000,
+    pricing: usd(0.25, 2.5, 6),
+    supportsVision: true,
     clientType: "openai",
     baseUrl: OPENROUTER_BASE_URL,
   },

--- a/packages/core/test/model-catalog.test.ts
+++ b/packages/core/test/model-catalog.test.ts
@@ -171,6 +171,7 @@ describe("model-catalog", () => {
       "openai/gpt-5.6-terra",
       "openai/gpt-5.5",
       "openrouter/free",
+      "qwen/qwen3.8-max",
       "qwen/qwen3.6-35b-a3b",
       "stepfun/step-3.7-flash",
       "tencent/hy3",

--- a/packages/skills/skills/agenthub-models/SKILL.md
+++ b/packages/skills/skills/agenthub-models/SKILL.md
@@ -3,8 +3,8 @@ name: agenthub-models
 description: Call model APIs through @prismshadow/agenthub — streaming text generation, image generation, speech synthesis, embeddings and the supported-model registry with one client.
 short_description: Call model APIs with one AgentHub client.
 short_description_zh: 用一个 AgentHub 客户端调用模型 API。
-version: 9
-updated: 2026-07-22T00:00:00Z
+version: 10
+updated: 2026-08-04T09:33:09Z
 ---
 
 # AgentHub Model APIs
@@ -63,6 +63,7 @@ Use exact model ids. If an id is not in the table below and the user has not giv
 | DeepSeek V4      | `deepseek-v4-pro`, `deepseek-v4-flash`                                | OpenRouter `deepseek/deepseek-v4-pro`, `deepseek/deepseek-v4-flash`, `deepseek/deepseek-v4-flash-0731`; SiliconFlow `deepseek-ai/DeepSeek-V4-Pro`, `deepseek-ai/DeepSeek-V4-Flash` |
 | GLM 5.2          | `glm-5.2`                                                             | OpenRouter `z-ai/glm-5.2`; SiliconFlow `zai-org/GLM-5.2`                                                                                        |
 | GLM 5.1          | `glm-5.1`                                                             | OpenRouter `z-ai/glm-5.1`; SiliconFlow `Pro/zai-org/GLM-5.1`                                                                                    |
+| Qwen 3.8 Max     | —                                                                     | OpenRouter `qwen/qwen3.8-max`                                                                                                                   |
 | Qwen 3.6         | —                                                                     | OpenRouter `qwen/qwen3.6-35b-a3b`; SiliconFlow `Qwen/Qwen3.6-35B-A3B`                                                                           |
 
 The image endpoint dropped its preview suffix: `gemini-3.1-flash-image-preview` is deprecated, use `gemini-3.1-flash-image`.


### PR DESCRIPTION
## Summary

Adds the OpenRouter model `qwen/qwen3.8-max` (Qwen 3.8 Max) to the preset model catalog, sourced from OpenRouter's models API (`/api/v1/models`, read 2026-08-04):

- `contextWindow: 1000000` (`context_length: 1000000`)
- `pricing: usd(0.25, 2.5, 6)` — published `input_cache_read` $0.25/Mtok, published `input_cache_write` $2.50/Mtok (a genuine 1.25x-input per-token write premium; prompt is $2/Mtok), `completion` $6/Mtok
- `supportsVision: true` (`input_modalities` include `image`)
- Placed immediately before `qwen/qwen3.6-35b-a3b` per the newer-series-first ordering rule; the OpenRouter block's provenance comment now names the qwen3.8-max row among those storing a genuine cache-write premium
- Display name "Qwen 3.8 Max" matches the existing Qwen Token Plan / Qwen Pay-As-You-Go rows for the same model

Also:

- `packages/core/test/model-catalog.test.ts`: added the id to the pinned OpenRouter ordering fixture
- `packages/skills/skills/agenthub-models/SKILL.md`: new "Qwen 3.8 Max" row in the model id table (OpenRouter spelling), frontmatter bumped to version 10 / updated 2026-08-04T09:33:09Z
- `README.md` / `README.zh.md`: the Supported Models table's "Qwen 3.8 Max" row now lists OpenRouter alongside the Qwen plans

Note: existing projects don't auto-migrate — the model appears for new projects, and existing ones pick it up via the models page "sync presets" action (established behavior for catalog additions). Changelog/docs are handled in the separate consolidated PR.

## Verification

- `pnpm -r build` — pass
- `pnpm typecheck` — pass
- `pnpm test` — pass (core 624, server 470, web 533, skills 18, cli 216, desktop 5, docs 32, landing 39)
- `pnpm format` + `pnpm format:check` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
