### PR TITLE
fix(web): preserve Benchmark selection

### DIFF
--- a/changelog/unreleased/2026-08-05-benchmark-selection.md
+++ b/changelog/unreleased/2026-08-05-benchmark-selection.md
@@ -1,0 +1,5 @@
+# Evaluation Center restores the selected Benchmark
+
+The Evaluation Center now remembers the last selected Agent and Benchmark for each user and Project, so following a Run's Session link into Trace Observability and returning through the sidebar restores the Benchmark instead of showing the empty initial state.
+
+Only the stable Agent and Benchmark ids are kept in browser storage. The current Benchmark summary is fetched again before restoration, invalid or stale selections are ignored, account and Project changes are isolated, and explicit `?agentId=` deep links retain their existing focus behavior. Unit coverage exercises storage validation and isolation, while a browser regression test follows the original Evaluation Center → Session trace → Evaluation Center path.

--- a/changelog/unreleased/README.md
+++ b/changelog/unreleased/README.md
@@ -1,0 +1,3 @@
+# Unreleased
+
+- [2026-08-05] Web App: the Evaluation Center remembers the last selected Benchmark per user and Project, restoring it after a Session trace visit while ignoring stale or cross-account browser data. ([details](2026-08-05-benchmark-selection.md))

--- a/packages/web/e2e/benchmark.spec.mjs
+++ b/packages/web/e2e/benchmark.spec.mjs
@@ -1,0 +1,28 @@
+import { test, expect } from "@playwright/test";
+import { provisionAndLogin } from "./auth.mjs";
+
+const BASE = process.env.BASE_URL;
+const U = "benchmarkuser";
+const P = "password123";
+
+test("Evaluation Center restores its Benchmark after opening a Session trace", async ({ page }) => {
+  await provisionAndLogin(page.request, U, P);
+  await page.goto(`${BASE}/benchmark`);
+
+  const main = page.locator("main");
+  await main.getByRole("button").filter({ hasText: "Example Benchmark" }).click();
+  await expect(main.getByRole("heading", { name: "Example Benchmark" })).toBeVisible();
+
+  // Open the latest Evaluation, its first Case, and one sample Run's Session link: this is
+  // the exact navigation path that used to unmount BenchmarkPage and lose its selection.
+  const evaluations = main.locator("table").first();
+  await evaluations.locator("tbody > tr").first().click();
+  const caseTable = evaluations.locator("tbody > tr").nth(1).locator("table");
+  await caseTable.locator("tbody > tr").first().click();
+  await evaluations.locator('a[href^="/traces?agentId=default_agent"]').first().click();
+  await expect(page).toHaveURL(/\/traces\?/);
+
+  await page.getByRole("link", { name: /Evaluation Center|评估中心/ }).click();
+  await expect(page).toHaveURL(/\/benchmark$/);
+  await expect(main.getByRole("heading", { name: "Example Benchmark" })).toBeVisible();
+});

--- a/packages/web/e2e/benchmark.spec.mjs
+++ b/packages/web/e2e/benchmark.spec.mjs
@@ -26,3 +26,24 @@ test("Evaluation Center restores its Benchmark after opening a Session trace", a
   await expect(page).toHaveURL(/\/benchmark$/);
   await expect(main.getByRole("heading", { name: "Example Benchmark" })).toBeVisible();
 });
+
+test("Evaluation Center restores its Benchmark after leaving an Agent-focused route", async ({
+  page,
+}) => {
+  await provisionAndLogin(page.request, U, P);
+  await page.goto(`${BASE}/benchmark`);
+
+  const main = page.locator("main");
+  await main.getByRole("button").filter({ hasText: "Example Benchmark" }).click();
+  await expect(main.getByRole("heading", { name: "Example Benchmark" })).toBeVisible();
+
+  // Search-param-only navigation keeps BenchmarkPage and each AgentNode mounted. The remembered
+  // Agent must therefore reopen when the sidebar removes the focus param; relying on the node's
+  // initial `defaultOpen` value would leave its Benchmark list unloaded forever.
+  await page.goto(`${BASE}/benchmark?agentId=missing_agent`);
+  await expect(main.getByRole("heading", { name: "Example Benchmark" })).toBeHidden();
+
+  await page.getByRole("link", { name: /Evaluation Center|评估中心/ }).click();
+  await expect(page).toHaveURL(/\/benchmark$/);
+  await expect(main.getByRole("heading", { name: "Example Benchmark" })).toBeVisible();
+});

