### PR TITLE
fix(release,landing): match the Linux desktop artifact names electron-builder emits

### DIFF
--- a/changelog/0.2.1/2026-08-04-desktop-distribution-and-download-page.md
+++ b/changelog/0.2.1/2026-08-04-desktop-distribution-and-download-page.md
@@ -2,7 +2,7 @@
 
 ## Distribution
 
-Desktop installers move to version-less artifact names following the CLI bundle convention — `penguin-desktop-darwin-{arm64,x64}.dmg` / `.zip`, `penguin-desktop-win32-x64.exe`, `penguin-desktop-linux-x64.AppImage` / `.deb` — with the version carried by the Release tag and `SHA256SUMS.desktop`. The OSS mirror job now mirrors all seven installers plus `SHA256SUMS.desktop` into the immutable per-tag prefix, verified as a set through `SHA256SUMS.desktop`; the CLI bundles' canonical manifest is unchanged.
+Desktop installers move to version-less artifact names following the CLI bundle convention — `penguin-desktop-darwin-{arm64,x64}.dmg` / `.zip`, `penguin-desktop-win32-x64.exe`, `penguin-desktop-linux-x86_64.AppImage` / `penguin-desktop-linux-amd64.deb` — with the version carried by the Release tag and `SHA256SUMS.desktop`. The OSS mirror job now mirrors all seven installers plus `SHA256SUMS.desktop` into the immutable per-tag prefix, verified as a set through `SHA256SUMS.desktop`; the CLI bundles' canonical manifest is unchanged.
 
 ## Landing site
 

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -56,6 +56,10 @@ nsis:
 linux:
   # The scoped package name is not a valid executable file name.
   executableName: penguin-harness
+  # ${arch} expands to each Linux target's own convention — x86_64 for AppImage, amd64
+  # for deb — so the published names are penguin-desktop-linux-x86_64.AppImage and
+  # penguin-desktop-linux-amd64.deb; the OSS mirror manifest and the landing download
+  # page name them accordingly.
   artifactName: penguin-desktop-linux-${arch}.${ext}
   category: Development
   maintainer: Prism Shadow <zheng@prismshadow.com>

--- a/packages/landing/src/lib/links.ts
+++ b/packages/landing/src/lib/links.ts
@@ -110,8 +110,8 @@ export const DESKTOP_INSTALLERS: Record<"mac" | "windows" | "linux", DesktopInst
   ],
   windows: [{ file: "penguin-desktop-win32-x64.exe", variant: "x64" }],
   linux: [
-    { file: "penguin-desktop-linux-x64.AppImage", variant: "AppImage" },
-    { file: "penguin-desktop-linux-x64.deb", variant: "deb" },
+    { file: "penguin-desktop-linux-x86_64.AppImage", variant: "AppImage" },
+    { file: "penguin-desktop-linux-amd64.deb", variant: "deb" },
   ],
 };
 

--- a/scripts/publish-release-to-oss.sh
+++ b/scripts/publish-release-to-oss.sh
@@ -78,8 +78,8 @@ penguin-desktop-darwin-arm64.dmg
 penguin-desktop-darwin-arm64.zip
 penguin-desktop-darwin-x64.dmg
 penguin-desktop-darwin-x64.zip
-penguin-desktop-linux-x64.AppImage
-penguin-desktop-linux-x64.deb
+penguin-desktop-linux-x86_64.AppImage
+penguin-desktop-linux-amd64.deb
 penguin-desktop-win32-x64.exe
 "
 FILES="$BUNDLES


### PR DESCRIPTION
The v0.2.1 mirror-oss job failed on `missing GitHub Release asset: penguin-desktop-linux-x64.AppImage`: electron-builder expands `${arch}` per Linux target convention (x86_64 for AppImage, amd64 for deb), so the shipped names are `penguin-desktop-linux-x86_64.AppImage` / `penguin-desktop-linux-amd64.deb`. Published assets are immutable, so this aligns the OSS manifest, the download page's Linux links, and the 0.2.1 changelog entry with what actually shipped (macOS/Windows names matched as predicted), and documents the expansion in electron-builder.yml. After merge, the mirror will be retried via the workflow's already-released-tag dispatch path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hq9ucVagGnWsDVMCAv6Nqm