### PR TITLE
feat(provenance): content-derived Agent fingerprint for scoreboard

### DIFF
--- a/packages/cli/src/commands/provenance.ts
+++ b/packages/cli/src/commands/provenance.ts
@@ -1,0 +1,70 @@
+/**
+ * `penguin provenance` — prints an Agent's content-derived reproducibility fingerprint.
+ *
+ *   penguin provenance [--agent-id <id>] [--project-id <id>] [--root <dir>]
+ *                      [--provider <p> --model-id <m>] [--format yaml|json]
+ *
+ * This is the deterministic capture path the self-evolution skills call: `agent-optimization`
+ * runs it against the Test Agent before writing a scoreboard record, and embeds the returned
+ * block as that evaluation's `provenance:` field. An LLM cannot reliably compute sha256, so the
+ * fingerprint must come from code — hence a CLI command rather than a skill instruction.
+ *
+ * Output goes to stdout only (no logs), so a skill can consume it verbatim; `--format yaml`
+ * (default) drops straight into scoreboard.yaml, `--format json` is available for programmatic use.
+ * Docs: /docs/cli § "penguin provenance".
+ */
+import path from "node:path";
+import type { Command } from "commander";
+import {
+  DEFAULT_AGENT_ID,
+  DEFAULT_PROJECT_ID,
+  buildAgentProvenance,
+  loadOrInitAgentState,
+  resolveRoot,
+  type ProvenanceModelRef,
+} from "@prismshadow/penguin-core";
+import { stringify as stringifyYaml } from "yaml";
+import type { Messages } from "../i18n.js";
+
+function resolveRootOption(root: string | undefined): string {
+  return root !== undefined ? path.resolve(root) : resolveRoot();
+}
+
+export function registerProvenanceCommand(program: Command, t: Messages): void {
+  program
+    .command("provenance")
+    .description(t.provenance.desc)
+    .option("--agent-id <id>", t.common.agentId, DEFAULT_AGENT_ID)
+    .option("--project-id <id>", t.common.projectId, DEFAULT_PROJECT_ID)
+    .option("--provider <group>", t.provenance.provider)
+    .option("--model-id <id>", t.provenance.modelId)
+    .option("--format <fmt>", t.provenance.format, "yaml")
+    .option("--root <dir>", t.common.root)
+    .action(async (opts) => {
+      const root = resolveRootOption(opts.root);
+      // A model reference is always the complete (provider, model_id) pair — reject a lone half.
+      if ((opts.provider === undefined) !== (opts.modelId === undefined)) {
+        throw new Error("--provider and --model-id must be given together (a model is a pair).");
+      }
+      const model: ProvenanceModelRef | undefined =
+        opts.provider !== undefined && opts.modelId !== undefined
+          ? { provider: opts.provider, model_id: opts.modelId }
+          : undefined;
+
+      const state = await loadOrInitAgentState({
+        root,
+        projectId: opts.projectId,
+        agentId: opts.agentId,
+      });
+      const provenance = await buildAgentProvenance(state, model ? { model } : undefined);
+
+      const format = String(opts.format).toLowerCase();
+      if (format === "json") {
+        process.stdout.write(`${JSON.stringify(provenance, null, 2)}\n`);
+      } else if (format === "yaml") {
+        process.stdout.write(stringifyYaml(provenance));
+      } else {
+        throw new Error(`Unknown --format ${JSON.stringify(opts.format)}: expected yaml or json.`);
+      }
+    });
+}

--- a/packages/cli/src/i18n.ts
+++ b/packages/cli/src/i18n.ts
@@ -73,6 +73,12 @@ export interface Messages {
     /** run's --goal: goal mode, with an optional token budget value (`--goal 500k`). */
     goal: string;
   };
