### PR TITLE
test(landing): account for the 0.2.1 release post in blog fixtures

### DIFF
--- a/packages/landing/test/blog.test.ts
+++ b/packages/landing/test/blog.test.ts
@@ -96,7 +96,7 @@ describe("frontmatter mapping (author / pinned / category)", () => {
   it("reads the pinned flag and sorts the pinned post first", () => {
     for (const locale of ["en", "zh"] as const) {
       const posts = postsFor(locale);
-      expect(posts.length).toBe(14);
+      expect(posts.length).toBe(15);
       // The launch post stays the single pinned post; newer posts sort under it by date.
       expect(posts.filter((p) => p.pinned).map((p) => p.slug)).toEqual([
         "introducing-penguinharness",
@@ -120,6 +120,7 @@ describe("frontmatter mapping (author / pinned / category)", () => {
   it("filters by the news category, newest first", () => {
     expect(postsFor("en", "news").map((p) => p.slug)).toEqual([
       "introducing-penguinharness",
+      "penguinharness-0-2-1",
       "penguinharness-0-2-0",
       "penguinharness-0-1-5",
       "penguinharness-0-1-4",


### PR DESCRIPTION
## Summary

The 0.2.1 release post (#207) added a 15th blog post but left `packages/landing/test/blog.test.ts` asserting 14 posts and the old news listing, so `pnpm test` (and with it the CI workflow) has been failing on every push to main since. This updates the expected post count to 15 and inserts `penguinharness-0-2-1` into the expected news ordering (pinned launch post first, then newest first).

## Verification

- `vitest run` in `packages/landing`: 39/39 tests pass (was 37 passed / 2 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAw5N2Vt7x44zgn2T8MDzL