### PR TITLE
release: align the repo version with the shipped 0.2.1 and guard future tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,10 @@ jobs:
       # message) and both standalone installers. The stamped installers then select the same immutable OSS/GitHub
       # release when run directly. BUILD_DATE is stamped alongside core with this run's UTC date.
       - name: Stamp release version
+        env:
+          # Referenced as a plain shell variable so the run block stays free of GitHub
+          # expressions: scripts/test-installer.sh replays this block verbatim as sh.
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           TAG="${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
           V="${TAG#v}"
@@ -123,15 +127,19 @@ jobs:
           # Guard: release prep must bump the repo to the tag's version (root + packages/*/package.json
           # and core's VERSION constant move together in the release: X.Y.Z PR). v0.2.1 was tagged with
           # a 0.2.0 repo, so every dev/source build nagged about updates until the repo caught up —
-          # fail the tag push instead. Manual dispatch only warns, keeping legacy tags rebuildable.
-          PKG_V="$(node -p 'require("./package.json").version')"
-          if [ "$PKG_V" != "$V" ]; then
-            MSG="tag $TAG does not match the repo version $PKG_V; bump root + packages/*/package.json and core VERSION during release prep, then re-tag (see CONTRIBUTING.md)."
-            if [ "${{ github.event_name }}" = "push" ]; then
-              echo "error: $MSG" >&2
-              exit 1
+          # fail the tag push instead. Manual dispatch (EVENT_NAME unset in replays) only warns,
+          # keeping legacy tags rebuildable; installer-test fixtures have no package.json, so the
+          # check self-skips there.
+          if [ -f package.json ]; then
+            PKG_V="$(node -p 'require("./package.json").version')"
+            if [ "$PKG_V" != "$V" ]; then
+              MSG="tag $TAG does not match the repo version $PKG_V; bump root + packages/*/package.json and core VERSION during release prep, then re-tag (see CONTRIBUTING.md)."
+              if [ "${EVENT_NAME:-}" = "push" ]; then
+                echo "error: $MSG" >&2
+                exit 1
+              fi
+              echo "warning: $MSG (continuing: manual dispatch)" >&2
             fi
-            echo "warning: $MSG (continuing: manual dispatch)" >&2
           fi
           grep -q 'export const VERSION = "' packages/core/src/index.ts
           sed -i "s/export const VERSION = \"[^\"]*\"/export const VERSION = \"$V\"/" packages/core/src/index.ts
@@ -519,20 +527,26 @@ jobs:
       # workspace:* dep to the dependency's current version, so the versions must match.
       # BUILD_DATE is stamped alongside VERSION with this run's UTC date (the repo keeps null for dev builds).
       - name: Stamp release version
+        env:
+          # Same shell-variable indirection as the release job's stamp step (no GitHub
+          # expressions in the body; see scripts/test-installer.sh).
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           TAG="${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
           V="${TAG#v}"
           # Same repo-version guard as the release job: both jobs start from a tag push in
           # parallel, so the check must fail here too or npm would publish from a tag whose
           # repo version was never bumped. Manual dispatch only warns (legacy-tag retries).
-          PKG_V="$(node -p 'require("./package.json").version')"
-          if [ "$PKG_V" != "$V" ]; then
-            MSG="tag $TAG does not match the repo version $PKG_V; bump root + packages/*/package.json and core VERSION during release prep, then re-tag (see CONTRIBUTING.md)."
-            if [ "${{ github.event_name }}" = "push" ]; then
-              echo "error: $MSG" >&2
-              exit 1
+          if [ -f package.json ]; then
+            PKG_V="$(node -p 'require("./package.json").version')"
+            if [ "$PKG_V" != "$V" ]; then
+              MSG="tag $TAG does not match the repo version $PKG_V; bump root + packages/*/package.json and core VERSION during release prep, then re-tag (see CONTRIBUTING.md)."
+              if [ "${EVENT_NAME:-}" = "push" ]; then
+                echo "error: $MSG" >&2
+                exit 1
+              fi
+              echo "warning: $MSG (continuing: manual dispatch)" >&2
             fi
