### PR TITLE
chore(deps): resolve Dependabot alert #24 (hono ReDoS, GHSA-8j4g-w8fx-2239)

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -41,7 +41,7 @@
     "@prismshadow/penguin-skills": "workspace:*",
     "dotenv": "^17.0.0",
     "fflate": "^0.8.3",
-    "hono": "^4.8.0",
+    "hono": "^4.12.34",
     "smol-toml": "^1.3.0",
     "tar": "^7.5.21",
     "yaml": "^2.5.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,7 +242,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: ^2.0.5
-        version: 2.0.12(hono@4.12.28)
+        version: 2.0.12(hono@4.12.34)
       '@prismshadow/penguin-core':
         specifier: workspace:*
         version: file:packages/core(supports-color@10.2.2)(ws@8.21.0)
@@ -256,8 +256,8 @@ importers:
         specifier: ^0.8.3
         version: 0.8.3
       hono:
-        specifier: ^4.8.0
-        version: 4.12.28
+        specifier: ^4.12.34
+        version: 4.12.34
       smol-toml:
         specifier: ^1.3.0
         version: 1.6.1
@@ -2201,8 +2201,8 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
-  hono@4.12.28:
-    resolution: {integrity: sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA==}
+  hono@4.12.34:
+    resolution: {integrity: sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==}
     engines: {node: '>=16.9.0'}
 
   hosted-git-info@4.1.0:
@@ -4224,9 +4224,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@hono/node-server@2.0.12(hono@4.12.28)':
+  '@hono/node-server@2.0.12(hono@4.12.34)':
     dependencies:
-      hono: 4.12.28
+      hono: 4.12.34
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
@@ -4345,12 +4345,12 @@ snapshots:
 
   '@prismshadow/penguin-server@file:packages/server(supports-color@10.2.2)(ws@8.21.0)':
     dependencies:
-      '@hono/node-server': 2.0.12(hono@4.12.28)
+      '@hono/node-server': 2.0.12(hono@4.12.34)
       '@prismshadow/penguin-core': file:packages/core(supports-color@10.2.2)(ws@8.21.0)
       '@prismshadow/penguin-skills': file:packages/skills
       dotenv: 17.4.2
       fflate: 0.8.3
-      hono: 4.12.28
+      hono: 4.12.34
       smol-toml: 1.6.1
       tar: 7.5.22
       yaml: 2.9.0
@@ -5903,7 +5903,7 @@ snapshots:
       property-information: 7.2.0
       space-separated-tokens: 2.0.2
 
-  hono@4.12.28: {}
+  hono@4.12.34: {}
 
   hosted-git-info@4.1.0:
     dependencies:


### PR DESCRIPTION
## Summary

Resolves [Dependabot alert #24](https://github.com/Prism-Shadow/penguin-harness/security/dependabot/24): **GHSA-8j4g-w8fx-2239 / CVE-2026-69207** — a moderate (CVSS 5.3) ReDoS in Hono's built-in CORS middleware. A CORS preflight request with a long whitespace run in `Access-Control-Request-Headers` triggers quadratic regex backtracking when `allowHeaders` is unconfigured, allowing unauthenticated denial of service. Vulnerable range `< 4.12.34`; first patched version `4.12.34`.

## Dependency chain

`hono` is a **direct dependency** of the workspace package `@prismshadow/penguin-server` (`packages/server`), previously `^4.8.0` resolved to `4.12.28`. The same resolution also satisfies the `hono: ^4` peer dependency of `@hono/node-server@2.0.12`.

## Fix

- Bumped `hono` in `packages/server/package.json` from `^4.8.0` to `^4.12.34`, excluding all vulnerable versions while staying within the existing caret convention (same major, compatible with `@hono/node-server`'s `^4` peer range).
- Regenerated `pnpm-lock.yaml` with `pnpm install`; the lockfile diff touches only the hono chain (`hono@4.12.28 -> 4.12.34` and the `@hono/node-server` snapshot keys referencing it). No `pnpm.overrides` needed.
- `pnpm why -r hono` now shows only `hono@4.12.34`; `pnpm audit --audit-level moderate` reports no known vulnerabilities.

## Verification

- `pnpm -r build` — pass
- `pnpm typecheck` — pass
- `pnpm test` — pass (all workspace suites green)
- `pnpm format` + `pnpm format:check` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)