### PR TITLE
feat(models): add Inkling and Fireworks DeepSeek V4 Flash 0731, delist gateway GLM-5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Four Skill groups ship in the box ([docs](https://penguin.ooo/docs/skills)); age
 | GPT 5.6          | OpenRouter                                                                       |
 | Gemini 3.6 Flash | Google Gemini, OpenRouter                                                        |
 | Claude 5         | Anthropic, OpenRouter                                                            |
+| Inkling          | OpenRouter, Fireworks AI                                                         |
 
 Each family's latest generation only — the app's **Models** page lists every built-in preset, and any OpenAI-protocol endpoint works too: pick a preset, or point a custom endpoint at any of the 1000+ online and local models.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -98,6 +98,7 @@ https://github.com/user-attachments/assets/aec49ae9-b743-467b-b247-37bedfeaa36e
 | GPT 5.6          | OpenRouter                                                                       |
 | Gemini 3.6 Flash | Google Gemini, OpenRouter                                                        |
 | Claude 5         | Anthropic, OpenRouter                                                            |
+| Inkling          | OpenRouter, Fireworks AI                                                         |
 
 上表每个系列只列最新一代，完整预置清单请在应用的**模型**页查看；只要是 OpenAI 协议的端点都可以接入：选择预置，或用自定义端点连接 1000+ 在线与本地模型。
 

--- a/packages/core/src/state/model-catalog.ts
+++ b/packages/core/src/state/model-catalog.ts
@@ -17,10 +17,12 @@
  *
  * Scope: excludes deepseek-chat / deepseek-reasoner legacy aliases that AgentHub cannot
  * auto-route (deprecated 2026-07-24), glm-5v-turbo (image input unsupported by AgentHub's GLM
- * client), non-chat models (embedding / image generation / TTS), and Bedrock. Direct-vendor
- * ids are auto-routed by AgentHub and leave client_type unset; the five gateway groups
- * (OpenRouter, Fireworks AI, SiliconFlow, Qwen Token Plan, Qwen Pay-As-You-Go) can't be
- * auto-routed, so they set `client_type: "openai"` and inline their preset base URL.
+ * client), the OpenRouter z-ai/glm-5.1 and SiliconFlow Pro/zai-org/GLM-5.1 gateway listings
+ * (delisted 2026-08-06; the Z.AI direct glm-5.1 remains), non-chat models (embedding / image
+ * generation / TTS), and Bedrock. Direct-vendor ids are auto-routed by AgentHub and leave
+ * client_type unset; the five gateway groups (OpenRouter, Fireworks AI, SiliconFlow, Qwen
+ * Token Plan, Qwen Pay-As-You-Go) can't be auto-routed, so they set `client_type: "openai"`
+ * and inline their preset base URL.
  *
  * This file imports no Node built-ins (type-only imports only), so it can be bundled directly
  * for the browser.
@@ -222,9 +224,9 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
   // -- OpenRouter (gateway: OpenAI-compatible protocol, preset base URL). Prices re-read in
   // one pass on 2026-08-03 from the models API (/api/v1/models): cache_read stores the
   // published input_cache_read (falling back to the input price for the few rows without
-  // one — qwen3.6-35b-a3b and the :free rows); cache_write stores input_cache_write only
-  // when it is a genuine per-token write premium (the Anthropic, GPT and qwen3.8-max rows,
-  // 1.25x input) —
+  // one — qwen3.6-35b-a3b, thinkingmachines/inkling and the :free rows); cache_write stores
+  // input_cache_write only when it is a genuine per-token write premium (the Anthropic, GPT
+  // and qwen3.8-max rows, 1.25x input) —
   // Gemini's field is an hourly cache-STORAGE rate, not a per-token price, so those rows
   // keep the input price — and otherwise also carries the input price. The :free tier and
   // the openrouter/free Free Models Router store a genuine $0 price (not "unknown"), so
@@ -504,6 +506,20 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     baseUrl: OPENROUTER_BASE_URL,
   },
   {
+    // Thinking Machines Lab's Inkling (released 2026-07-14): multimodal (image + audio
+    // input). Specs and pricing from its OpenRouter page (2026-08-06), which publishes no
+    // cached-input price, so cache_read repeats the input price (no discount assumed; see
+    // the block comment above).
+    modelId: "thinkingmachines/inkling",
+    displayName: "Inkling",
+    provider: "openrouter",
+    contextWindow: 1000000,
+    pricing: usd(0.95, 0.95, 4.05),
+    supportsVision: true,
+    clientType: "openai",
+    baseUrl: OPENROUTER_BASE_URL,
+  },
+  {
     modelId: "x-ai/grok-4.5",
     displayName: "Grok 4.5",
     provider: "openrouter",
@@ -533,19 +549,19 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     clientType: "openai",
     baseUrl: OPENROUTER_BASE_URL,
   },
