### PR TITLE
fix(desktop): stamp the release version into desktop builds

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -11,7 +11,13 @@
 name: Desktop packages
 
 on:
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      tag:
+        description: Release tag (vX.Y.Z) stamped into the app; empty keeps dev versions.
+        required: false
+        type: string
+        default: ""
   workflow_dispatch: {}
 
 env:
@@ -45,6 +51,33 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
+
+      # Stamp the release version the same way release.yml stamps the CLI artifacts —
+      # core's VERSION/BUILD_DATE constants (what the app and server report) plus the
+      # desktop package.json electron-builder reads its installer metadata from;
+      # otherwise every installer carries the in-repo dev version (v0.2.1 shipped
+      # Windows metadata saying 0.2.0 this way). node instead of sed -i: this matrix
+      # includes macOS, whose BSD sed spells in-place editing differently. Dry runs
+      # (no tag) keep the dev versions.
+      - name: Stamp release version
+        if: inputs.tag != ''
+        shell: bash
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          V="${TAG#v}"
+          D="$(date -u +%Y-%m-%d)"
+          V="$V" D="$D" node -e '
+            const fs = require("fs");
+            const p = "packages/core/src/index.ts";
+            let s = fs.readFileSync(p, "utf8");
+            if (!/export const VERSION = "/.test(s)) throw new Error("VERSION const not found");
+            s = s.replace(/export const VERSION = "[^"]*"/, `export const VERSION = "${process.env.V}"`);
+            if (!/export const BUILD_DATE: string \| null = /.test(s)) throw new Error("BUILD_DATE const not found");
+            s = s.replace(/export const BUILD_DATE: string \| null = [^;]*/, `export const BUILD_DATE: string | null = "${process.env.D}"`);
+            fs.writeFileSync(p, s);
+          '
+          (cd packages/desktop && npm version --no-git-tag-version --allow-same-version "$V")
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,8 @@ jobs:
     needs: check-release
     if: needs.check-release.outputs.exists != 'true'
     uses: ./.github/workflows/desktop-build.yml
+    with:
+      tag: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 
   release:
     needs: [check-release, desktop]


### PR DESCRIPTION
v0.2.1's desktop installers carry version 0.2.0: `desktop-build.yml` never stamped versions, so electron-builder read the in-repo `packages/desktop/package.json` (0.2.0) for installer metadata and the app bundles core's dev `VERSION` constant (0.2.0) for self-reporting.

The reusable workflow gains an optional `tag` input which release.yml passes (tag push or dispatch alike); when set, the build stamps core's `VERSION`/`BUILD_DATE` exactly like release.yml's CLI stamp step plus the desktop `package.json`, before `pnpm -r build` and staging. Implemented with node instead of `sed -i` because this matrix includes macOS (BSD sed). `workflow_dispatch` dry runs pass no tag and keep dev versions. Stamp script dry-run tested locally against the real constants.

The already-published v0.2.1 installers are immutable and keep their 0.2.0 metadata; the fix takes effect from the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hq9ucVagGnWsDVMCAv6Nqm