-            echo "warning: $MSG (continuing: manual dispatch)" >&2
           fi
           grep -q 'export const VERSION = "' packages/core/src/index.ts
           sed -i "s/export const VERSION = \"[^\"]*\"/export const VERSION = \"$V\"/" packages/core/src/index.ts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,19 @@ jobs:
           TAG="${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
           V="${TAG#v}"
           printf '%s\n' "$TAG" | grep -Eq '^v[0-9A-Za-z][0-9A-Za-z._-]*$'
+          # Guard: release prep must bump the repo to the tag's version (root + packages/*/package.json
+          # and core's VERSION constant move together in the release: X.Y.Z PR). v0.2.1 was tagged with
+          # a 0.2.0 repo, so every dev/source build nagged about updates until the repo caught up —
+          # fail the tag push instead. Manual dispatch only warns, keeping legacy tags rebuildable.
+          PKG_V="$(node -p 'require("./package.json").version')"
+          if [ "$PKG_V" != "$V" ]; then
+            MSG="tag $TAG does not match the repo version $PKG_V; bump root + packages/*/package.json and core VERSION during release prep, then re-tag (see CONTRIBUTING.md)."
+            if [ "${{ github.event_name }}" = "push" ]; then
+              echo "error: $MSG" >&2
+              exit 1
+            fi
+            echo "warning: $MSG (continuing: manual dispatch)" >&2
+          fi
           grep -q 'export const VERSION = "' packages/core/src/index.ts
           sed -i "s/export const VERSION = \"[^\"]*\"/export const VERSION = \"$V\"/" packages/core/src/index.ts
           SH_MARKER='EMBEDDED_RELEASE_VERSION="__PENGUIN_RELEASE_VERSION__"'
@@ -509,6 +522,18 @@ jobs:
         run: |
           TAG="${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
           V="${TAG#v}"
+          # Same repo-version guard as the release job: both jobs start from a tag push in
+          # parallel, so the check must fail here too or npm would publish from a tag whose
+          # repo version was never bumped. Manual dispatch only warns (legacy-tag retries).
+          PKG_V="$(node -p 'require("./package.json").version')"
+          if [ "$PKG_V" != "$V" ]; then
+            MSG="tag $TAG does not match the repo version $PKG_V; bump root + packages/*/package.json and core VERSION during release prep, then re-tag (see CONTRIBUTING.md)."
+            if [ "${{ github.event_name }}" = "push" ]; then
+              echo "error: $MSG" >&2
+              exit 1
+            fi
+            echo "warning: $MSG (continuing: manual dispatch)" >&2
+          fi
           grep -q 'export const VERSION = "' packages/core/src/index.ts
           sed -i "s/export const VERSION = \"[^\"]*\"/export const VERSION = \"$V\"/" packages/core/src/index.ts
           D="$(date -u +%Y-%m-%d)"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,12 @@ pnpm test:e2e                                        # core live-model e2e, need
   before creating the tag** — the release workflow reads it from the tag's checkout, so a
   file added later never reaches the Release page. Without it the workflow falls back to
   GitHub's auto-generated notes.