-  {
-    modelId: "z-ai/glm-5.1",
-    displayName: "GLM-5.1",
-    provider: "openrouter",
-    contextWindow: 204800,
-    pricing: usd(0.1794, 0.966, 3.036),
-    supportsVision: false,
-    clientType: "openai",
-    baseUrl: OPENROUTER_BASE_URL,
-  },
   // -- Fireworks AI (gateway, standard serverless USD pricing: cached input / uncached
   // input / output from each model's page; API ids use the accounts/fireworks/models/<slug>
   // form) --
+  {
+    modelId: "accounts/fireworks/models/deepseek-v4-flash-0731",
+    displayName: "DeepSeek V4 Flash 0731",
+    provider: "fireworks",
+    contextWindow: 1000000,
+    pricing: usd(0.028, 0.14, 0.28),
+    supportsVision: false,
+    clientType: "openai",
+    baseUrl: FIREWORKS_BASE_URL,
+  },
   {
     modelId: "accounts/fireworks/models/deepseek-v4-flash",
     displayName: "DeepSeek V4 Flash",
@@ -573,6 +589,18 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     contextWindow: 1000000,
     pricing: usd(0.14, 1.4, 4.4),
     supportsVision: false,
+    clientType: "openai",
+    baseUrl: FIREWORKS_BASE_URL,
+  },
+  {
+    // Thinking Machines Lab's Inkling (released 2026-07-14): multimodal (image + audio
+    // input); specs and serverless pricing from its Fireworks model page (2026-08-06).
+    modelId: "accounts/fireworks/models/inkling",
+    displayName: "Inkling",
+    provider: "fireworks",
+    contextWindow: 1000000,
+    pricing: usd(0.17, 1, 4.05),
+    supportsVision: true,
     clientType: "openai",
     baseUrl: FIREWORKS_BASE_URL,
   },
@@ -649,9 +677,7 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
   },
   // The Pro/ and Qwen/ entries below were unpriced until 2026-08-03 (SiliconFlow's price
   // list sits behind an authenticated console); prices below are its official CNY list
-  // prices. GLM-5.1 bills in two input-length tiers ([0, 32k) and [32k, +inf) for hit/input/
-  // output alike); the catalog stores one number per bucket, so these rows keep the LOWER
-  // tier — treat its cost as a floor for long-context use.
+  // prices.
   {
     modelId: "Pro/moonshotai/Kimi-K2.6",
     displayName: "Kimi K2.6",
@@ -659,16 +685,6 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     contextWindow: 262144,
     pricing: cny(1.1, 6.5, 27),
     supportsVision: true,
-    clientType: "openai",
-    baseUrl: SILICONFLOW_BASE_URL,
-  },
-  {
-    modelId: "Pro/zai-org/GLM-5.1",
-    displayName: "GLM-5.1",
-    provider: "siliconflow",
-    contextWindow: 200000,
-    pricing: cny(1.3, 6, 24),
-    supportsVision: false,
     clientType: "openai",
     baseUrl: SILICONFLOW_BASE_URL,
   },

