### PR TITLE
fix(web): queue follow-ups across steering completion races

### DIFF
--- a/packages/web/e2e/reloaded-followup.spec.mjs
+++ b/packages/web/e2e/reloaded-followup.spec.mjs
@@ -1,0 +1,97 @@
+/** Regression for #89: a Task posted after reloading a completed Session must execute. */
+import { test, expect } from "@playwright/test";
+import { provisionAndLogin } from "./auth.mjs";
+
+const BASE = process.env.BASE_URL;
+const MOCK = process.env.MOCK_URL;
+const U = "reloadedfollowupuser";
+const P = "password123";
+
+async function createSession(page) {
+  await provisionAndLogin(page.request, U, P);
+  const projects = await (await page.request.get(`${BASE}/api/projects`)).json();
+  const projectId = projects.projects[0].projectId;
+  const models = await page.request.put(`${BASE}/api/projects/${projectId}/models`, {
+    data: {
+      defaultModel: { provider: "custom", modelId: "claude-4-8" },
+      models: [
+        {
+          provider: "custom",
+          modelId: "claude-4-8",
+          apiKey: "sk-mock",
+          baseUrl: MOCK,
+          contextWindow: 200000,
+        },
+      ],
+    },
+  });
+  expect(models.ok(), "put models").toBeTruthy();
+  const session = await page.request.post(
+    `${BASE}/api/projects/${projectId}/agents/default_agent/sessions`,
+    {
+      data: {
+        provider: "custom",
+        modelId: "claude-4-8",
+        approvalMode: "always-ask",
+      },
+    },
+  );
+  expect(session.ok(), `create session: ${await session.text()}`).toBeTruthy();
+  return (await session.json()).session.sessionId;
+}
+
+test("a stale steer response after reload queues the follow-up instead of stranding it", async ({
+  page,
+}) => {
+  const sessionId = await createSession(page);
+  await page.goto(`${BASE}/chat/${sessionId}`);
+  const composer = page.locator("textarea").first();
+  await composer.waitFor();
+
+  await composer.fill("first task before reload");
+  const firstPost = page.waitForResponse((response) =>
+    response.url().endsWith(`/sessions/${sessionId}/tasks`),
+  );
+  await page.getByRole("button", { name: "发送" }).click();
+  expect((await firstPost).status()).toBe(202);
+
+  // Reproduce the post-reload stale-state seam deterministically: the client still sees a
+  // running Task, but /steer reports that the core run just ended. The fallback must use the
+  // server's queue-if-busy path, which is safe on both sides of the completion race.
+  await expect(page.getByRole("button", { name: "允许" })).toBeVisible();
+  await page.route(`**/api/sessions/${sessionId}/steer`, (route) =>
+    route.fulfill({
+      status: 409,
+      contentType: "application/json",
+      body: JSON.stringify({
+        error: {
+          code: "not_running",
+          message: "This Session has no Task in progress; send a new task instead.",
+        },
+      }),
+    }),
+  );
+  await page.reload();
+  await composer.waitFor();
+  await expect(page.getByRole("button", { name: "停止" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "允许" })).toBeVisible();
+
+  await composer.fill("hello after reload");
+  const followUpPost = page.waitForResponse((response) =>
+    response.url().endsWith(`/sessions/${sessionId}/tasks`),
+  );
+  await page.getByRole("button", { name: "发送给运行中的 Agent" }).click();
+  const response = await followUpPost;
+  expect(response.status()).toBe(202);
+  expect(response.request().postDataJSON()).toMatchObject({ queueIfBusy: true });
+  expect(await response.json()).toMatchObject({ queued: true });
+  await expect(page.getByText("1 条跟进消息已排队，本轮结束后自动发送")).toBeVisible();
+  await expect(composer).toHaveValue("");
+
+  // The first task completes, then the accepted follow-up reaches the LLM and produces a
+  // second answer instead of remaining an inert 202 response.
+  await page.getByRole("button", { name: "允许" }).click();
+  await expect(page.getByText("Command finished; the result looks as expected.")).toHaveCount(2, {
+    timeout: 30_000,
+  });
+});

--- a/packages/web/src/features/chat/chat-input.tsx
+++ b/packages/web/src/features/chat/chat-input.tsx
@@ -1744,10 +1744,13 @@ export function ChatInput({
         setBusy(false);
         textareaRef.current?.focus();
       }
-      // Completion race (server: no Task running anymore): deliver the whole draft — skills
-      // and all — through the full normal send path. The draft is untouched in this branch
-      // (nothing was cleared), so the images go out with it.
-      if (res === "not_running") await sendNormal();
+      // Completion race: the SSE snapshot can still say running after /steer reports that the
+      // core run has ended. Deliver the untouched whole draft — skills and all — through the
+      // queue-if-busy path. That endpoint is safe on both sides of the server's own completion
+      // seam: it starts immediately when idle, or queues behind the last sliver of the old run.
+      // A plain Task POST could race the manager's idle flip and return 409, stranding the draft
+      // on a reloaded page (#89).
+      if (res === "not_running") await sendNormal(onQueueFollowUp ?? onSend);
       return;
     }
     if (!canSend) return;


### PR DESCRIPTION
Closes #89.

## Problem

After reloading a running Session, the Web client can briefly retain a stale
`running` state while the Task is completing.

If the user sends a message in that window, the composer first calls `/steer`.
When `/steer` returns `409 not_running`, the current fallback retries the draft
with a plain `POST /tasks`.

That request can reach the server before the runtime finishes its idle
transition, receive `409 task_in_progress`, and leave the draft unsent.

## Fix

Route the `not_running` fallback through the existing `queueIfBusy` Task path.

This path is safe on both sides of the completion boundary:

- when the Session is idle, the Task starts immediately;
- when the runtime is still finishing, the Task is queued and starts afterward.

The fallback still uses the normal draft composition path, so text, selected
Skills, images, and file attachments are preserved.

No server behavior or API was added.

## Tests

Added a deterministic Playwright regression that:

- keeps the first Task running on tool approval;
- reloads the Session;
- forces `/steer` to return `409 not_running`;
- verifies the fallback request contains `queueIfBusy: true`;
- verifies the server returns `202 { queued: true }`;
- completes the first Task and waits for the follow-up's model response.

Local verification:

- `pnpm -r build`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm test` — 2,071 passed, 5 skipped
- Server follow-up and steering tests — 8 passed
- targeted `reloaded-followup.spec.mjs` Playwright regression — passed

Implemented with agent assistance. I reviewed the state transition, final diff,
and regression assertions before submission.