--- a/packages/web/src/features/benchmark/benchmark-page.tsx
+++ b/packages/web/src/features/benchmark/benchmark-page.tsx
@@ -84,6 +84,12 @@ function AgentNode({
   const [benchmarks, setBenchmarks] = useState<BenchmarkSummary[] | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  // A query-only navigation keeps this component mounted, so `defaultOpen` is not applied again.
+  // Open the remembered Agent explicitly when the bare route makes it eligible for restoration.
+  useEffect(() => {
+    if (restoreBenchmarkId) setOpen(true);
+  }, [restoreBenchmarkId]);
+
   useEffect(() => {
     if (!open || benchmarks) return;
     api

--- a/packages/web/src/features/benchmark/benchmark-page.tsx
+++ b/packages/web/src/features/benchmark/benchmark-page.tsx
@@ -8,7 +8,7 @@
  * Session link.
  * With a ?agentId= deep link, only the target Agent is expanded by default.
  */
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Link, useSearchParams } from "react-router";
 import type {
   BenchmarkCaseScore,
@@ -21,6 +21,7 @@ import { S } from "../../lib/strings";
 import { apiErrorText } from "../../lib/api-error";
 import { useDocumentTitle } from "../../lib/use-document-title";
 import { formatDateTime, formatMoney, formatScore, humanizeDuration } from "../../lib/format";
+import { useAuth } from "../../state/auth";
 import { agentDisplayName, useProject } from "../../state/project";
 import { useTheme } from "../../state/theme";
 import type { Currency } from "../../state/theme";
@@ -42,6 +43,13 @@ import {
 } from "./benchmark-metrics";
 import type { EvaluationSeries } from "./benchmark-metrics";
 import { BenchmarkCaseBrowser } from "./benchmark-case-browser";
+import {
+  benchmarkSelectionKey,
+  clearBenchmarkSelection,
+  loadBenchmarkSelection,
+  saveBenchmarkSelection,
+} from "./benchmark-selection";
+import type { BenchmarkSelectionRef } from "./benchmark-selection";
 
 interface Selection {
   agentId: string;
@@ -55,7 +63,10 @@ function AgentNode({
   name,
   defaultOpen,
   selection,
+  restoreBenchmarkId,
   onSelect,
+  onRestore,
+  onRestoreMissing,
 }: {
   projectId: string;
   agentId: string;
@@ -63,7 +74,11 @@ function AgentNode({
   /** Whether initially expanded: all expanded when there's no deep link; only the target Agent expanded with a ?agentId= deep link. */
   defaultOpen: boolean;
   selection: Selection | null;
+  /** Remembered Benchmark id for this Agent; resolved against the freshly fetched list. */
+  restoreBenchmarkId: string | null;
   onSelect: (sel: Selection) => void;
+  onRestore: (sel: Selection) => void;
+  onRestoreMissing: (selection: BenchmarkSelectionRef) => void;
 }) {
   const [open, setOpen] = useState(defaultOpen);
   const [benchmarks, setBenchmarks] = useState<BenchmarkSummary[] | null>(null);
@@ -76,6 +91,15 @@ function AgentNode({
       .then((data) => setBenchmarks(data.benchmarks))
       .catch((e: unknown) => setError(apiErrorText(e)));
   }, [open, benchmarks, projectId, agentId]);
+
+  // Restore by id only after this Project's live list arrives. Browser storage never supplies
+  // the Benchmark summary itself, so changed scores/titles cannot be resurrected from cache.
+  useEffect(() => {
+    if (selection || !benchmarks || !restoreBenchmarkId) return;
+    const benchmark = benchmarks.find((candidate) => candidate.id === restoreBenchmarkId);
+    if (benchmark) onRestore({ agentId, benchmark });
+    else onRestoreMissing({ agentId, benchmarkId: restoreBenchmarkId });
+  }, [agentId, benchmarks, onRestore, onRestoreMissing, restoreBenchmarkId, selection]);
 
   return (
     <li className="pt-2.5">
@@ -518,21 +542,88 @@ function CasesSection({
 
 export function BenchmarkPage() {
   useDocumentTitle(S.benchmark.title);
+  const { user } = useAuth();
   const { currentProject, agents, agentsLoading } = useProject();
   const { currency } = useTheme();
   const projectId = currentProject?.projectId ?? null;
   // ?agentId= deep link (entered from the "Benchmark" tab on the Agent settings page): only the target Agent is expanded by default.
   const [searchParams] = useSearchParams();
   const focusAgentId = searchParams.get("agentId");
-  const [selection, setSelection] = useState<Selection | null>(null);
+  const storageKey = user && projectId ? benchmarkSelectionKey(user.userId, projectId) : null;
+  // Both state holders carry their storage key. On a Project/account switch, an old value is
+  // therefore invisible immediately (before the synchronization effect runs after paint).
+  const [selectionState, setSelectionState] = useState<{
+    key: string | null;
+    value: Selection | null;
+  }>(() => ({ key: storageKey, value: null }));
+  const [rememberedState, setRememberedState] = useState<{
+    key: string | null;
+    value: BenchmarkSelectionRef | null;
+  }>(() => ({
+    key: storageKey,
+    value: storageKey ? loadBenchmarkSelection(storageKey) : null,
+  }));
+  const selection = selectionState.key === storageKey ? selectionState.value : null;
+  const rememberedSelection = rememberedState.key === storageKey ? rememberedState.value : null;
   const [caseStatements, setCaseStatements] = useState<BenchmarkCaseSummary[] | null>(null);
   const [caseError, setCaseError] = useState<string | null>(null);
   const [openCaseId, setOpenCaseId] = useState<string | null>(null);
 
-  // Clear the selection when the Project changes.
+  // Reload the independently scoped remembered ids when the account or Project changes.
   useEffect(() => {
-    setSelection(null);
-  }, [projectId]);
+    setSelectionState({ key: storageKey, value: null });
+    setRememberedState({
+      key: storageKey,
+      value: storageKey ? loadBenchmarkSelection(storageKey) : null,
+    });
+  }, [storageKey]);
+
+  const selectBenchmark = useCallback(
+    (next: Selection) => {
+      setSelectionState({ key: storageKey, value: next });
+      if (!storageKey) return;
+      const remembered = { agentId: next.agentId, benchmarkId: next.benchmark.id };
+      saveBenchmarkSelection(storageKey, remembered);
+      setRememberedState({ key: storageKey, value: remembered });
+    },
+    [storageKey],
+  );
+
+  const restoreBenchmark = useCallback(
+    (restored: Selection) => {
+      // A late lazy-list response must not override a Benchmark the user selected meanwhile.
+      setSelectionState((current) =>
+        current.key === storageKey && current.value === null
+          ? { key: storageKey, value: restored }
+          : current,
+      );
+    },
+    [storageKey],
+  );
+
+  const forgetMissingBenchmark = useCallback(
+    (missing: BenchmarkSelectionRef) => {
+      if (!storageKey) return;
+      clearBenchmarkSelection(storageKey, missing);
+      setRememberedState((current) =>
+        current.key === storageKey &&
+        current.value?.agentId === missing.agentId &&
+        current.value.benchmarkId === missing.benchmarkId
+          ? { key: storageKey, value: null }
+          : current,
+      );
+    },
+    [storageKey],
+  );
+
+  // An explicit Agent deep link keeps its existing meaning: focus that Agent for this visit.
+  // The remembered selection is restored on the bare sidebar route, or when it belongs to the
+  // same deep-linked Agent; a saved choice from another Agent stays dormant rather than opening
+  // an unrelated group.
+  const restoreSelection =
+    rememberedSelection && (focusAgentId === null || focusAgentId === rememberedSelection.agentId)
+      ? rememberedSelection
+      : null;
 
   useEffect(() => {
     setCaseStatements(null);
@@ -575,13 +666,18 @@ export function BenchmarkPage() {
           <ul>
             {agents.map((a) => (
               <AgentNode
-                key={a.agentId}
+                key={`${projectId}/${a.agentId}`}
                 projectId={projectId}
                 agentId={a.agentId}
                 name={agentDisplayName(a)}
                 defaultOpen={focusAgentId === null || focusAgentId === a.agentId}
                 selection={selection}
-                onSelect={setSelection}
+                restoreBenchmarkId={
+                  restoreSelection?.agentId === a.agentId ? restoreSelection.benchmarkId : null
+                }
+                onSelect={selectBenchmark}
+                onRestore={restoreBenchmark}
+                onRestoreMissing={forgetMissingBenchmark}
               />
             ))}
           </ul>

--- a/packages/web/src/features/benchmark/benchmark-selection.ts
+++ b/packages/web/src/features/benchmark/benchmark-selection.ts
@@ -1,0 +1,85 @@
+/**
+ * Evaluation Center selection cache (localStorage; one entry per "user × Project").
+ * Only stable ids are stored: the Benchmark summary is fetched again on restore so scores,
+ * titles, and case counts never come from stale browser data. Reads validate the complete
+ * shape and writes are best-effort for browsers that deny storage access.
+ */
+
+export interface BenchmarkSelectionRef {
+  agentId: string;
+  benchmarkId: string;
+}
+
+/** Minimal storage interface for pure Node tests and browsers with Web Storage. */
+export interface BenchmarkSelectionStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+/** Cache key scoped by account and Project, preventing another login from inheriting it. */
+export const benchmarkSelectionKey = (userId: string, projectId: string): string =>
+  `penguin.benchmarkSelection.${userId}.${projectId}`;
+
+/** Invalid or legacy data is ignored rather than preventing the Evaluation Center from loading. */
+export function parseBenchmarkSelection(raw: string | null): BenchmarkSelectionRef | null {
+  if (!raw) return null;
+  try {
+    const value: unknown = JSON.parse(raw);
+    if (typeof value !== "object" || value === null) return null;
+    const record = value as Record<string, unknown>;
+    if (
+      typeof record.agentId !== "string" ||
+      record.agentId === "" ||
+      typeof record.benchmarkId !== "string" ||
+      record.benchmarkId === ""
+    ) {
+      return null;
+    }
+    return { agentId: record.agentId, benchmarkId: record.benchmarkId };
+  } catch {
+    return null;
+  }
+}
+
+export function loadBenchmarkSelection(
+  key: string,
+  storage: BenchmarkSelectionStorage = localStorage,
+): BenchmarkSelectionRef | null {
+  try {
+    return parseBenchmarkSelection(storage.getItem(key));
+  } catch {
+    return null;
+  }
+}
+
+export function saveBenchmarkSelection(
+  key: string,
+  selection: BenchmarkSelectionRef,
+  storage: BenchmarkSelectionStorage = localStorage,
+): void {
+  try {
+    storage.setItem(key, JSON.stringify(selection));
+  } catch {
+    /* Storage can be unavailable under privacy restrictions; page state still works. */
+  }
+}
+
+/**
+ * Clears a stale remembered selection only if it is still the value the caller resolved.
+ * The equality check prevents a late Benchmark request from deleting a newer user choice.
+ */
+export function clearBenchmarkSelection(
+  key: string,
+  expected: BenchmarkSelectionRef,
+  storage: BenchmarkSelectionStorage = localStorage,
+): void {
+  try {
+    const current = parseBenchmarkSelection(storage.getItem(key));
+    if (current?.agentId === expected.agentId && current.benchmarkId === expected.benchmarkId) {
+      storage.removeItem(key);
+    }
+  } catch {
+    /* Best-effort cleanup only. */
+  }
+}

--- a/packages/web/src/features/benchmark/benchmark-selection.ts
+++ b/packages/web/src/features/benchmark/benchmark-selection.ts
@@ -44,10 +44,10 @@ export function parseBenchmarkSelection(raw: string | null): BenchmarkSelectionR
 
 export function loadBenchmarkSelection(
   key: string,
-  storage: BenchmarkSelectionStorage = localStorage,
+  storage?: BenchmarkSelectionStorage,
 ): BenchmarkSelectionRef | null {
   try {
-    return parseBenchmarkSelection(storage.getItem(key));
+    return parseBenchmarkSelection((storage ?? localStorage).getItem(key));
   } catch {
     return null;
   }
@@ -56,10 +56,10 @@ export function loadBenchmarkSelection(
 export function saveBenchmarkSelection(
   key: string,
   selection: BenchmarkSelectionRef,
-  storage: BenchmarkSelectionStorage = localStorage,
+  storage?: BenchmarkSelectionStorage,
 ): void {
   try {
-    storage.setItem(key, JSON.stringify(selection));
+    (storage ?? localStorage).setItem(key, JSON.stringify(selection));
   } catch {
     /* Storage can be unavailable under privacy restrictions; page state still works. */
   }
@@ -72,12 +72,13 @@ export function saveBenchmarkSelection(
 export function clearBenchmarkSelection(
   key: string,
   expected: BenchmarkSelectionRef,
-  storage: BenchmarkSelectionStorage = localStorage,
+  storage?: BenchmarkSelectionStorage,
 ): void {
   try {
-    const current = parseBenchmarkSelection(storage.getItem(key));
+    const target = storage ?? localStorage;
+    const current = parseBenchmarkSelection(target.getItem(key));
     if (current?.agentId === expected.agentId && current.benchmarkId === expected.benchmarkId) {
-      storage.removeItem(key);
+      target.removeItem(key);
     }
   } catch {
     /* Best-effort cleanup only. */

--- a/packages/web/test/benchmark-selection.test.ts
+++ b/packages/web/test/benchmark-selection.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+  benchmarkSelectionKey,
+  clearBenchmarkSelection,
+  loadBenchmarkSelection,
+  parseBenchmarkSelection,
+  saveBenchmarkSelection,
+} from "../src/features/benchmark/benchmark-selection";
+import type { BenchmarkSelectionStorage } from "../src/features/benchmark/benchmark-selection";
+
+function memoryStorage(): BenchmarkSelectionStorage & { values: Map<string, string> } {
+  const values = new Map<string, string>();
+  return {
+    values,
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, value),
+    removeItem: (key) => values.delete(key),
+  };
+}
+
+describe("Benchmark selection cache", () => {
+  it("round-trips stable ids and scopes them by user and Project", () => {
+    const storage = memoryStorage();
+    const a = benchmarkSelectionKey("user-a", "project-1");
+    const b = benchmarkSelectionKey("user-b", "project-1");
+    const c = benchmarkSelectionKey("user-a", "project-2");
+
+    saveBenchmarkSelection(a, { agentId: "agent-a", benchmarkId: "benchmark-a" }, storage);
+
+    expect(loadBenchmarkSelection(a, storage)).toEqual({
+      agentId: "agent-a",
+      benchmarkId: "benchmark-a",
+    });
+    expect(loadBenchmarkSelection(b, storage)).toBeNull();
+    expect(loadBenchmarkSelection(c, storage)).toBeNull();
+  });
+
+  it.each([
+    null,
+    "",
+    "not json",
+    "[]",
+    "{}",
+    '{"agentId":"agent-a"}',
+    '{"agentId":"","benchmarkId":"benchmark-a"}',
+    '{"agentId":"agent-a","benchmarkId":42}',
+  ])("drops malformed or incomplete data: %s", (raw) => {
+    expect(parseBenchmarkSelection(raw)).toBeNull();
+  });
+
+  it("clears a stale value without deleting a newer choice", () => {
+    const storage = memoryStorage();
+    const key = benchmarkSelectionKey("user-a", "project-1");
+    const stale = { agentId: "agent-a", benchmarkId: "old-benchmark" };
+    const current = { agentId: "agent-a", benchmarkId: "new-benchmark" };
+
+    saveBenchmarkSelection(key, stale, storage);
+    clearBenchmarkSelection(key, stale, storage);
+    expect(loadBenchmarkSelection(key, storage)).toBeNull();
+
+    saveBenchmarkSelection(key, current, storage);
+    clearBenchmarkSelection(key, stale, storage);
+    expect(loadBenchmarkSelection(key, storage)).toEqual(current);
+  });
+
+  it("degrades safely when browser storage is unavailable", () => {
+    const broken: BenchmarkSelectionStorage = {
+      getItem: () => {
+        throw new Error("SecurityError");
+      },
+      setItem: () => {
+        throw new Error("QuotaExceededError");
+      },
+      removeItem: () => {
+        throw new Error("SecurityError");
+      },
+    };
+    const key = benchmarkSelectionKey("user-a", "project-1");
+    const value = { agentId: "agent-a", benchmarkId: "benchmark-a" };
+
+    expect(loadBenchmarkSelection(key, broken)).toBeNull();
+    expect(() => saveBenchmarkSelection(key, value, broken)).not.toThrow();
+    expect(() => clearBenchmarkSelection(key, value, broken)).not.toThrow();
+  });
+});

--- a/packages/web/test/benchmark-selection.test.ts
+++ b/packages/web/test/benchmark-selection.test.ts
@@ -82,4 +82,15 @@ describe("Benchmark selection cache", () => {
     expect(() => saveBenchmarkSelection(key, value, broken)).not.toThrow();
     expect(() => clearBenchmarkSelection(key, value, broken)).not.toThrow();
   });
+
+  it("degrades safely when the default localStorage global is unavailable", () => {
+    const key = benchmarkSelectionKey("user-a", "project-1");
+    const value = { agentId: "agent-a", benchmarkId: "benchmark-a" };
+
+    // Vitest runs in Node without a localStorage global. Resolving the default inside each try
+    // keeps that ReferenceError on the same best-effort path as browser SecurityErrors.
+    expect(loadBenchmarkSelection(key)).toBeNull();
+    expect(() => saveBenchmarkSelection(key, value)).not.toThrow();
+    expect(() => clearBenchmarkSelection(key, value)).not.toThrow();
+  });
 });


### PR DESCRIPTION
## Summary

- remember the selected Agent and Benchmark per user and Project
- resolve remembered ids against fresh Benchmark data and ignore invalid or stale browser storage
- preserve the existing `?agentId=` deep-link behavior and reset lazy Agent data across Projects
- add unit and browser regression coverage for the Evaluation Center → Session trace → Evaluation Center flow

Closes #181

## Root cause

`BenchmarkPage` kept its selection only in component state. Opening a Run's Session trace unmounted the page, and the sidebar returned to bare `/benchmark`, so the selection was recreated as `null`.

## Validation

- `pnpm build`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm --filter @prismshadow/penguin-web test` — 595 passed
- Playwright `packages/web/e2e/benchmark.spec.mjs` — 2 passed

## Existing suite notes

- `pnpm test` reaches two pre-existing `packages/landing/test/blog.test.ts` failures: `main` contains the 0.2.1 blog post while those assertions still expect 14 posts and omit its slug.
- The complete Web E2E suite also reached two unrelated existing test failures; the new regression passes independently.
