### PR TITLE
fix(core): strip desktop-mode credentials from Agent command environments

### DIFF
--- a/packages/core/src/environment/tools/command/session-manager.ts
+++ b/packages/core/src/environment/tools/command/session-manager.ts
@@ -61,7 +61,20 @@ const HARDENED_ENV: NodeJS.ProcessEnv = {
  * self-development case may legitimately want the same data root — sharing state is a config
  * decision, whereas serving a deployment's code from a workspace checkout never is.
  */
-const STRIPPED_ENV_KEYS = new Set(["PORT", "HOST", "PENGUIN_CLI_ENTRY", "PENGUIN_WEB_DIST"]);
+const STRIPPED_ENV_KEYS = new Set([
+  "PORT",
+  "HOST",
+  "PENGUIN_CLI_ENTRY",
+  "PENGUIN_WEB_DIST",
+  // Desktop-mode process credentials and wiring: the shell's token authorizes the
+  // server shutdown endpoint (and desktop-login until redeemed), and the port file is
+  // the shell's private channel — neither is a user-facing setting, and leaking them
+  // into Agent-run commands would let a prompt-injected command stop the server.
+  "PENGUIN_DESKTOP_TOKEN",
+  "PENGUIN_PORT_FILE",
+  // Pinned seed password (tests/e2e): a credential, not a data-selection setting.
+  "PENGUIN_SEED_ADMIN_PASSWORD",
+]);
 
 /** The host environment minus {@link STRIPPED_ENV_KEYS}. */
 function hostEnvForChild(): NodeJS.ProcessEnv {

--- a/packages/core/test/exec-session.test.ts
+++ b/packages/core/test/exec-session.test.ts
@@ -294,7 +294,15 @@ describe("exec_command — long-running command sessions", () => {
 });
 
 describe("harness environment variables never reach a spawned command", () => {
-  const KEYS = ["PORT", "HOST", "PENGUIN_CLI_ENTRY", "PENGUIN_WEB_DIST"] as const;
+  const KEYS = [
+    "PORT",
+    "HOST",
+    "PENGUIN_CLI_ENTRY",
+    "PENGUIN_WEB_DIST",
+    "PENGUIN_DESKTOP_TOKEN",
+    "PENGUIN_PORT_FILE",
+    "PENGUIN_SEED_ADMIN_PASSWORD",
+  ] as const;
   const saved: Partial<Record<(typeof KEYS)[number], string | undefined>> = {};
 
   beforeEach(() => {
@@ -305,6 +313,11 @@ describe("harness environment variables never reach a spawned command", () => {
     process.env.HOST = "127.0.0.1";
     process.env.PENGUIN_CLI_ENTRY = "/opt/penguin/lib/dist/index.js";
     process.env.PENGUIN_WEB_DIST = "/opt/penguin/web";
+    // The desktop shell's process credentials (see design § "桌面端原型"): a leaked token
+    // would let an Agent-run command call the server's shutdown endpoint.
+    process.env.PENGUIN_DESKTOP_TOKEN = "secret-desktop-token";
+    process.env.PENGUIN_PORT_FILE = "/tmp/port-file";
+    process.env.PENGUIN_SEED_ADMIN_PASSWORD = "penguin-0000";
   });
   afterEach(() => {
     for (const k of KEYS) {


### PR DESCRIPTION
## Summary

Found while surveying network touchpoints for the proxy-toggle design: the desktop shell passes `PENGUIN_DESKTOP_TOKEN` (authorizes `POST /api/desktop/shutdown`, and `desktop-login` until redeemed) and `PENGUIN_PORT_FILE` to the server it spawns — and the server passes its whole environment on to Agent `exec_command` children, which only strip PORT/HOST/PENGUIN_CLI_ENTRY/PENGUIN_WEB_DIST. A prompt-injected command could read the token and gracefully stop the desktop server. `PENGUIN_SEED_ADMIN_PASSWORD` (pinned seed credential for tests/e2e) rides along for the same reason.

Adds the three keys to core's `STRIPPED_ENV_KEYS` (they are process credentials/wiring, not user-facing data-selection settings, matching the documented stripping rationale) and extends the exec-session test matrix that proves spawned commands never see them.

## Verification

- `pnpm -r build`, core typecheck, `pnpm format:check` — clean.
- `packages/core` exec-session tests pass with the extended 7-key matrix (including the Windows-casing case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JCbi3tjwdnyfSZa3eJKZRx