--- a/packages/core/test/model-catalog.test.ts
+++ b/packages/core/test/model-catalog.test.ts
@@ -41,6 +41,11 @@ describe("model-catalog", () => {
     expect(providerInfo("siliconflow")!.label).toBe("SiliconFlow");
     // The catalog no longer includes GLM-5-Turbo.
     expect(ids).not.toContain("glm-5-turbo");
+    // The OpenRouter and SiliconFlow gateway listings of GLM-5.1 were delisted 2026-08-06;
+    // the Z.AI direct glm-5.1 remains in the catalog.
+    expect(ids).not.toContain("z-ai/glm-5.1");
+    expect(ids).not.toContain("Pro/zai-org/GLM-5.1");
+    expect(ids).toContain("glm-5.1");
   });
 
   it("every provider is in MODEL_PROVIDERS (custom only groups user-defined models; the catalog never uses it)", () => {
@@ -175,10 +180,10 @@ describe("model-catalog", () => {
       "qwen/qwen3.6-35b-a3b",
       "stepfun/step-3.7-flash",
       "tencent/hy3",
+      "thinkingmachines/inkling",
       "x-ai/grok-4.5",
       "xiaomi/mimo-v2.5",
       "z-ai/glm-5.2",
-      "z-ai/glm-5.1",
     ]);
     for (const m of or) {
       expect(m.clientType).toBe("openai");
@@ -186,9 +191,11 @@ describe("model-catalog", () => {
     }
     const fw = MODEL_CATALOG.filter((m) => m.provider === "fireworks");
     expect(fw.map((m) => [m.modelId, m.supportsVision])).toEqual([
+      ["accounts/fireworks/models/deepseek-v4-flash-0731", false],
       ["accounts/fireworks/models/deepseek-v4-flash", false],
       ["accounts/fireworks/models/deepseek-v4-pro", false],
       ["accounts/fireworks/models/glm-5p2", false],
+      ["accounts/fireworks/models/inkling", true],
       ["accounts/fireworks/models/kimi-k3", true],
       ["accounts/fireworks/models/kimi-k2p7-code", true],
       ["accounts/fireworks/models/minimax-m3", true],
@@ -206,7 +213,6 @@ describe("model-catalog", () => {
       "meituan-longcat/LongCat-2.0",
       "moonshotai/Kimi-K2.7-Code",
       "Pro/moonshotai/Kimi-K2.6",
-      "Pro/zai-org/GLM-5.1",
       "Qwen/Qwen3.6-35B-A3B",
       "zai-org/GLM-5.2",
     ]);
@@ -370,14 +376,18 @@ describe("model-catalog", () => {
       ["moonshot", "kimi-k3", "openrouter", "moonshotai/kimi-k3"],
       ["moonshot", "kimi-k2.6", "openrouter", "moonshotai/kimi-k2.6"],
       ["moonshot", "kimi-k2.6", "siliconflow", "Pro/moonshotai/Kimi-K2.6"],
-      ["zhipu", "glm-5.1", "openrouter", "z-ai/glm-5.1"],
-      ["zhipu", "glm-5.1", "siliconflow", "Pro/zai-org/GLM-5.1"],
     ] as const) {
       expect(
         catalogEntryFor(gatewayProvider, gatewayId)!.displayName,
         `${gatewayProvider}/${gatewayId}`,
       ).toBe(catalogEntryFor(directProvider, directId)!.displayName);
     }
+    // Inkling has no direct-vendor group (Thinking Machines Lab is gateway-only); its two
+    // gateway listings still share one display name, with the vendor prefix stripped.
+    expect(catalogEntryFor("openrouter", "thinkingmachines/inkling")!.displayName).toBe("Inkling");
+    expect(catalogEntryFor("fireworks", "accounts/fireworks/models/inkling")!.displayName).toBe(
+      "Inkling",
+    );
   });
 
   it("DeepSeek and Kimi are initialized from official CNY prices (stored in USD; x7 recovers the official price)", () => {

--- a/packages/skills/skills/agenthub-models/SKILL.md
+++ b/packages/skills/skills/agenthub-models/SKILL.md
@@ -3,8 +3,8 @@ name: agenthub-models
 description: Call model APIs through @prismshadow/agenthub — streaming text generation, image generation, speech synthesis, embeddings and the supported-model registry with one client.
 short_description: Call model APIs with one AgentHub client.
 short_description_zh: 用一个 AgentHub 客户端调用模型 API。
-version: 10
-updated: 2026-08-04T09:33:09Z
+version: 11
+updated: 2026-08-06T11:51:12Z
 ---
 
 # AgentHub Model APIs
@@ -60,11 +60,12 @@ Use exact model ids. If an id is not in the table below and the user has not giv
 | OpenAI embedding | `text-embedding-3-small`, `text-embedding-3-large`                    | —                                                                                                                                               |
 | Kimi K3          | `kimi-k3`                                                             | OpenRouter `moonshotai/kimi-k3`                                                                                                                 |
 | Kimi K2.6        | `kimi-k2.6`                                                           | OpenRouter `moonshotai/kimi-k2.6`; SiliconFlow `Pro/moonshotai/Kimi-K2.6`                                                                       |
-| DeepSeek V4      | `deepseek-v4-pro`, `deepseek-v4-flash`                                | OpenRouter `deepseek/deepseek-v4-pro`, `deepseek/deepseek-v4-flash`, `deepseek/deepseek-v4-flash-0731`; SiliconFlow `deepseek-ai/DeepSeek-V4-Pro`, `deepseek-ai/DeepSeek-V4-Flash` |
+| DeepSeek V4      | `deepseek-v4-pro`, `deepseek-v4-flash`                                | OpenRouter `deepseek/deepseek-v4-pro`, `deepseek/deepseek-v4-flash`, `deepseek/deepseek-v4-flash-0731`; Fireworks AI `accounts/fireworks/models/deepseek-v4-flash-0731`; SiliconFlow `deepseek-ai/DeepSeek-V4-Pro`, `deepseek-ai/DeepSeek-V4-Flash` |
 | GLM 5.2          | `glm-5.2`                                                             | OpenRouter `z-ai/glm-5.2`; SiliconFlow `zai-org/GLM-5.2`                                                                                        |
-| GLM 5.1          | `glm-5.1`                                                             | OpenRouter `z-ai/glm-5.1`; SiliconFlow `Pro/zai-org/GLM-5.1`                                                                                    |
+| GLM 5.1          | `glm-5.1`                                                             | —                                                                                                                                               |
 | Qwen 3.8 Max     | —                                                                     | OpenRouter `qwen/qwen3.8-max`                                                                                                                   |
 | Qwen 3.6         | —                                                                     | OpenRouter `qwen/qwen3.6-35b-a3b`; SiliconFlow `Qwen/Qwen3.6-35B-A3B`                                                                           |
+| Inkling          | —                                                                     | OpenRouter `thinkingmachines/inkling`; Fireworks AI `accounts/fireworks/models/inkling`                                                         |
 
 The image endpoint dropped its preview suffix: `gemini-3.1-flash-image-preview` is deprecated, use `gemini-3.1-flash-image`.
 


### PR DESCRIPTION
## Summary

Built-in model catalog update in `packages/core/src/state/model-catalog.ts` (the single source of truth); metadata read from the provider pages on 2026-08-06.

**Added**
- OpenRouter `thinkingmachines/inkling` — Thinking Machines Lab's Inkling (released 2026-07-14), 1M context, multimodal (image + audio input), $0.95 input / $4.05 output per mtok. The OpenRouter page publishes no cached-input price, so per the group's provenance rule `cache_read` repeats the input price; the provenance comment now names this row among the fallback cases.
- Fireworks AI `accounts/fireworks/models/inkling` — same model on Fireworks serverless: $0.17 cached / $1 uncached input / $4.05 output.
- Fireworks AI `accounts/fireworks/models/deepseek-v4-flash-0731` — $0.028 / $0.14 / $0.28, placed before the undated `deepseek-v4-flash` row per the newer-versions-first ordering rule (mirroring the OpenRouter pair).

**Removed (delisted 2026-08-06)**
- OpenRouter `z-ai/glm-5.1`
- SiliconFlow `Pro/zai-org/GLM-5.1`

The Z.AI direct `glm-5.1` entry stays — only the two gateway listings are delisted. Existing project configs keep working: model entries are copied into `.project_config.toml` at project creation and nothing rewrites them on upgrade; delisted presets simply stop being re-added by the Web "sync presets" action.

**Files**
- `packages/core/src/state/model-catalog.ts` — the three additions, the two removals, the header scope comment records the delistings, the stale SiliconFlow GLM-5.1 two-tier pricing note is dropped.
- `packages/core/test/model-catalog.test.ts` — exact per-group order arrays updated; negative guards for the removed gateway ids (and a keep-guard for the direct `glm-5.1`); the two removed display-name tuples dropped; Inkling display-name assertions added.
- `packages/skills/skills/agenthub-models/SKILL.md` — model table gains the Inkling row and the Fireworks 0731 spelling, GLM 5.1 row no longer names the delisted gateway spellings; version 10 → 11.
- `README.md` / `README.zh.md` — Inkling family row (OpenRouter, Fireworks AI) added to the supported-models tables.

No design-spec change needed: the specs describe the catalog mechanism, not the lineup (matching prior single-model catalog PRs). Changelog intentionally untouched (separate batch PR). Released blog posts mentioning GLM 5.1 stay frozen per precedent.

## Verification

- `pnpm install --frozen-lockfile` — ok
- `pnpm -r build` — ok
- `pnpm typecheck` — ok
- `pnpm -r test` — all green (core 632 passed / 5 skipped, server 520, web 583, cli 235, skills 18, docs 32, landing 39, desktop 12)
- `pnpm format` + `pnpm format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAkj9ao8kGTiBjAcsxnC1x