+  provenance: {
+    desc: string;
+    format: string;
+    provider: string;
+    modelId: string;
+  };
   chat: { desc: string; resume: string };
   serve: {
     serverDesc: string;
@@ -319,6 +325,12 @@ const en: Messages = {
     message: "Prompt for this Task",
     goal: "Goal mode: loop until the goal completes; optional token budget (e.g. 500k, 2m)",
   },
+  provenance: {
+    desc: "Print the Agent's content-derived reproducibility fingerprint (for scoreboard records)",
+    format: "Output format: yaml (default) or json",
+    provider: "Provider group of the evaluation model (folded into the fingerprint; pairs with --model-id)",
+    modelId: "Upstream model id of the evaluation model (pairs with --provider)",
+  },
   chat: {
     desc: "Open the interactive REPL",
     resume:
@@ -536,6 +548,12 @@ const zh: Messages = {
     desc: "单次运行一个 Task",
     message: "本次 Task 的 Prompt",
     goal: "目标模式：循环运行直至目标完成；可选 token 预算（如 500k、2m）",
+  },
+  provenance: {
+    desc: "打印 Agent 的内容派生可复现指纹（用于 scoreboard 记录）",
+    format: "输出格式：yaml（缺省）或 json",
+    provider: "评测模型的 provider 分组（并入指纹；与 --model-id 配对）",
+    modelId: "评测模型的上游 model id（与 --provider 配对）",
   },
   chat: {
     desc: "打开交互式 REPL",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,6 +17,7 @@ import { Command } from "commander";
 import { VERSION } from "@prismshadow/penguin-core";
 import { registerConfigCommand } from "./commands/config.js";
 import { registerRunCommand } from "./commands/run.js";
+import { registerProvenanceCommand } from "./commands/provenance.js";
 import { registerChatCommand } from "./commands/chat.js";
 import { registerServeCommands } from "./commands/serve.js";
 import { registerUpdateCommand } from "./commands/update.js";
@@ -34,6 +35,7 @@ program
 
 registerConfigCommand(program, t);
 registerRunCommand(program, t);
+registerProvenanceCommand(program, t);
 registerChatCommand(program, t);
 registerServeCommands(program, t);
 registerUpdateCommand(program, t);

--- a/packages/core/src/state/example-benchmark.ts
+++ b/packages/core/src/state/example-benchmark.ts
@@ -80,6 +80,46 @@ interface ExampleRun {
 }
 
 /**
+ * Example provenance fingerprints (illustrative only — not computed from a real Agent). The
+ * three rounds share the same tools/skills hashes (nothing was installed or uninstalled) while
+ * the system prompt hash and the top-level agent hash change each round: this is exactly the
+ * localization story provenance is meant to tell — "the prompt changed, the skills didn't". Real
+ * fingerprints come from `penguin provenance`.
+ */
+const EXAMPLE_TOOLS_SHA = "08910c743d74efbbe547657603461d72c8fea7361e3bbc88e6a9cac896374ef3";
+const EXAMPLE_SKILLS_SHA = "69bf7c0181bb8cc80044504c9681ff87b34b706811f1bb6a5f17eb642ceb497e";
+const EXAMPLE_AGENTS_MD_SHA =
+  "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+/** A shape-valid 64-char hex string seeded by `tag` + `v` (illustrative, not a real digest). */
+function fakeHex(tag: string, v: number): string {
+  const seed = `${tag}${v}`;
+  let hex = "";
+  for (let i = 0; hex.length < 64; i += 1) {
+    hex += (((seed.charCodeAt(i % seed.length) * 7 + i * 31 + v) % 16) & 0xf).toString(16);
+  }
+  return hex.slice(0, 64);
+}
+
+/** Builds an illustrative provenance block for example version `v` (fake but shape-valid hashes). */
+function exampleProvenance(v: number): Record<string, unknown> {
+  return {
+    provenance_version: 1,
+    version: v,
+    // Changes each round (the prompt was edited every version).
+    system_prompt_sha256: fakeHex("sysprompt", v),
+    agents_md_sha256: EXAMPLE_AGENTS_MD_SHA,
+    // Constant across rounds (no tool/skill install or uninstall).
+    tools_sha256: EXAMPLE_TOOLS_SHA,
+    skills_sha256: EXAMPLE_SKILLS_SHA,
+    model: { provider: "deepseek", model_id: "deepseek-v4-pro" },
+    thinking_level: "medium",
+    // Top-level fingerprint changes each round because the prompt hash feeds into it.
+    agent_sha256: fakeHex("agent", v),
+  };
+}
+
+/**
  * Raw runs for the three sample evaluations (case-level and evaluation-level metrics are
  * computed from these, keeping the numbers self-consistent). Each carries the model actually
  * used for that round; the examples all use deepseek-v4-pro at medium thinking.
@@ -279,6 +319,7 @@ export function buildExampleScoreboard(): {
     score: number;
     cost: number | null;
     duration_ms: number;
+    provenance: Record<string, unknown>;
     cases: Array<{
       case: string;
       score: number;
@@ -308,6 +349,7 @@ export function buildExampleScoreboard(): {
         score: averageTwo(cases.map((c) => c.score)),
         cost: averageKnownCost(cases.map((c) => c.cost)),
         duration_ms: averageDuration(cases.map((c) => c.duration_ms)),
+        provenance: exampleProvenance(e.version),
         cases,
       };
     }),

--- a/packages/core/src/state/index.ts
+++ b/packages/core/src/state/index.ts
@@ -11,6 +11,7 @@ export * from "./project-config.js";
 export * from "./agent-state.js";
 export * from "./agent-vault.js";
 export * from "./example-benchmark.js";
+export * from "./provenance.js";
 
 // Skill library types and frontmatter parser (from the skills package; server reuses the same implementation via core).
 export { parseSkillFrontmatter, type SkillMetadata } from "@prismshadow/penguin-skills";

--- a/packages/core/src/state/provenance.ts
+++ b/packages/core/src/state/provenance.ts
@@ -1,0 +1,163 @@
+/**
+ * Agent provenance fingerprint: a content-derived hash of the editable inputs that
+ * determine an Agent's behavior (the system prompt template, AGENTS.md, installed skills,
+ * tool contract, and model parameters).
+ *
+ * Why: the self-evolution loop appends an evaluation to `scoreboard.yaml` each round, but a
+ * record only carries `version` + `provider` + `model_id`. `version` is a human-assigned
+ * monotonic integer, not content-derived — so editing the system prompt / AGENTS.md / a skill
+ * without bumping `version` leaves two evaluations looking identical while testing different
+ * Agents, and score differences become unattributable. `agent_sha256` answers "did the config
+ * change?" in one glance; the per-part sub-hashes answer "what changed?".
+ *
+ * The fingerprint hashes the **raw config inputs** (before placeholder substitution), NOT the
+ * assembled `session_meta.system_prompt` — the assembled prompt embeds per-run values
+ * (`{{DATE}}`, `{{SESSION_ID}}`, `{{CWD}}`) that vary every run and would make the hash useless
+ * as a config identity.
+ *
+ * Reading follows the same degrade-to-null discipline as the rest of Agent State loading:
+ * a missing AGENTS.md / skill file hashes an empty string rather than throwing.
+ */
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { agentStateVersion } from "./default-config.js";
+import { agentsMdPath, skillsDir } from "./paths.js";
+import { buildToolConfig, listInstalledSkills, type AgentState } from "./agent-state.js";
+
+/** Fingerprint of a single installed skill. */
+export interface AgentSkillFingerprint {
+  name: string;
+  version: number;
+  /** sha256 of the skill's full SKILL.md content. */
+  sha256: string;
+}
+
+/** Optional model reference for the fingerprint (the model an evaluation ran on). */
+export interface ProvenanceModelRef {
+  provider: string;
+  model_id: string;
+}
+
+/**
+ * Content-derived provenance fingerprint of an Agent State.
+ * Docs: /docs/self-improvement § "Provenance".
+ */
+export interface AgentProvenance {
+  provenance_version: 1;
+  /** Agent State version number (the `version` in system_config.yaml; treated as 1 if missing). */
+  version: number;
+  /** sha256 of the raw system_prompt template (before placeholder substitution). */
+  system_prompt_sha256: string;
+  /** sha256 of the full AGENTS.md content (empty string when the file is missing). */
+  agents_md_sha256: string;
+  /** sha256 of the canonicalized builtin tool contract (name + description + parameters). */
+  tools_sha256: string;
+  /** Per-skill fingerprints, sorted by name. */
+  skills: AgentSkillFingerprint[];
+  /** Order-independent combined hash of the skills array. */
+  skills_sha256: string;
+  /** The model this fingerprint is paired with (optional; e.g. the evaluation's model). */
+  model?: ProvenanceModelRef;
+  /** The effective thinking level (optional). */
+  thinking_level?: string;
+  /** Top-level fingerprint combining every field above — the single "did config change?" answer. */
+  agent_sha256: string;
+}
+
+/** Recursively sort object keys so `JSON.stringify` is stable across machines/insertion order. */
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      out[key] = canonicalize((value as Record<string, unknown>)[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
+/** sha256 hex of a string. */
+function sha256(text: string): string {
+  return createHash("sha256").update(text, "utf8").digest("hex");
+}
+
+/** sha256 hex of a value's canonical JSON form (key-order independent). */
+function sha256Canonical(value: unknown): string {
+  return sha256(JSON.stringify(canonicalize(value)));
+}
+
+/**
+ * Builds the content-derived provenance fingerprint for an Agent State. The optional model /
+ * thinking level are folded into the top-level `agent_sha256` when provided (so an evaluation on
+ * a different model gets a distinct fingerprint), and echoed as their own fields.
+ */
+export async function buildAgentProvenance(
+  state: AgentState,
+  opts?: { model?: ProvenanceModelRef; thinkingLevel?: string },
+): Promise<AgentProvenance> {
+  const version = agentStateVersion(state.systemConfig);
+
+  // Raw template, NOT the assembled prompt — assembly injects per-run environment values.
+  const systemPromptSha = sha256(state.systemConfig.system_prompt);
+
+  // AGENTS.md: degrade to an empty-string hash when missing (matches agent-state loading).
+  const agentsMdText = await readFileOrEmpty(
+    agentsMdPath(state.root, state.projectId, state.agentId),
+  );
+  const agentsMdSha = sha256(agentsMdText);
+
+  // Tool contract: the full builtin tool definitions (name + description + parameters), since
+  // description-driven behavior is part of what the model sees.
+  const tools = buildToolConfig(state).customTools.map((t) => ({
+    name: t.name,
+    description: t.description,
+    parameters: t.parameters ?? null,
+  }));
+  const toolsSha = sha256Canonical(tools);
+
+  // Skills: full SKILL.md content per installed skill, sorted by name.
+  const installed = await listInstalledSkills(state.root, state.projectId, state.agentId);
+  const dir = skillsDir(state.root, state.projectId, state.agentId);
+  const skills: AgentSkillFingerprint[] = [];
+  for (const skill of installed) {
+    const content = await readFileOrEmpty(path.join(dir, skill.name, "SKILL.md"));
+    skills.push({ name: skill.name, version: skill.version, sha256: sha256(content) });
+  }
+  skills.sort((a, b) => a.name.localeCompare(b.name));
+  const skillsSha = sha256Canonical(skills);
+
+  const agentSha = sha256Canonical({
+    provenance_version: 1,
+    version,
+    system_prompt_sha256: systemPromptSha,
+    agents_md_sha256: agentsMdSha,
+    tools_sha256: toolsSha,
+    skills_sha256: skillsSha,
+    ...(opts?.model ? { model: opts.model } : {}),
+    ...(opts?.thinkingLevel !== undefined ? { thinking_level: opts.thinkingLevel } : {}),
+  });
+
+  return {
+    provenance_version: 1,
+    version,
+    system_prompt_sha256: systemPromptSha,
+    agents_md_sha256: agentsMdSha,
+    tools_sha256: toolsSha,
+    skills,
+    skills_sha256: skillsSha,
+    ...(opts?.model ? { model: opts.model } : {}),
+    ...(opts?.thinkingLevel !== undefined ? { thinking_level: opts.thinkingLevel } : {}),
+    agent_sha256: agentSha,
+  };
+}
+
+/** Reads a file's text, returning "" when it's missing (degrade-to-null discipline). */
+async function readFileOrEmpty(filePath: string): Promise<string> {
+  try {
+    return await fs.readFile(filePath, "utf8");
+  } catch {
+    return "";
+  }
+}

--- a/packages/core/test/provenance.test.ts
+++ b/packages/core/test/provenance.test.ts
@@ -1,0 +1,112 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+import {
+  DEFAULT_AGENT_ID,
+  DEFAULT_PROJECT_ID,
+  buildAgentProvenance,
+  installSkill,
+  loadOrInitAgentState,
+  removeSkill,
+  systemConfigPath,
+  type AgentState,
+} from "../src/state/index.js";
+
+let tmpRoot: string;
+let prevHome: string | undefined;
+
+beforeEach(async () => {
+  prevHome = process.env.PENGUIN_HOME;
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "penguin-prov-"));
+  process.env.PENGUIN_HOME = tmpRoot;
+});
+
+afterEach(async () => {
+  if (prevHome === undefined) {
+    delete process.env.PENGUIN_HOME;
+  } else {
+    process.env.PENGUIN_HOME = prevHome;
+  }
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+/** Init a fresh default_agent (gets the example skills + benchmark) and return its state. */
+async function initState(): Promise<AgentState> {
+  return loadOrInitAgentState({
+    root: tmpRoot,
+    projectId: DEFAULT_PROJECT_ID,
+    agentId: DEFAULT_AGENT_ID,
+  });
+}
+
+/** Rewrite system_config.yaml's system_prompt in place, then reload the state. */
+async function editSystemPrompt(newPrompt: string): Promise<AgentState> {
+  const cfgPath = systemConfigPath(tmpRoot, DEFAULT_PROJECT_ID, DEFAULT_AGENT_ID);
+  const cfg = parseYaml(await fs.readFile(cfgPath, "utf8")) as Record<string, unknown>;
+  cfg.system_prompt = newPrompt;
+  await fs.writeFile(cfgPath, stringifyYaml(cfg), "utf8");
+  return initState();
+}
+
+describe("buildAgentProvenance", () => {
+  it("is deterministic for the same Agent State", async () => {
+    const state = await initState();
+    const a = await buildAgentProvenance(state);
+    const b = await buildAgentProvenance(state);
+    expect(a.agent_sha256).toBe(b.agent_sha256);
+    expect(a.system_prompt_sha256).toBe(b.system_prompt_sha256);
+    expect(a.skills_sha256).toBe(b.skills_sha256);
+    expect(a.tools_sha256).toBe(b.tools_sha256);
+    expect(a.provenance_version).toBe(1);
+  });
+
+  it("changes agent_sha256 and system_prompt_sha256 (only) when the system prompt is edited", async () => {
+    const before = await buildAgentProvenance(await initState());
+    const after = await buildAgentProvenance(
+      await editSystemPrompt("# Role\nYou are a totally different agent.\n"),
+    );
+    expect(after.agent_sha256).not.toBe(before.agent_sha256);
+    expect(after.system_prompt_sha256).not.toBe(before.system_prompt_sha256);
+    // Localization: skills and tools didn't change, so their sub-hashes stay put.
+    expect(after.skills_sha256).toBe(before.skills_sha256);
+    expect(after.tools_sha256).toBe(before.tools_sha256);
+  });
+
+  it("changes skills_sha256 and agent_sha256 when a skill is added or removed", async () => {
+    const state = await initState();
+    const before = await buildAgentProvenance(state);
+
+    await installSkill(tmpRoot, DEFAULT_PROJECT_ID, DEFAULT_AGENT_ID, {
+      name: "extra-skill",
+      content:
+        "---\nname: extra-skill\ndescription: test\nversion: 1\nupdated: 2026-01-01T00:00:00Z\n---\n\n# Extra\n",
+    });
+    const added = await buildAgentProvenance(state);
+    expect(added.skills_sha256).not.toBe(before.skills_sha256);
+    expect(added.agent_sha256).not.toBe(before.agent_sha256);
+    expect(added.skills.some((s) => s.name === "extra-skill")).toBe(true);
+    expect(added.system_prompt_sha256).toBe(before.system_prompt_sha256);
+
+    await removeSkill(tmpRoot, DEFAULT_PROJECT_ID, DEFAULT_AGENT_ID, "extra-skill");
+    const removed = await buildAgentProvenance(state);
+    expect(removed.skills_sha256).toBe(before.skills_sha256);
+    expect(removed.agent_sha256).toBe(before.agent_sha256);
+  });
+
+  it("folds the model reference into agent_sha256 and echoes it", async () => {
+    const state = await initState();
+    const plain = await buildAgentProvenance(state);
+    const withModel = await buildAgentProvenance(state, {
+      model: { provider: "deepseek", model_id: "deepseek-v4-pro" },
+    });
+    expect(withModel.model).toEqual({ provider: "deepseek", model_id: "deepseek-v4-pro" });
+    expect(withModel.agent_sha256).not.toBe(plain.agent_sha256);
+    // Same model reference → same fingerprint again.
+    const withModel2 = await buildAgentProvenance(state, {
+      model: { provider: "deepseek", model_id: "deepseek-v4-pro" },
+    });
+    expect(withModel2.agent_sha256).toBe(withModel.agent_sha256);
+  });
+});

--- a/packages/server/src/api/types.ts
+++ b/packages/server/src/api/types.ts
@@ -1300,6 +1300,31 @@ export interface BenchmarkCaseScore {
   runs: BenchmarkRunScore[];
 }
 
+/** A single installed skill's fingerprint (part of provenance). */
+export interface BenchmarkProvenanceSkill {
+  name: string;
+  version: number;
+  sha256: string;
+}
+
+/**
+ * Content-derived provenance fingerprint attached to an evaluation (the camelCase DTO of core's
+ * AgentProvenance; on disk the scoreboard stores it snake_case). `agentSha256` answers "did the
+ * Agent config change between rounds?"; the per-part hashes localize what changed.
+ */
+export interface BenchmarkProvenance {
+  provenanceVersion: number;
+  version: number;
+  systemPromptSha256: string;
+  agentsMdSha256: string;
+  toolsSha256: string;
+  skills: BenchmarkProvenanceSkill[];
+  skillsSha256: string;
+  model?: { provider: string; modelId: string };
+  thinkingLevel?: string;
+  agentSha256: string;
+}
+
 export interface BenchmarkEvaluation {
   /** Evaluation timestamp (ISO 8601). */
   time: string;
@@ -1321,6 +1346,8 @@ export interface BenchmarkEvaluation {
   cost: number | null;
   /** Model-written average of Case durations, rounded to an integer. */
   durationMs: number;
+  /** Content-derived reproducibility fingerprint of the Agent under test (optional; legacy records lack it). */
+  provenance?: BenchmarkProvenance;
   cases: BenchmarkCaseScore[];
 }
 

--- a/packages/server/src/services/benchmark-service.ts
+++ b/packages/server/src/services/benchmark-service.ts
@@ -22,6 +22,8 @@ import type {
   BenchmarkCaseSummary,
   BenchmarkCasesResponse,
   BenchmarkEvaluation,
+  BenchmarkProvenance,
+  BenchmarkProvenanceSkill,
   BenchmarkRunScore,
   BenchmarkSummary,
   BenchmarksResponse,
@@ -138,6 +140,51 @@ function toCase(v: unknown): BenchmarkCaseScore | null {
   };
 }
 
+/** Shapes a single skill fingerprint entry; a bad entry (missing name/sha) returns null and is dropped. */
+function toProvenanceSkill(v: unknown): BenchmarkProvenanceSkill | null {
+  const r = asRecord(v);
+  const name = stringOr(r.name);
+  const sha = stringOr(r.sha256);
+  if (name === undefined || sha === undefined) return null;
+  const version = numberOr(r.version) ?? 1;
+  return { name, version, sha256: sha };
+}
+
+/**
+ * Shapes the provenance block (scoreboard stores it snake_case; the DTO is camelCase). The
+ * top-level `agent_sha256` is the minimum requirement — without it the block carries no
+ * reproducibility value, so the whole block is dropped (undefined) rather than partially kept.
+ * Every other field tolerates being absent.
+ */
+function toProvenance(v: unknown): BenchmarkProvenance | undefined {
+  const r = asRecord(v);
+  const agentSha256 = stringOr(r.agent_sha256);
+  if (agentSha256 === undefined) return undefined;
+  const skills: BenchmarkProvenanceSkill[] = Array.isArray(r.skills)
+    ? r.skills.map(toProvenanceSkill).filter((s): s is BenchmarkProvenanceSkill => s !== null)
+    : [];
+  const modelRec = asRecord(r.model);
+  const modelProvider = stringOr(modelRec.provider);
+  const modelId = stringOr(modelRec.model_id);
+  const model =
+    modelProvider !== undefined && modelId !== undefined
+      ? { provider: modelProvider, modelId }
+      : undefined;
+  const thinkingLevel = stringOr(r.thinking_level);
+  return {
+    provenanceVersion: numberOr(r.provenance_version) ?? 1,
+    version: numberOr(r.version) ?? 1,
+    systemPromptSha256: stringOr(r.system_prompt_sha256) ?? "",
+    agentsMdSha256: stringOr(r.agents_md_sha256) ?? "",
+    toolsSha256: stringOr(r.tools_sha256) ?? "",
+    skills,
+    skillsSha256: stringOr(r.skills_sha256) ?? "",
+    ...(model !== undefined ? { model } : {}),
+    ...(thinkingLevel !== undefined ? { thinkingLevel } : {}),
+    agentSha256,
+  };
+}
+
 /** Shapes one current-format Evaluation and trusts its stored aggregate metrics. */
 function toEvaluation(v: unknown): BenchmarkEvaluation | null {
   const r = asRecord(v);
@@ -153,6 +200,7 @@ function toEvaluation(v: unknown): BenchmarkEvaluation | null {
   const provider = stringOr(r.provider);
   const thinkingLevel = stringOr(r.thinking_level);
   const version = nonNegativeIntegerOr(r.version);
+  const provenance = toProvenance(r.provenance);
   if (
     typeof time !== "string" ||
     time === "" ||
@@ -183,6 +231,7 @@ function toEvaluation(v: unknown): BenchmarkEvaluation | null {
     version,
     cost,
     durationMs,
+    ...(provenance !== undefined ? { provenance } : {}),
     cases,
   };
 }

--- a/packages/server/test/benchmarks.test.ts
+++ b/packages/server/test/benchmarks.test.ts
@@ -345,4 +345,118 @@ describe("benchmarks api", () => {
 
     expect((await outsider.get(base)).status).toBe(404);
   });
+
+  it("provenance: valid block parsed (snake→camel); missing agent_sha256 dropped; absent omitted", async () => {
+    const dir = path.join(benchmarksDir(t.root, projectId, AGENT), "prov-bench");
+    await fs.mkdir(path.join(dir, "CASE-001-task", "statement"), { recursive: true });
+    await fs.writeFile(path.join(dir, "benchmark_config.toml"), `title = "Prov"\nruns = 1\n`, "utf8");
+    await fs.writeFile(
+      path.join(dir, "scoreboard.yaml"),
+      [
+        "evaluations:",
+        // Round 1: a full, valid provenance block → parsed and camelCased.
+        '  - time: "2026-07-16T10:00:00Z"',
+        "    version: 1",
+        '    provider: "deepseek"',
+        '    model_id: "deepseek-v4-pro"',
+        '    thinking_level: "medium"',
+        "    score: 4.0",
+        "    cost: null",
+        "    duration_ms: 1000",
+        "    provenance:",
+        "      provenance_version: 1",
+        "      version: 1",
+        '      system_prompt_sha256: "aaaa"',
+        '      agents_md_sha256: "bbbb"',
+        '      tools_sha256: "cccc"',
+        "      skills:",
+        '        - name: "web-design"',
+        "          version: 3",
+        '          sha256: "dddd"',
+        '      skills_sha256: "eeee"',
+        "      model:",
+        '        provider: "deepseek"',
+        '        model_id: "deepseek-v4-pro"',
+        '      thinking_level: "medium"',
+        '      agent_sha256: "ffff"',
+        "    cases:",
+        '      - case: "CASE-001-task"',
+        "        score: 4.0",
+        "        cost: null",
+        "        duration_ms: 1000",
+        "        runs:",
+        "          - score: 4.0",
+        "            cost: null",
+        "            duration_ms: 1000",
+        '            session_id: "s1"',
+        // Round 2: provenance present but missing agent_sha256 → whole block dropped.
+        '  - time: "2026-07-17T10:00:00Z"',
+        "    version: 2",
+        '    provider: "deepseek"',
+        '    model_id: "deepseek-v4-pro"',
+        '    thinking_level: "medium"',
+        "    score: 4.5",
+        "    cost: null",
+        "    duration_ms: 1000",
+        "    provenance:",
+        "      provenance_version: 1",
+        '      system_prompt_sha256: "zzzz"',
+        "    cases:",
+        '      - case: "CASE-001-task"',
+        "        score: 4.5",
+        "        cost: null",
+        "        duration_ms: 1000",
+        "        runs:",
+        "          - score: 4.5",
+        "            cost: null",
+        "            duration_ms: 1000",
+        '            session_id: "s2"',
+        // Round 3: no provenance field at all → omitted.
+        '  - time: "2026-07-18T10:00:00Z"',
+        "    version: 3",
+        '    provider: "deepseek"',
+        '    model_id: "deepseek-v4-pro"',
+        '    thinking_level: "medium"',
+        "    score: 5.0",
+        "    cost: null",
+        "    duration_ms: 1000",
+        "    cases:",
+        '      - case: "CASE-001-task"',
+        "        score: 5.0",
+        "        cost: null",
+        "        duration_ms: 1000",
+        "        runs:",
+        "          - score: 5.0",
+        "            cost: null",
+        "            duration_ms: 1000",
+        '            session_id: "s3"',
+      ].join("\n"),
+      "utf8",
+    );
+
+    const res = (await (await member.get(base)).json()) as BenchmarksResponse;
+    const evals = res.benchmarks[0]!.evaluations;
+    expect(evals).toHaveLength(3);
+
+    // Round 1: fully parsed and camelCased.
+    expect(evals[0]!.provenance).toEqual({
+      provenanceVersion: 1,
+      version: 1,
+      systemPromptSha256: "aaaa",
+      agentsMdSha256: "bbbb",
+      toolsSha256: "cccc",
+      skills: [{ name: "web-design", version: 3, sha256: "dddd" }],
+      skillsSha256: "eeee",
+      model: { provider: "deepseek", modelId: "deepseek-v4-pro" },
+      thinkingLevel: "medium",
+      agentSha256: "ffff",
+    });
+
+    // Round 2: invalid provenance dropped, but the evaluation itself survives.
+    expect(evals[1]!.score).toBe(4.5);
+    expect("provenance" in evals[1]!).toBe(false);
+
+    // Round 3: no provenance → field omitted.
+    expect("provenance" in evals[2]!).toBe(false);
+  });
 });

--- a/packages/skills/skills/agent-evaluation/SKILL.md
+++ b/packages/skills/skills/agent-evaluation/SKILL.md
@@ -3,8 +3,8 @@ name: agent-evaluation
 description: Run one specified Test Agent on one specified Benchmark Case exactly once, privately score that execution, and return one protocol result.
 short_description: Run and score one isolated Benchmark Case.
 short_description_zh: 隔离执行并评分一个 Benchmark Case。
-version: 5
-updated: 2026-07-29T17:20:58Z
+version: 6
+updated: 2026-08-04T00:00:00Z
 ---
 
 # Agent Evaluation
@@ -85,6 +85,8 @@ Inspect only new or changed Traces. Bind exactly one root Test Trace whose Works
 Inspect only the isolated Workspace, the bound root Trace, its directly referenced child Traces, and the private Rubric. Apply every scoring item and allowed equivalent. Keep Rubric contents, Gold answers, per-item scoring, and scoring rationale private.
 
 A wrong answer, missing artifact, malformed output, or task failure attributable to the Test Agent is scored behavior and returns `status: ok`. A launcher, Trace-binding, or Evaluator failure is not scored. Return `benchmark_invalid` when the Rubric cannot be applied and `evaluation_failed` when the score is non-finite or outside `0..100`.
+
+The caller (`agent-optimization`) records a content-derived Agent fingerprint alongside each scoreboard evaluation via `penguin provenance`; the fingerprint's `version` must equal the `expected_version` you validate here. This leaf worker's return protocol is unchanged — do not compute or emit a fingerprint yourself.
 
 Set `duration_ms` from the root Test Session. Compute cost only from reliable final cumulative usage or cost already recorded in that Session and directly referenced child Traces found in the same bounded pass. Never browse, query a pricing service, or infer cost from external model prices. If the required data is unavailable, return `cost: null`. Missing cost data must not invalidate a score.
 

--- a/packages/skills/skills/agent-optimization/SKILL.md
+++ b/packages/skills/skills/agent-optimization/SKILL.md
@@ -3,7 +3,7 @@ name: agent-optimization
 description: Improve an Agent State through versioned scores and score-linked Traces from a frozen Benchmark.
 short_description: Improve an Agent from measured Benchmark results.
 short_description_zh: 根据 Benchmark 结果改进 Agent。
-version: 9
+version: 10
 updated: 2026-08-04T00:00:00Z
 ---
 
@@ -113,6 +113,7 @@ Append each complete accepted Candidate Evaluation to `scoreboard.yaml` immediat
   score: <average of the Case scores>
   cost: <average of known Case costs, or null when every Case cost is null>
   duration_ms: <average of the Case durations>
+  provenance: <block captured with `penguin provenance`, see below>
   cases:
     - case: <case_id>
       score: <average of the Run scores>
@@ -124,6 +125,15 @@ Append each complete accepted Candidate Evaluation to `scoreboard.yaml` immediat
           duration_ms: <Run duration>
           session_id: <Test Session id>
 ```
+
+The `provenance` block is a content-derived reproducibility fingerprint of the tested Candidate State. Never hand-compute or invent its hashes — `version` alone is a human-assigned counter, so two rounds that forget to bump it look identical, whereas the fingerprint's `agent_sha256` distinguishes them and its per-part hashes (`system_prompt_sha256` / `agents_md_sha256` / `tools_sha256` / `skills_sha256`) localize what changed. Before appending, with the accepted Candidate State still active, capture it deterministically:
+
+```bash
+penguin provenance --agent-id <test_agent_id> --project-id "$PROJECT_ID" \
+  --provider <provider> --model-id <model_id> --format yaml
+```
+
+Nest the returned block under `provenance:` verbatim (do not edit its hashes). Its `version` must equal the Candidate version you evaluated; if it does not, the State changed under you — stop without appending. Capture the no-edit Reference Evaluation the same way at its own version.
 
 After writing, parse the complete `scoreboard.yaml` and verify the appended Evaluation before reporting success or continuing.
 


### PR DESCRIPTION
Add a reproducibility fingerprint to the self-evolution loop. Each scoreboard evaluation records only version + provider + model_id, with no content fingerprint, so editing the system prompt / AGENTS.md / a skill without bumping version leaves two evaluations looking identical while testing different Agents.

- core: buildAgentProvenance() hashes the raw config inputs (system prompt template, AGENTS.md, tool contract, each installed SKILL.md) into per-part sub-hashes plus a top-level agent_sha256; canonical-JSON hashing for stability.
- server: BenchmarkEvaluation gains an optional provenance field, parsed fault-tolerantly (snake_case on disk -> camelCase DTO; a block missing agent_sha256 is dropped whole).
- cli: `penguin provenance` prints the fingerprint deterministically (yaml/json) -- the capture path the skills call, since an LLM cannot compute sha256.
- skills: agent-optimization captures the fingerprint via the CLI before appending an evaluation; agent-evaluation notes the version tie-in.
- example benchmark carries illustrative provenance so the eval center shows it.