### PR TITLE
feat(core): wire MCP servers into Environment via adapter layer

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,6 +40,7 @@
     "build": "tsup"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
     "@prismshadow/agenthub": "^0.4.1",
     "@prismshadow/penguin-skills": "workspace:*",
     "smol-toml": "^1.3.0",

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -711,7 +711,7 @@ export class Agent {
     // into command subprocesses (shared by createSession and resumeSession; the
     // caller reads the current agent_state/.vault.toml); a child Agent loads **its
     // own** vault via createAgent rather than inheriting the parent's.
-    const environment = new Environment({
+    const environment = await Environment.create({
       workspaceDir,
       toolConfig,
       // The Session's generic scratchpad root; Environment derives its truncated-tool-output

--- a/packages/core/src/environment/environment.ts
+++ b/packages/core/src/environment/environment.ts
@@ -36,6 +36,7 @@ import type {
 } from "../interfaces.js";
 import type { BuiltinTool, ToolResult } from "./tools/types.js";
 import { BUILTIN_TOOL_FACTORIES } from "./tools/registry.js";
+import { McpToolAdapter } from "./mcp/client.js";
 import { CommandSessionManager } from "./tools/command/index.js";
 import { SubagentSessionManager } from "./tools/subagent/index.js";
 import {
@@ -93,6 +94,8 @@ export class Environment implements EnvironmentInterface {
   private readonly truncatedToolOutputArchive: TruncatedToolOutputArchive | null;
   /** Assembled built-in tools: tool name -> BuiltinTool. Only tools supported by the registry and present in config. */
   private readonly tools: Map<string, BuiltinTool>;
+  /** MCP adapter (connects declared mcpServers, exposes their tools as BuiltinTool). Null when none configured. */
+  private mcpAdapter: McpToolAdapter | null = null;
   /** Long-running command session registry: constructed within this Environment and shared between exec_command / input_command. */
   private readonly commandSessions: CommandSessionManager;
   /** Background subagent session registry: constructed within this Environment and shared between run_subagent / input_subagent. */
@@ -128,10 +131,35 @@ export class Environment implements EnvironmentInterface {
     }
   }
 
+  /**
+   * Async factory: connects any declared MCP servers before the Environment is usable. The
+   * constructor stays synchronous (callers that don't configure mcpServers can keep using it),
+   * but when mcpServers is non-empty you MUST use create() so the adapter can connect.
+   */
+  static async create(config: EnvironmentConfig): Promise<Environment> {
+    const env = new Environment(config);
+    const servers = config.toolConfig.mcpServers ?? [];
+    if (servers.length > 0) {
+      const adapter = new McpToolAdapter(servers);
+      await adapter.init();
+      env.mcpAdapter = adapter;
+      const services = {
+        ...config.services,
+        commandSessions: env.commandSessions,
+        subagentSessions: env.subagentSessions,
+      };
+      for (const def of adapter.listToolDefinitions()) {
+        env.tools.set(def.name, adapter.toBuiltinTool(def));
+      }
+    }
+    return env;
+  }
+
   /** Releases runtime resources held by Environment: finalizes all managed background sessions (command and subagent). Idempotent. */
   dispose(): void {
     this.commandSessions.dispose();
     this.subagentSessions.dispose();
+    this.mcpAdapter?.dispose();
   }
 
   /**
@@ -147,13 +175,16 @@ export class Environment implements EnvironmentInterface {
    * is left to a later adapter layer.
    */
   async listTools(): Promise<ToolDefinition[]> {
-    return this.toolConfig.customTools
+    const builtins = this.toolConfig.customTools
       .filter((tool) => this.tools.has(tool.name))
       .map((tool) => ({
         name: tool.name,
         description: tool.description,
         ...(tool.parameters !== undefined ? { parameters: tool.parameters } : {}),
       }));
+    // Merge in enumerated MCP tool definitions (the "later adapter layer").
+    const mcp = this.mcpAdapter ? this.mcpAdapter.listToolDefinitions() : [];
+    return [...builtins, ...mcp];
   }
 
   /** Looks up a tool's permission level (for the frontend's permission-mode decisions); returns undefined for an unknown tool. */

--- a/packages/core/src/environment/mcp/client.ts
+++ b/packages/core/src/environment/mcp/client.ts
@@ -1,0 +1,181 @@
+/**
+ * MCP adapter — connects declared MCP servers and exposes their tools as PenguinHarness
+ * BuiltinTool instances. This is the "later adapter layer" referenced in environment.ts and the
+ * docs (tools.en.md / configuration.en.md: "enumerating concrete MCP tools is reserved for a
+ * later adapter layer").
+ *
+ * Design: keep MCP entirely behind this module. Environment only knows about BuiltinTool, so we
+ * wrap each enumerated MCP tool in a BuiltinTool whose execute() delegates to the connected
+ * client. Tool names are namespaced as `mcp__<serverName>__<toolName>` to avoid collisions.
+ *
+ * Depends on @modelcontextprotocol/sdk — add it to packages/core/package.json:
+ *   "dependencies": { "@modelcontextprotocol/sdk": "^1.x" }
+ */
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import { partialToolCallOutput } from "../../omnimessage/index.js";
+import type { OmniMessage } from "../../omnimessage/index.js";
+import type { MCPServerConfig, ToolDefinition, ToolDefinitionConfig } from "../../interfaces.js";
+import type { BuiltinTool, ToolExecutionContext, ToolResult } from "../tools/types.js";
+
+const MCP_NAME_PREFIX = "mcp__";
+
+interface McpToolEntry {
+  serverName: string;
+  originalName: string;
+  client: Client;
+  definition: ToolDefinitionConfig;
+}
+
+/**
+ * Parse the free-form MCPServerConfig.config into a concrete transport.
+ * Expected shapes:
+ *   stdio: { command: string, args?: string[], env?: Record<string,string>, cwd?: string }
+ *   sse:   { url: string, headers?: Record<string,string> }
+ */
+function buildTransport(serverName: string, cfg: Record<string, unknown>): StdioClientTransport | SSEClientTransport {
+  if (typeof cfg.command === "string") {
+    return new StdioClientTransport({
+      command: cfg.command,
+      args: Array.isArray(cfg.args) ? (cfg.args as string[]) : undefined,
+      env: (cfg.env as Record<string, string> | undefined) ?? undefined,
+      cwd: typeof cfg.cwd === "string" ? cfg.cwd : undefined,
+      // Carry the server name so the connected Client can self-identify (used by init() to
+      // map enumerated tools back to their originating server).
+      ...{ config: { serverName } },
+    });
+  }
+  if (typeof cfg.url === "string") {
+    const headers = (cfg.headers as Record<string, string> | undefined) ?? undefined;
+    return new SSEClientTransport(
+      new URL(cfg.url),
+      headers ? { requestInit: { headers } } : {},
+    );
+  }
+  throw new Error(
+    `MCP server config must specify either "command" (stdio) or "url" (sse); got: ${JSON.stringify(cfg)}`,
+  );
+}
+
+export class McpToolAdapter {
+  private readonly servers: MCPServerConfig[];
+  private readonly clients = new Map<string, Client>();
+  private readonly entries: McpToolEntry[] = [];
+
+  constructor(servers: MCPServerConfig[]) {
+    this.servers = servers;
+  }
+
+  /** Connect every declared server and enumerate its tools. Per-server failures are isolated. */
+  async init(): Promise<void> {
+    for (const server of this.servers) {
+      try {
+        const client = new Client({ name: "penguin-harness", version: "0.2.1" });
+        await client.connect(buildTransport(server.name, server.config));
+        this.clients.set(server.name, client);
+        const { tools } = await client.listTools();
+        for (const tool of tools) {
+          const namespaced = `${MCP_NAME_PREFIX}${server.name}__${tool.name}`;
+          const definition: ToolDefinitionConfig = {
+            name: namespaced,
+            description: tool.description ?? `MCP tool ${tool.name} from ${server.name}`,
+            // MCP inputSchema IS JSON Schema; ToolDefinitionConfig.parameters is an open Record,
+            // so it drops straight in with no conversion layer.
+            parameters: tool.inputSchema as Record<string, unknown>,
+            permission: "rw",
+          };
+          this.entries.push({
+            serverName: server.name,
+            originalName: tool.name,
+            client,
+            definition,
+          });
+        }
+      } catch (err) {
+        process.stderr.write(
+          `[penguin] MCP server "${server.name}" failed to connect: ${
+            err instanceof Error ? err.message : String(err)
+          }\n`,
+        );
+      }
+    }
+  }
+
+  /** Tool definitions (namespaced) for Environment.listTools(). */
+  listToolDefinitions(): ToolDefinition[] {
+    return this.entries.map((e) => ({
+      name: e.definition.name,
+      description: e.definition.description,
+      ...(e.definition.parameters !== undefined ? { parameters: e.definition.parameters } : {}),
+    }));
+  }
+
+  /** Wrap a namespaced MCP tool as a BuiltinTool delegating to the connected client. */
+  toBuiltinTool(def: ToolDefinitionConfig): BuiltinTool {
+    const entry = this.entries.find((e) => e.definition.name === def.name);
+    if (!entry) throw new Error(`MCP tool not found: ${def.name}`);
+    return {
+      name: def.name,
+      definition: def,
+      execute: (args, ctx) => this.execute(entry, args, ctx),
+    };
+  }
+
+  private async *execute(
+    entry: McpToolEntry,
+    args: Record<string, unknown>,
+    ctx: ToolExecutionContext,
+  ): AsyncGenerator<OmniMessage, ToolResult | void> {
+    try {
+      // NOTE: signal forwarding to the SDK call is a follow-up; the surrounding Environment
+      // still enforces timeout/abort on the tool stream.
+      const result = await entry.client.callTool({
+        name: entry.originalName,
+        arguments: args,
+      });
+      const images: string[] = [];
+      let text = "";
+      const blocks = (result.content ?? []) as Array<{
+        type: string;
+        text?: string;
+        data?: string;
+        mimeType?: string;
+      }>;
+      for (const block of blocks) {
+        if (block.type === "text" && block.text) {
+          text += block.text;
+          yield partialToolCallOutput({
+            eventType: "delta",
+            output: block.text,
+            toolCallId: ctx.toolCallId,
+          });
+        } else if (block.type === "image" && block.data) {
+          const mime = block.mimeType ?? "image/png";
+          images.push(`data:${mime};base64,${block.data}`);
+        }
+      }
+      if (result.isError) {
+        return { stopReason: "failed", note: text ? undefined : "[MCP tool returned error]" };
+      }
+      return images.length > 0 ? { images } : undefined;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      yield partialToolCallOutput({
+        eventType: "delta",
+        output: `[MCP tool error] ${message}`,
+        toolCallId: ctx.toolCallId,
+      });
+      return { stopReason: "failed" };
+    }
+  }
+
+  /** Close all connected clients. Idempotent. */
+  dispose(): void {
+    for (const client of this.clients.values()) {
+      client.close().catch(() => {});
+    }
+    this.clients.clear();
+    this.entries.length = 0;
+  }
+}

--- a/packages/core/src/environment/mcp/client.ts
+++ b/packages/core/src/environment/mcp/client.ts
@@ -13,6 +13,7 @@
  */
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import type { StdioServerParameters } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { partialToolCallOutput } from "../../omnimessage/index.js";
 import type { OmniMessage } from "../../omnimessage/index.js";
@@ -41,9 +42,9 @@ function buildTransport(serverName: string, cfg: Record<string, unknown>): Stdio
       args: Array.isArray(cfg.args) ? (cfg.args as string[]) : undefined,
       env: (cfg.env as Record<string, string> | undefined) ?? undefined,
       cwd: typeof cfg.cwd === "string" ? cfg.cwd : undefined,
-      // Carry the server name so the connected Client can self-identify (used by init() to
-      // map enumerated tools back to their originating server).
-      ...{ config: { serverName } },
+      // Carry the server name on the transport so the connected Client can self-identify
+      // (used by the mock Client in tests, ignored by the real SDK's StdioClientTransport).
+      ...{ config: { serverName } } as Partial<StdioServerParameters>,
     });
   }
   if (typeof cfg.url === "string") {
@@ -128,12 +129,18 @@ export class McpToolAdapter {
     ctx: ToolExecutionContext,
   ): AsyncGenerator<OmniMessage, ToolResult | void> {
     try {
-      // NOTE: signal forwarding to the SDK call is a follow-up; the surrounding Environment
-      // still enforces timeout/abort on the tool stream.
-      const result = await entry.client.callTool({
-        name: entry.originalName,
-        arguments: args,
-      });
+      // Forward the caller's abort signal into the MCP call so user-interrupt / timeout
+      // cancels an in-flight request to the server (not just the surrounding stream).
+      const options: { signal?: AbortSignal } = {};
+      if (ctx.signal) options.signal = ctx.signal;
+      const result = await entry.client.callTool(
+        {
+          name: entry.originalName,
+          arguments: args,
+        },
+        undefined,
+        options,
+      );
       const images: string[] = [];
       let text = "";
       const blocks = (result.content ?? []) as Array<{

--- a/packages/core/test/fixtures/echo-mcp-server.mjs
+++ b/packages/core/test/fixtures/echo-mcp-server.mjs
@@ -1,0 +1,40 @@
+// Minimal real MCP server (stdio) for the penguin-core MCP adapter e2e test.
+// Exposes one tool `echo` that returns its input text. Uses the real @modelcontextprotocol/sdk.
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { ListToolsRequestSchema, CallToolRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+const server = new Server(
+  { name: "echo-mcp-server", version: "0.0.1" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(
+  ListToolsRequestSchema,
+  async () => ({
+    tools: [
+      {
+        name: "echo",
+        description: "Echo back the provided text.",
+        inputSchema: {
+          type: "object",
+          properties: { text: { type: "string", description: "Text to echo" } },
+          required: ["text"],
+        },
+      },
+    ],
+  }),
+);
+
+server.setRequestHandler(
+  CallToolRequestSchema,
+  async (request) => {
+    const text = (request.params?.arguments?.text ?? "").toString();
+    return {
+      content: [{ type: "text", text: `echo: ${text}` }],
+    };
+  },
+);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/packages/core/test/mcp-client.test.ts
+++ b/packages/core/test/mcp-client.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Unit test for McpToolAdapter. The real @modelcontextprotocol/sdk Client + StdioClientTransport
+ * are mocked so the test exercises OUR wiring (server connection, tool enumeration, namespacing,
+ * BuiltinTool delegation, inputSchema passthrough, per-server fault isolation) without spawning
+ * a process. The mock transport preserves all options (incl. the serverName we thread through),
+ * which is what the mock Client uses to resolve its tool list.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Per-server tool registries the mock Client will return from listTools().
+const listToolsByServer = new Map<string, { name: string; description?: string; inputSchema?: unknown }[]>();
+const callToolResults = new Map<string, unknown>();
+const connectFailures = new Set<string>();
+
+vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+  // Mock transport: expose every option as an own property (incl. the serverName threaded
+  // via buildTransport's `config` field) so the mock Client can recover it.
+  StdioClientTransport: class {
+    constructor(opts: Record<string, unknown>) {
+      Object.assign(this, opts);
+    }
+  },
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => {
+  return {
+    Client: class {
+      serverName = "";
+      opts: Record<string, unknown>;
+      constructor(_opts: unknown) {
+        this.opts = {};
+      }
+      async connect(transport: { config?: { serverName?: string } }) {
+        const name = transport?.config?.serverName ?? "";
+        this.serverName = name;
+        if (connectFailures.has(name)) throw new Error(`connect failed: ${name}`);
+      }
+      async listTools() {
+        return { tools: listToolsByServer.get(this.serverName) ?? [] };
+      }
+      async callTool(req: { name: string }) {
+        return (
+          callToolResults.get(req.name) ?? {
+            content: [{ type: "text", text: `mock output for ${req.name}` }],
+          }
+        );
+      }
+      close() {
+        return Promise.resolve();
+      }
+    },
+  };
+});
+
+import { McpToolAdapter } from "../src/environment/mcp/client.js";
+import type { MCPServerConfig } from "../src/interfaces.js";
+
+function makeServers(): MCPServerConfig[] {
+  return [
+    {
+      name: "fs",
+      config: { command: "npx", args: ["-y", "@modelcontextprotocol/server-filesystem", "."] },
+    },
+    {
+      name: "git",
+      config: { command: "npx", args: ["-y", "@modelcontextprotocol/server-git"] },
+    },
+  ];
+}
+
+describe("McpToolAdapter", () => {
+  beforeEach(() => {
+    callToolResults.clear();
+    listToolsByServer.clear();
+    connectFailures.clear();
+    listToolsByServer.set("fs", [
+      { name: "read_file", description: "Read a file", inputSchema: { type: "object", properties: { path: { type: "string" } } } },
+      { name: "write_file", description: "Write a file", inputSchema: { type: "object" } },
+    ]);
+    listToolsByServer.set("git", [
+      { name: "status", description: "Git status", inputSchema: { type: "object" } },
+    ]);
+  });
+
+  it("enumerates tools namespaced across servers and passes inputSchema through", async () => {
+    const adapter = new McpToolAdapter(makeServers());
+    await adapter.init();
+    const defs = adapter.listToolDefinitions();
+    const names = defs.map((d) => d.name).sort();
+    expect(names).toEqual(["mcp__fs__read_file", "mcp__fs__write_file", "mcp__git__status"]);
+
+    const readFile = defs.find((d) => d.name === "mcp__fs__read_file")!;
+    // inputSchema (JSON Schema) must pass straight through into parameters with no conversion.
+    expect(readFile.parameters).toEqual({ type: "object", properties: { path: { type: "string" } } });
+  });
+
+  it("wraps an MCP tool as a BuiltinTool and delegates execute -> callTool", async () => {
+    callToolResults.set("read_file", {
+      content: [{ type: "text", text: "file contents here" }],
+    });
+    const adapter = new McpToolAdapter(makeServers());
+    await adapter.init();
+    const def = adapter.listToolDefinitions().find((d) => d.name === "mcp__fs__read_file")!;
+    const tool = adapter.toBuiltinTool(def);
+    expect(tool.name).toBe("mcp__fs__read_file");
+
+    const chunks: string[] = [];
+    const gen = tool.execute({ path: "/x" }, { toolCallId: "tc2", signal: undefined, workspaceDir: "/tmp" });
+    for await (const m of gen) {
+      const p = m as { payload?: { type?: string; event_type?: string; output?: string } };
+      if (p.payload?.type === "partial_tool_call_output" && p.payload.event_type === "delta") {
+        chunks.push(p.payload.output ?? "");
+      }
+    }
+    expect(chunks.join("")).toBe("file contents here");
+  });
+
+  it("isolates a failing server instead of crashing the whole Environment", async () => {
+    connectFailures.add("git");
+    const adapter = new McpToolAdapter(makeServers());
+    await adapter.init(); // should not throw
+    const names = adapter.listToolDefinitions().map((d) => d.name).sort();
+    expect(names).toEqual(["mcp__fs__read_file", "mcp__fs__write_file"]);
+  });
+});

--- a/packages/core/test/mcp-e2e.mts
+++ b/packages/core/test/mcp-e2e.mts
@@ -40,8 +40,10 @@ if (!names.includes("mcp__echo__echo")) {
 }
 
 // 2) executeTool should route to the real MCP server and stream its output.
-const request = {
+const request: any = {
   toolCall: {
+    timestamp: new Date().toISOString(),
+    type: "tool_call",
     payload: {
       tool_call_id: "tc-e2e",
       name: "mcp__echo__echo",

--- a/packages/core/test/mcp-e2e.mts
+++ b/packages/core/test/mcp-e2e.mts
@@ -1,0 +1,77 @@
+/**
+ * Real end-to-end check for the MCP adapter: spins up an actual stdio MCP server
+ * (test/fixtures/echo-mcp-server.mjs) and drives it through the real penguin-core
+ * Environment.create -> listTools -> executeTool pipeline. No mocking.
+ *
+ * Run with: npx tsx test/mcp-e2e.mts   (from packages/core)
+ */
+import { Environment } from "../src/environment/environment.js";
+import type { MCPServerConfig, ToolDefinitionConfig } from "../src/interfaces.js";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const serverPath = path.join(here, "fixtures", "echo-mcp-server.mjs");
+
+const mcpServer: MCPServerConfig = {
+  name: "echo",
+  config: { command: process.execPath, args: [serverPath] },
+};
+
+const toolConfig = {
+  customTools: [] as ToolDefinitionConfig[],
+  mcpServers: [mcpServer],
+};
+
+const config = {
+  workspaceDir: here,
+  toolConfig,
+  sessionScratchpadDir: path.join(here, ".mcp-e2e-scratch"),
+};
+
+const env = await Environment.create(config);
+
+// 1) listTools should surface the namespaced MCP tool.
+const tools = await env.listTools();
+const names = tools.map((t) => t.name);
+console.log("[e2e] listed tools:", JSON.stringify(names));
+if (!names.includes("mcp__echo__echo")) {
+  throw new Error(`expected mcp__echo__echo in ${JSON.stringify(names)}`);
+}
+
+// 2) executeTool should route to the real MCP server and stream its output.
+const request = {
+  toolCall: {
+    payload: {
+      tool_call_id: "tc-e2e",
+      name: "mcp__echo__echo",
+      arguments: JSON.stringify({ text: "hello from penguin" }),
+    },
+  },
+  signal: undefined,
+};
+
+let streamed = "";
+let stopReason = "";
+for await (const msg of env.executeTool(request)) {
+  const p = (msg as { payload?: { type?: string; event_type?: string; output?: string; stop_reason?: string } })
+    .payload;
+  if (p?.type === "partial_tool_call_output" && p.event_type === "delta") {
+    streamed += p.output ?? "";
+  }
+  if (p?.type === "partial_tool_call_output" && p.event_type === "stop") {
+    stopReason = p.stop_reason ?? "";
+  }
+}
+console.log("[e2e] streamed output:", JSON.stringify(streamed));
+console.log("[e2e] stop_reason:", stopReason);
+
+if (!streamed.includes("echo: hello from penguin")) {
+  throw new Error(`MCP tool did not return expected echo; got: ${JSON.stringify(streamed)}`);
+}
+if (stopReason !== "completed") {
+  throw new Error(`expected completed, got ${stopReason}`);
+}
+
+env.dispose();
+console.log("[e2e] PASS: real MCP server reachable through Environment adapter");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,10 +15,10 @@ importers:
     devDependencies:
       '@prismshadow/penguin-cli':
         specifier: workspace:*
-        version: file:packages/cli(supports-color@10.2.2)
+        version: file:packages/cli(supports-color@10.2.2)(zod@4.4.3)
       '@prismshadow/penguin-core':
         specifier: workspace:*
-        version: file:packages/core(supports-color@10.2.2)(ws@8.21.0)
+        version: file:packages/core(supports-color@10.2.2)(ws@8.21.0)(zod@4.4.3)
       '@types/node':
         specifier: ^24.0.0
         version: 24.13.3
@@ -42,13 +42,13 @@ importers:
     dependencies:
       '@prismshadow/agenthub':
         specifier: ^0.4.1
-        version: 0.4.1(supports-color@10.2.2)(ws@8.21.0)
+        version: 0.4.1(@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.21.0)(zod@4.4.3)
       '@prismshadow/penguin-core':
         specifier: workspace:*
         version: link:../core
       '@prismshadow/penguin-server':
         specifier: workspace:*
-        version: file:packages/server(supports-color@10.2.2)(ws@8.21.0)
+        version: file:packages/server(supports-color@10.2.2)(ws@8.21.0)(zod@4.4.3)
       '@prismshadow/penguin-skills':
         specifier: workspace:*
         version: link:../skills
@@ -83,9 +83,12 @@ importers:
 
   packages/core:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.0.0
+        version: 1.30.0(supports-color@10.2.2)(zod@4.4.3)
       '@prismshadow/agenthub':
         specifier: ^0.4.1
-        version: 0.4.1(supports-color@10.2.2)(ws@8.21.0)
+        version: 0.4.1(@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.21.0)(zod@4.4.3)
       '@prismshadow/penguin-skills':
         specifier: workspace:*
         version: link:../skills
@@ -116,7 +119,7 @@ importers:
     dependencies:
       '@prismshadow/penguin-core':
         specifier: workspace:*
-        version: file:packages/core(supports-color@10.2.2)(ws@8.21.0)
+        version: file:packages/core(supports-color@10.2.2)(ws@8.21.0)(zod@4.4.3)
       '@prismshadow/penguin-server':
         specifier: workspace:*
         version: link:../server
@@ -245,7 +248,7 @@ importers:
         version: 2.0.12(hono@4.12.34)
       '@prismshadow/penguin-core':
         specifier: workspace:*
-        version: file:packages/core(supports-color@10.2.2)(ws@8.21.0)
+        version: file:packages/core(supports-color@10.2.2)(ws@8.21.0)(zod@4.4.3)
       '@prismshadow/penguin-skills':
         specifier: workspace:*
         version: link:../skills
@@ -303,7 +306,7 @@ importers:
     dependencies:
       '@prismshadow/penguin-core':
         specifier: workspace:*
-        version: file:packages/core(supports-color@10.2.2)(ws@8.21.0)
+        version: file:packages/core(supports-color@10.2.2)(ws@8.21.0)(zod@4.4.3)
       react:
         specifier: ^19.1.0
         version: 19.2.7
@@ -828,6 +831,16 @@ packages:
   '@malept/flatpak-bundler@0.4.0':
     resolution: {integrity: sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==}
     engines: {node: '>= 10.0.0'}
+
+  '@modelcontextprotocol/sdk@1.30.0':
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@noble/hashes@1.4.0':
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
@@ -1456,6 +1469,10 @@ packages:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn@8.17.0:
     resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
     engines: {node: '>=0.4.0'}
@@ -1464,6 +1481,14 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
 
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
@@ -1555,6 +1580,10 @@ packages:
   body-parser@1.20.6:
     resolution: {integrity: sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
 
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
@@ -1743,9 +1772,17 @@ packages:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -1756,12 +1793,20 @@ packages:
   cookie-signature@1.0.7:
     resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
 
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cross-dirname@0.1.0:
     resolution: {integrity: sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==}
@@ -1986,6 +2031,14 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -1993,9 +2046,19 @@ packages:
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
 
+  express-rate-limit@8.6.2:
+    resolution: {integrity: sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
   express@4.22.2:
     resolution: {integrity: sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==}
     engines: {node: '>= 0.10.0'}
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -2036,6 +2099,10 @@ packages:
     resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
     engines: {node: '>= 0.8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   fix-dts-default-cjs-exports@1.0.1:
     resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
@@ -2054,6 +2121,10 @@ packages:
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
@@ -2238,6 +2309,10 @@ packages:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
 
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
+
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
@@ -2247,6 +2322,10 @@ packages:
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  ip-address@10.4.0:
+    resolution: {integrity: sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==}
+    engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -2271,6 +2350,9 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
@@ -2303,6 +2385,9 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  jose@6.2.8:
+    resolution: {integrity: sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==}
+
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
@@ -2334,6 +2419,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
@@ -2532,8 +2620,16 @@ packages:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
+  media-typer@1.1.1:
+    resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
+    engines: {node: '>= 0.8'}
+
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
@@ -2627,9 +2723,17 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
@@ -2698,6 +2802,10 @@ packages:
 
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
   node-abi@4.33.0:
@@ -2810,6 +2918,9 @@ packages:
   path-to-regexp@0.1.13:
     resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
 
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -2831,6 +2942,10 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -2940,6 +3055,10 @@ packages:
     resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
     engines: {node: '>= 0.8'}
 
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
+
   react-dom@19.2.7:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
     peerDependencies:
@@ -3048,6 +3167,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
@@ -3095,6 +3218,10 @@ packages:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serialize-error@7.0.1:
     resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
     engines: {node: '>=10'}
@@ -3102,6 +3229,10 @@ packages:
   serve-static@1.16.3:
     resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
     engines: {node: '>= 0.8.0'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -3355,6 +3486,10 @@ packages:
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -3610,14 +3745,22 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
-  '@anthropic-ai/bedrock-sdk@0.26.4':
+  '@anthropic-ai/bedrock-sdk@0.26.4(zod@4.4.3)':
     dependencies:
-      '@anthropic-ai/sdk': 0.91.1
+      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-crypto/sha256-js': 4.0.0
       '@aws-sdk/client-bedrock-runtime': 3.1068.0
       '@aws-sdk/credential-providers': 3.1068.0
@@ -3631,9 +3774,11 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  '@anthropic-ai/sdk@0.91.1':
+  '@anthropic-ai/sdk@0.91.1(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.4.3
 
   '@aws-crypto/crc32@3.0.0':
     dependencies:
@@ -4213,12 +4358,14 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@google/genai@1.52.0(supports-color@10.2.2)':
+  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)':
     dependencies:
       google-auth-library: 10.7.0(supports-color@10.2.2)
       p-retry: 4.6.2
       protobufjs: 7.6.5
       ws: 8.21.0
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.30.0(supports-color@10.2.2)(zod@4.4.3)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -4264,6 +4411,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 2.0.12(hono@4.12.34)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1(supports-color@10.2.2)
+      express-rate-limit: 8.6.2(express@5.2.1(supports-color@10.2.2))(supports-color@10.2.2)
+      hono: 4.12.34
+      jose: 6.2.8
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
+
   '@noble/hashes@1.4.0': {}
 
   '@noble/hashes@2.2.0': {}
@@ -4296,13 +4465,13 @@ snapshots:
     dependencies:
       playwright: 1.61.1
 
-  '@prismshadow/agenthub@0.4.1(supports-color@10.2.2)(ws@8.21.0)':
+  '@prismshadow/agenthub@0.4.1(@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.21.0)(zod@4.4.3)':
     dependencies:
-      '@anthropic-ai/bedrock-sdk': 0.26.4
-      '@anthropic-ai/sdk': 0.91.1
-      '@google/genai': 1.52.0(supports-color@10.2.2)
+      '@anthropic-ai/bedrock-sdk': 0.26.4(zod@4.4.3)
+      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
+      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)
       express: 4.22.2(supports-color@10.2.2)
-      openai: 6.42.0(ws@8.21.0)
+      openai: 6.42.0(ws@8.21.0)(zod@4.4.3)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - bufferutil
@@ -4311,17 +4480,18 @@ snapshots:
       - ws
       - zod
 
-  '@prismshadow/penguin-cli@file:packages/cli(supports-color@10.2.2)':
+  '@prismshadow/penguin-cli@file:packages/cli(supports-color@10.2.2)(zod@4.4.3)':
     dependencies:
-      '@prismshadow/agenthub': 0.4.1(supports-color@10.2.2)(ws@8.21.0)
-      '@prismshadow/penguin-core': file:packages/core(supports-color@10.2.2)(ws@8.21.0)
-      '@prismshadow/penguin-server': file:packages/server(supports-color@10.2.2)(ws@8.21.0)
+      '@prismshadow/agenthub': 0.4.1(@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.21.0)(zod@4.4.3)
+      '@prismshadow/penguin-core': file:packages/core(supports-color@10.2.2)(ws@8.21.0)(zod@4.4.3)
+      '@prismshadow/penguin-server': file:packages/server(supports-color@10.2.2)(ws@8.21.0)(zod@4.4.3)
       '@prismshadow/penguin-skills': file:packages/skills
       commander: 13.1.0
       dotenv: 17.4.2
       smol-toml: 1.6.1
       yaml: 2.9.0
     transitivePeerDependencies:
+      - '@cfworker/json-schema'
       - '@modelcontextprotocol/sdk'
       - bufferutil
       - supports-color
@@ -4329,24 +4499,25 @@ snapshots:
       - ws
       - zod
 
-  '@prismshadow/penguin-core@file:packages/core(supports-color@10.2.2)(ws@8.21.0)':
+  '@prismshadow/penguin-core@file:packages/core(supports-color@10.2.2)(ws@8.21.0)(zod@4.4.3)':
     dependencies:
-      '@prismshadow/agenthub': 0.4.1(supports-color@10.2.2)(ws@8.21.0)
+      '@modelcontextprotocol/sdk': 1.30.0(supports-color@10.2.2)(zod@4.4.3)
+      '@prismshadow/agenthub': 0.4.1(@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.21.0)(zod@4.4.3)
       '@prismshadow/penguin-skills': file:packages/skills
       smol-toml: 1.6.1
       yaml: 2.9.0
     transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
+      - '@cfworker/json-schema'
       - bufferutil
       - supports-color
       - utf-8-validate
       - ws
       - zod
 
-  '@prismshadow/penguin-server@file:packages/server(supports-color@10.2.2)(ws@8.21.0)':
+  '@prismshadow/penguin-server@file:packages/server(supports-color@10.2.2)(ws@8.21.0)(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 2.0.12(hono@4.12.34)
-      '@prismshadow/penguin-core': file:packages/core(supports-color@10.2.2)(ws@8.21.0)
+      '@prismshadow/penguin-core': file:packages/core(supports-color@10.2.2)(ws@8.21.0)(zod@4.4.3)
       '@prismshadow/penguin-skills': file:packages/skills
       dotenv: 17.4.2
       fflate: 0.8.3
@@ -4355,7 +4526,7 @@ snapshots:
       tar: 7.5.22
       yaml: 2.9.0
     transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
+      - '@cfworker/json-schema'
       - bufferutil
       - supports-color
       - utf-8-validate
@@ -4958,9 +5129,18 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn@8.17.0: {}
 
   agent-base@7.1.4: {}
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
 
   ajv@8.20.0:
     dependencies:
@@ -5081,6 +5261,20 @@ snapshots:
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  body-parser@2.3.0(supports-color@10.2.2):
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3(supports-color@10.2.2)
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.15.2
+      raw-body: 3.0.2
+      type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -5272,7 +5466,11 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  content-disposition@1.1.0: {}
+
   content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
 
   convert-source-map@2.0.0: {}
 
@@ -5280,9 +5478,16 @@ snapshots:
 
   cookie-signature@1.0.7: {}
 
+  cookie-signature@1.2.2: {}
+
   cookie@0.7.2: {}
 
   core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cross-dirname@0.1.0:
     optional: true
@@ -5545,9 +5750,23 @@ snapshots:
 
   etag@1.8.1: {}
 
+  eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
+
   expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
+
+  express-rate-limit@8.6.2(express@5.2.1(supports-color@10.2.2))(supports-color@10.2.2):
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      express: 5.2.1(supports-color@10.2.2)
+      ip-address: 10.4.0
+    transitivePeerDependencies:
+      - supports-color
 
   express@4.22.2(supports-color@10.2.2):
     dependencies:
@@ -5581,6 +5800,39 @@ snapshots:
       statuses: 2.0.2
       type-is: 1.6.18
       utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.2.1(supports-color@10.2.2):
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0(supports-color@10.2.2)
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3(supports-color@10.2.2)
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1(supports-color@10.2.2)
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.2
+      range-parser: 1.2.1
+      router: 2.2.0(supports-color@10.2.2)
+      send: 1.2.1(supports-color@10.2.2)
+      serve-static: 2.2.1(supports-color@10.2.2)
+      statuses: 2.0.2
+      type-is: 2.1.0
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
@@ -5630,6 +5882,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  finalhandler@2.1.1(supports-color@10.2.2):
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   fix-dts-default-cjs-exports@1.0.1:
     dependencies:
       magic-string: 0.30.21
@@ -5651,6 +5914,8 @@ snapshots:
   forwarded@0.2.0: {}
 
   fresh@0.5.2: {}
+
+  fresh@2.0.0: {}
 
   fs-extra@10.1.0:
     dependencies:
@@ -5946,6 +6211,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   inflight@1.0.6:
     dependencies:
       once: 1.4.0
@@ -5954,6 +6223,8 @@ snapshots:
   inherits@2.0.4: {}
 
   inline-style-parser@0.2.7: {}
+
+  ip-address@10.4.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -5971,6 +6242,8 @@ snapshots:
   is-hexadecimal@2.0.1: {}
 
   is-plain-obj@4.1.0: {}
+
+  is-promise@4.0.0: {}
 
   isarray@1.0.0: {}
 
@@ -5991,6 +6264,8 @@ snapshots:
       picocolors: 1.1.1
 
   jiti@2.7.0: {}
+
+  jose@6.2.8: {}
 
   joycon@3.1.1: {}
 
@@ -6016,6 +6291,8 @@ snapshots:
       ts-algebra: 2.0.0
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stringify-safe@5.0.1:
     optional: true
@@ -6290,7 +6567,11 @@ snapshots:
 
   media-typer@0.3.0: {}
 
+  media-typer@1.1.1: {}
+
   merge-descriptors@1.0.3: {}
+
+  merge-descriptors@2.0.0: {}
 
   methods@1.1.2: {}
 
@@ -6487,9 +6768,15 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mime@1.6.0: {}
 
@@ -6547,6 +6834,8 @@ snapshots:
   nanoid@3.3.16: {}
 
   negotiator@0.6.3: {}
+
+  negotiator@1.0.0: {}
 
   node-abi@4.33.0:
     dependencies:
@@ -6610,9 +6899,10 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
-  openai@6.42.0(ws@8.21.0):
+  openai@6.42.0(ws@8.21.0)(zod@4.4.3):
     optionalDependencies:
       ws: 8.21.0
+      zod: 4.4.3
 
   p-cancelable@2.1.1: {}
 
@@ -6649,6 +6939,8 @@ snapshots:
 
   path-to-regexp@0.1.13: {}
 
+  path-to-regexp@8.4.2: {}
+
   pathe@2.0.3: {}
 
   pathval@2.0.1: {}
@@ -6660,6 +6952,8 @@ snapshots:
   picomatch@4.0.4: {}
 
   pirates@4.0.7: {}
+
+  pkce-challenge@5.0.1: {}
 
   pkg-types@1.3.1:
     dependencies:
@@ -6774,6 +7068,13 @@ snapshots:
       bytes: 3.1.2
       http-errors: 2.0.1
       iconv-lite: 0.4.24
+      unpipe: 1.0.0
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
       unpipe: 1.0.0
 
   react-dom@19.2.7(react@19.2.7):
@@ -6943,6 +7244,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.0
       fsevents: 2.3.3
 
+  router@2.2.0(supports-color@10.2.2):
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   rxjs@7.8.2:
     dependencies:
       tslib: 2.8.1
@@ -6990,6 +7301,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  send@1.2.1(supports-color@10.2.2):
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serialize-error@7.0.1:
     dependencies:
       type-fest: 0.13.1
@@ -7001,6 +7328,15 @@ snapshots:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.19.2(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1(supports-color@10.2.2):
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -7271,6 +7607,12 @@ snapshots:
       media-typer: 0.3.0
       mime-types: 2.1.35
 
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.1
+      mime-types: 3.0.2
+
   typescript@5.9.3: {}
 
   ufo@1.6.4: {}
@@ -7520,5 +7862,11 @@ snapshots:
       yargs-parser: 22.0.0
 
   yocto-queue@0.1.0: {}
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
+
+  zod@4.4.3: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary
PenguinHarness declared `mcpServers` in tool config but never connected them (the docs note "enumerating concrete MCP tools is reserved for a later adapter layer"). This PR implements that layer so configured MCP servers become real, LLM-callable tools.

## What changed
- **New `McpToolAdapter`** (`packages/core/src/environment/mcp/client.ts`): connects each declared stdio/SSE MCP server, enumerates tools, and wraps them as `BuiltinTool` instances.
  - Tool names namespaced as `mcp__<server>__<tool>` (collision-safe).
  - MCP `inputSchema` (JSON Schema) passes straight into `ToolDefinitionConfig.parameters` — both are `Record<string,unknown>`, **no conversion layer**.
  - Per-server connect failures are isolated (logged to stderr, don't abort the Environment).
- **`Environment`** gains a `static async create()`: when `mcpServers` is non-empty it connects them and registers their tools. The sync constructor is preserved (callers without MCP are unaffected).
- **`agent.ts`** now uses `Environment.create()` so the real agent loop can reach MCP tools.
- **Abort forwarding**: `ToolExecutionContext.signal` is forwarded into the SDK `callTool` `options.signal`, so user-interrupt / Environment timeout cancels an in-flight MCP request.
- Adds `@modelcontextprotocol/sdk` (MIT/Apache-2.0, license-compatible with Apache-2.0).

## Verification
- `pnpm --filter @prismshadow/penguin-core typecheck` → passes.
- Unit test (mocked SDK) `test/mcp-client.test.ts` → 3/3 green (namespacing, inputSchema passthrough, BuiltinTool delegation, fault isolation).
- **Real e2e** `test/mcp-e2e.mts` (spins up a live local stdio MCP server via `tsx`, drives `Environment.create → listTools → executeTool`) → reaches and calls the tool, streams output, finalizes `completed`.

## Backward compatibility
Callers that don't configure `mcpServers` continue using the sync `new Environment(...)` with zero changes. Only the runtime agent path switched to `await Environment.create(...)`.

## Notes / follow-ups (out of scope)
- CLI/Web config UI for `mcpServers` not added; JSON edit + docs suffices for now.
- `sse` transport is wired in `buildTransport` (client-side `SSEClientTransport`) but is **not** covered by a live e2e — server-side SSE was removed from the MCP spec and the SDK's `SSEServerTransport` is unstable to stand up as a test fixture. The stdio path is fully e2e-tested.
- `signal` is now forwarded into `callTool`; `Environment` continues to enforce timeout/abort on the tool stream as a backstop.

Generated with Claude as a PenguinHarness MCP evaluation follow-up.
