### PR TITLE
fix(web): restyle the home update hint as plain superscript text

### DIFF
--- a/packages/web/src/features/chat/draft-view.tsx
+++ b/packages/web/src/features/chat/draft-view.tsx
@@ -613,12 +613,15 @@ export function DraftView({
 }
 
 /**
- * Superscript "new version" pill on the version line (accent-colored, raised via
- * align-super). The only remaining copy: the sidebar's version row dropped its badge when
- * the three update rows collapsed into one whose label already names the new version.
+ * Superscript "new version" hint on the version line: plain small text raised via
+ * align-super, in the version line's own muted color and weight. Deliberately not a pill —
+ * user feedback was that the earlier accent-colored pill read as a button; the link case
+ * only adds a hover underline. The only remaining copy: the sidebar's version row dropped
+ * its badge when the three update rows collapsed into one whose label already names the
+ * new version.
  */
 const versionBadgeClass =
-  "ml-1.5 inline-block rounded-full bg-[var(--accent-bg)] px-1.5 align-super text-[10px] font-medium leading-4 text-[var(--accent-fg)] transition-opacity duration-150 hover:opacity-80";
+  "ml-1.5 inline-block align-super text-[10px] leading-4 text-gray-400 dark:text-gray-500";
 
 /**
  * Quiet version line under the brand subtitle: `vX.Y.Z · Last updated Jul 26`
@@ -654,7 +657,7 @@ function VersionLine() {
             rel="noopener noreferrer"
             title={S.update.newVersion(update.latestVersion)}
             aria-label={S.update.newVersion(update.latestVersion)}
-            className={versionBadgeClass}
+            className={`${versionBadgeClass} hover:underline`}
           >
             {S.update.newVersionBadge}
           </a>


### PR DESCRIPTION
## Summary

The quiet version line on the home (new-chat draft) page — `vX.Y.Z · Last updated …` — showed its "new version available" hint as an accent-colored pill (`rounded-full bg-[var(--accent-bg)] px-1.5 … font-medium text-[var(--accent-fg)]`). User feedback: it reads as a button.

This restyles `versionBadgeClass` in `packages/web/src/features/chat/draft-view.tsx` into a plain superscript continuation of the version line:

- Removed: background, rounded pill, horizontal padding, accent color, `font-medium`, opacity hover transition.
- Kept: `ml-1.5`, `align-super`, `text-[10px]`, `leading-4`; now uses the version line's own muted color (`text-gray-400 dark:text-gray-500`) and normal weight.
- The release-link `<a>` case adds only `hover:underline` as a subtle affordance; the `<span>` fallback stays fully inert.
- Structure and behavior untouched: `<a>` (releaseUrl/target/rel/title/aria-label) vs `<span>` fallback, `S.update.newVersionBadge` copy, and mount/fetch logic are all unchanged.
- The `versionBadgeClass` doc comment now records the new intent (plain superscript text, per the pill-reads-as-a-button feedback).

Checked: `versionBadgeClass` has no other usages, the sidebar renders no such badge, and no tests/e2e reference this styling.

## Verification

- `pnpm -r build` — pass
- `pnpm typecheck` — pass
- `pnpm test` — pass (web: 41 files / 533 tests)
- `pnpm format` + `pnpm format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)