### PR TITLE
blog: PenguinHarness 0.2.1 release post (zh/en)

### DIFF
--- a/packages/landing/content/blog/penguinharness-0-2-1.en.md
+++ b/packages/landing/content/blog/penguinharness-0-2-1.en.md
@@ -1,0 +1,53 @@
+---
+title: "PenguinHarness 0.2.1: the desktop app arrives"
+date: 2026-08-04
+category: news
+excerpt: 0.2.1 packs the full Web experience into a double-click desktop app — installers for macOS / Windows / Linux, signed in on open, sharing one data root with CLI installs. Around it, a software download page goes live with the installers mirrored to Alibaba Cloud OSS, standalone install scripts and penguin update learn to pick their download source, compaction failures stop trapping sessions with their retry costs finally visible, and the seeded admin password goes random with login throttling. Here is what shipped.
+---
+
+PenguinHarness 0.2.1 is out. The headline is the desktop app: no terminal, no login page — double-click an icon and you are in the full PenguinHarness. Around it, the distribution pipeline and download experience level up too. Feature by feature:
+
+## The desktop app
+
+A deliberately thin Electron shell: it forks the existing server as a child process and points its window at `http://localhost` — no private IPC, no preload, no node integration; every capability still flows through the same HTTP API. It opens already signed in: a one-shot token lands an admin session, so there is no login page and no initial password to copy down.
+
+Data is **fully shared** with CLI installs under `~/.penguin/data`: the desktop app and `penguin web` can be used interchangeably, and a data root only ever runs one server (a new `server.lock` single-instance guard that the CLI and the shell both honor) — if a CLI-started instance is already up, the app simply attaches to it. UI preferences (language, theme) survive restarts: the shell remembers the port the server last bound and reuses it while still free, keeping the window origin — and the origin-scoped browser storage behind your preferences — stable.
+
+Installers cover macOS (dmg, Apple silicon / Intel), Windows (NSIS) and Linux (AppImage / deb). Current builds are unsigned: on first launch use right-click → Open on macOS, and "More info → Run anyway" past Windows SmartScreen.
+
+## A download page, and desktop installers on the OSS mirror
+
+[penguin.ooo/download](https://penguin.ooo/download) is a classic software download page: one card per platform, your detected system badged, click to download. Buttons default to GitHub's static `releases/latest/download` links — made possible by the installers moving to version-less names — while the page resolves the OSS mirror's `latest.json` in the background and, on success, switches to the mirror's immutable per-version directory, showing the resolved version with a manual source toggle. Desktop installers are mirrored byte-for-byte to Alibaba Cloud OSS, just like the CLI bundles.
+
+## Install scripts and penguin update pick their download source
+
+An `install.sh` / `install.ps1` saved from a Release page now follows the same policy as the penguin.ooo forwarding layer: `PENGUIN_DOWNLOAD_SOURCE=auto|oss|github`, with `auto` preferring OSS and falling back to the same version on GitHub. Newly published installers embed their own Release tag, so however long you keep one around it downloads the matching version instead of silently following a future latest. `penguin update` adopts the same contract: upgrades no longer start at GitHub — version discovery prefers the OSS `latest.json`, forced modes are strict, and failures are reported localized.
+
+## Compaction failures stop trapping sessions
+
+Some models write `[summary]` as a title and put the body after the closing tag — the old logic extracted an empty summary, and every retry showed the model its own bad output to copy again, locking the session in a failing loop. In 0.2.1 summary extraction applies a tolerance ladder, unusable responses retry on the standard budget and backoff ladder with a corrective note, and the burned attempts and tokens finally land in stats and the cost center, with retry detail (`error_message` / `attempt` / `retry_in_ms`) visible in both the CLI and the Web.
+
+## Login hardened
+
+The fixed seed password `penguin-2026` retires: first start generates a random password, printed exactly once; the login endpoint throttles per username with exponential delays (5 free failures, 1s doubling to 60s), so the 4-digit space cannot be enumerated.
+
+## Web App improvements
+
+Skills become manageable in the interface: Agent settings gains a Skills tab listing the installed set from disk, with uninstall, zip import/export and chat-driven install; the new `skill-porting` library skill normalizes skills from other ecosystems in. Project settings gains "New chat defaults" — default agent, working directory, approval mode, thinking level and model, seeded into every new draft. The Traces page shares the session sidebar's grouping components, sessions page server-side, and trace discovery moves onto a SQLite index instead of per-request filesystem walks. On the chat page: the outline tick rail windows to ±20 turns and stops overlapping the composer, the cost stat no longer blinks out across task boundaries, uploaded file attachments render as user content (right-aligned with the same timestamp treatment as images, and visible inside steering chips), and ANSI color codes are kept out of tool output for good.
+
+## Everything else
+
+The server's last two IO hotspots close: the 30-second scheduler tick and the schedules routes serve from mtime-gated caches, and `GET /messages` gains cursor pagination with tail-first web loading. `hono` moves past the CORS-preflight ReDoS advisory, and the OpenRouter catalog gains `qwen/qwen3.8-max`. The full list, item by item: [changelog/0.2.1](https://github.com/Prism-Shadow/penguin-harness/tree/main/changelog/0.2.1).
+
+## Install or upgrade
+
+Desktop app: grab your platform's installer at [penguin.ooo/download](https://penguin.ooo/download).
+
+CLI / server:
+
+```sh
+curl -fsSL https://penguin.ooo/install.sh | sh
+penguin web
+```
+
+Windows (PowerShell): `irm https://penguin.ooo/install.ps1 | iex`; or `npm install -g @prismshadow/penguin-cli` with Node >= 24. Existing installs: just `penguin update` — which, as of this release, rides the mirror too.

--- a/packages/landing/content/blog/penguinharness-0-2-1.zh.md
+++ b/packages/landing/content/blog/penguinharness-0-2-1.zh.md
@@ -1,0 +1,53 @@
+---
+title: "PenguinHarness 0.2.1：桌面端应用来了"
+date: 2026-08-04
+category: news
+excerpt: 0.2.1 把完整的 Web 体验装进一个双击即用的桌面应用——macOS / Windows / Linux 三平台安装包、打开即已登录、与 CLI 安装共用同一份数据；配套上线软件下载页，安装包同步镜像到阿里云 OSS；独立安装脚本与 penguin update 学会自选下载源；压缩失败不再拖垮会话、烧掉的重试成本终于可见；管理员初始密码随机化并加登录限流。逐项看看。
+---
+
+PenguinHarness 0.2.1 发布了。主角是桌面端：不打开终端、不看登录页，双击图标就是完整的 PenguinHarness。围绕它，分发管道与下载体验也一并升级。逐项说明：
+
+## 桌面端应用
+
+一个刻意做薄的 Electron 壳：它把现有服务端作为子进程拉起，窗口指向 `http://localhost`——没有私有 IPC、没有 preload、没有 node integration，一切能力仍然走同一套 HTTP API。打开即已登录：一次性 token 落地管理员会话，没有登录页，也没有要抄写的初始密码。
+
+数据与 CLI 安装**完全共用** `~/.penguin/data`：桌面端与 `penguin web` 可以混用，同一数据目录同一时刻只运行一个服务端（新增的 `server.lock` 单实例锁，CLI 与壳都遵守）——CLI 已启动实例时，应用直接接入它。UI 偏好（语言、主题）在重启后保持：壳会记住上次绑定的端口并在仍空闲时复用，窗口 origin 稳定，浏览器按 origin 存放的偏好随之稳定。
+
+安装包覆盖 macOS（dmg，Apple 芯片 / Intel）、Windows（NSIS）与 Linux（AppImage / deb）。当前构建暂未签名：macOS 首次启动右键 →「打开」，Windows 在 SmartScreen 中选「更多信息 → 仍要运行」。
+
+## 下载页，以及镜像到 OSS 的桌面安装包
+
+[penguin.ooo/download](https://penguin.ooo/download) 是一张经典的软件下载页：每个平台一张卡片、检测到的系统打上标记、点击即下载。按钮默认指向 GitHub 的 `releases/latest/download` 静态直链——安装包改为无版本号命名，这类链接才成为可能——页面同时在后台解析 OSS 镜像的 `latest.json`，解析成功即切到镜像的不可变版本目录，并显示当前版本号，可手动切换来源。桌面安装包与 CLI 包一样逐字节镜像到阿里云 OSS。
+
+## 安装脚本与 penguin update 自选下载源
+
+从 Release 页保存的 `install.sh` / `install.ps1` 现在与 penguin.ooo 转发层同口径：`PENGUIN_DOWNLOAD_SOURCE=auto|oss|github`，`auto` 优先 OSS、同版本回退 GitHub；新发布的安装脚本内嵌自己的 Release tag，保存多久都下载与之匹配的版本，不再悄悄跟随未来的 latest。`penguin update` 采用同一契约：升级不再从 GitHub 起步，版本发现优先走 OSS 的 `latest.json`，强制模式严格生效，失败信息本地化。
+
+## 压缩失败不再拖垮会话
+
+某些模型会把 `[summary]` 写成标题、正文放在闭合标签之后——旧逻辑取到空摘要，每次重试还把模型自己的错误输出回显给它，会话就此陷入失败循环。0.2.1 的摘要提取带容错阶梯，不可用的响应按标准重试预算与退避阶梯重来并附纠正提示；烧掉的尝试次数与 token 终于计入统计与成本中心，重试详情（`error_message` / `attempt` / `retry_in_ms`）在 CLI 与 Web 上直接可见。
+
+## 登录加固
+
+固定的初始密码 `penguin-2026` 退役：首次启动生成随机密码、只打印一次；登录端点按用户名做指数限流（5 次免罚，1 秒起倍增至 60 秒），4 位数字空间不再可枚举。
+
+## Web 应用改进
+
+技能可以在界面里管理了：Agent 设置新增 Skills 标签页，列出磁盘上已装技能，支持卸载、zip 导入导出与对话驱动安装；新的 `skill-porting` 库技能把外部生态的技能规范化迁入。Project 设置新增「新对话默认值」——默认 Agent、工作目录、审批模式、思考等级与模型，落进每个新草稿。Traces 页与会话侧栏共享同一套分组组件，会话分页、轨迹索引落到 SQLite，不再逐请求扫文件系统。对话页：大纲刻度轨按 ±20 轮开窗不再压住输入区，成本统计跨任务边界不再闪没，上传的文件附件按用户内容渲染（右对齐、随图片同款时间戳，插话 chip 里也能看到），工具输出的 ANSI 颜色码被彻底拦下。
+
+## 其余改进
+
+服务端最后两个 IO 热点关闭：调度器每 30 秒的 tick 与 schedules 路由改为 mtime 门控缓存，`GET /messages` 支持游标分页与 Web 端尾部优先加载。`hono` 升级越过 CORS 预检 ReDoS 通告；OpenRouter 目录新增 `qwen/qwen3.8-max`。完整清单逐条见 [changelog/0.2.1](https://github.com/Prism-Shadow/penguin-harness/tree/main/changelog/0.2.1)。
+
+## 安装或升级
+
+桌面端：前往 [penguin.ooo/download](https://penguin.ooo/download) 下载对应平台安装包。
+
+CLI / 服务端：
+
+```sh
+curl -fsSL https://penguin.ooo/install.sh | sh
+penguin web
+```
+
+Windows（PowerShell）：`irm https://penguin.ooo/install.ps1 | iex`；或在 Node >= 24 下 `npm install -g @prismshadow/penguin-cli`。已有安装直接 `penguin update`——这一版起，它也走镜像了。


### PR DESCRIPTION
Bilingual release post for 0.2.1, following the 0.2.0 post's structure (frontmatter, per-theme sections, install/upgrade footer — now leading with the download page). Landing build + postbuild verified locally: the post's route shell is generated and prettier is clean; zh punctuation normalized to full-width per the existing posts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hq9ucVagGnWsDVMCAv6Nqm