+- **Release prep bumps the repo version**: the same `release: X.Y.Z` PR that renames
+  `changelog/unreleased/` also bumps the root and every `packages/*/package.json`
+  `version`, plus core's `VERSION` constant (`packages/core/src/index.ts`), to the release
+  version. The release workflow refuses a tag push whose version does not match the
+  repo's, so a forgotten bump fails before anything is published (v0.2.1 was tagged with a
+  0.2.0 repo, and every dev build nagged about an update until the repo caught up).
 - README assets under `assets/readme/` are generated — the benchmark charts from the
   landing benchmark data, and the demo screenshots via
   `node packages/landing/scripts/capture-readme-demo.mjs` (build first; needs Playwright

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "penguin-harness",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "description": "PenguinHarness \u2014 TypeScript AI Agent (SDK + CLI).",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismshadow/penguin-cli",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "description": "PenguinHarness CLI: interactive REPL and single-task runner over @prismshadow/penguin-core.",
   "license": "Apache-2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismshadow/penguin-core",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "description": "PenguinHarness core SDK: context_engine, OmniMessage protocol, LLM/Environment interfaces.",
   "license": "Apache-2.0",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -59,7 +59,7 @@ export { Agent, createAgent } from "./agent.js";
 export type { CreateAgentOptions, CreateSessionOptions, ResumeSessionOptions } from "./agent.js";
 
 /** SDK version number. */
-export const VERSION = "0.2.0";
+export const VERSION = "0.2.1";
 /** Release build date (UTC yyyy-mm-dd), stamped by the release workflow next to VERSION; null in a dev/source build. */
 export const BUILD_DATE: string | null = null;
 // Version-string helpers (shared by the CLI's `penguin update` and the server's update check).

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismshadow/penguin-desktop",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "description": "PenguinHarness desktop app: Electron shell running @prismshadow/penguin-server as a utilityProcess, window on http://localhost (same-origin HTTP/SSE, no private IPC).",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismshadow/penguin-docs",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "description": "PenguinHarness documentation site (React + Vite + Tailwind CSS): bilingual zh/en Markdown pages with light/dark themes and per-page Copy Markdown, deployed to GitHub Pages under /docs/ next to the landing page.",

--- a/packages/landing/package.json
+++ b/packages/landing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismshadow/penguin-landing",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "description": "PenguinHarness landing page (React + Vite + Tailwind CSS): multilingual, light/dark themes, benchmark showcase, and a local Markdown blog, deployed to GitHub Pages via GitHub Actions.",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismshadow/penguin-server",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "description": "PenguinHarness web server: multi-user authentication and authorization, Session execution with SSE streaming, and usage accounting, built on @prismshadow/penguin-core.",
   "license": "Apache-2.0",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismshadow/penguin-skills",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "description": "PenguinHarness skill library: built-in SKILL.md documents and skill groups, decoupled from core.",
   "license": "Apache-2.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismshadow/penguin-web",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "description": "PenguinHarness web frontend SPA: React + Vite + Tailwind CSS, rendering conversations streamed over the OmniMessage protocol, plus Agent configuration, model configuration, usage stats, and Traces.",


### PR DESCRIPTION
## What

The 0.2.1 release prep (#204) moved the changelog and wrote RELEASE.md but skipped the repo version bump that 0.2.0's prep (#168) performed. The repo therefore still said 0.2.0 everywhere, and every dev/source build (including the desktop shell run from source) saw the published v0.2.1 as an update and kept prompting. Release artifacts were unaffected because the release workflow stamps versions from the tag at build time — which is exactly why the miss went unnoticed.

- Bump root + all `packages/*/package.json` versions and core's `VERSION` constant to **0.2.1** (matching the shipped release, same as 0.2.0's release commit did).
- `release.yml`: both "Stamp release version" steps (release job and publish-npm job — they start in parallel from a tag push) now **fail a tag push whose version does not match the repo's package.json**, with a message pointing at the release-prep step. Manual `workflow_dispatch` only warns, so a legacy tag with a missing Release can still be rebuilt as-is.
- `CONTRIBUTING.md`: document the version bump as an explicit release-prep step.

## Verification

- `pnpm install --frozen-lockfile`, `pnpm -r build`, `pnpm typecheck`, `pnpm -r test`, `pnpm format` + `pnpm format:check` — all green in a clean worktree.
- Grepped for version-coupled assertions: the remaining `0.2.0` literals in tests (cli update tests, web update-check tests) are fixture data, not comparisons against the live `VERSION`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAkj9ao8kGTiBjAcsxnC1x