### PR TITLE
docs(changelog): 2026-08-06 batch entries

### DIFF
--- a/changelog/unreleased/2026-08-06-desktop-app.md
+++ b/changelog/unreleased/2026-08-06-desktop-app.md
@@ -1,0 +1,20 @@
+# Desktop app: brand icons, completion notifications, single-user mode, bundled penguin CLI
+
+## App icons
+
+Every platform now shows the penguin brand mark instead of the stock Electron icon: electron-builder converts the committed 1024px PNG (rendered from the brand SVG by `scripts/render-icon.mjs`, which reuses the landing package's Playwright chromium) to icns/ico for macOS/Windows, Linux ships a pre-rendered freedesktop icon set, and the window itself carries the icon on Linux/Windows. No tray is introduced — the "default icon" came from the window/app icons never being configured.
+
+## Task-completion notifications
+
+An agent run finishing while the desktop window is unfocused or hidden now raises a system notification with the Session title; clicking it focuses the window and opens that Session. Implemented renderer-side with the standard Web Notification API over the session list's status transitions (first observations never fire; per-run dedupe with a stale-snapshot cooldown) — no preload and no private IPC, honoring the desktop shell's plain-browser-window design. Active only for desktop-shell sessions (`sessionVia === "desktop"`), so browsers are never permission-prompted; Windows toasts get their AppUserModelID from the shell.
+
+## Single-user desktop mode
+
+The desktop app is now explicitly single-user: under the desktop shell the server rejects user management (`/api/admin/users*`) and Project member routes with `403 desktop_single_user`, and the web app hides the Users menu entry, the admin users page, and the Project members section in desktop mode. Existing users and data are untouched, and normal multi-user servers are unaffected.
+
+## Bundled penguin CLI
+
+The installed desktop app now contains the full CLI, runnable without a system Node installation via launchers that run the app's own Electron runtime as Node (`ELECTRON_RUN_AS_NODE`):
+
+- Linux deb: `/usr/bin/penguin` is created automatically at install (postinst extends electron-builder's stock template; never clobbers a non-symlink file, removed on uninstall only when it points at this app).
+- macOS / Windows / AppImage: an "Install 'penguin' Command…" native menu item plus a one-time first-launch offer — macOS symlinks `/usr/local/bin/penguin` (one admin escalation when needed), Windows appends the app's `bin` directory to the user PATH (idempotent, new terminals pick it up), AppImage writes a `~/.local/bin/penguin` wrapper that runs the AppImage itself as Node.

--- a/changelog/unreleased/2026-08-06-landing-desktop-first.md
+++ b/changelog/unreleased/2026-08-06-landing-desktop-first.md
@@ -1,0 +1,8 @@
+# Landing homepage leads with the desktop app
+
+The homepage now presents the desktop download as the first install path; CLI and self-host content sits below the fold at the quick start.
+
+- Hero: the CLI one-liner install box is replaced by a platform-aware "Download for \<OS\>" primary button linking to `/download` (generic label when detection fails), an "All platforms" line, and a "CLI and self-hosted install ↓" link down to the quick start; the GitHub button stays.
+- Closing CTA: primary → `/download`, secondary → quick start; "Read the docs" kept.
+- Quick start step 1's desktop note now reads from the "already on the desktop app?" angle (shared local data root), still linking to the download page.
+- OS detection is extracted to `src/lib/platform.ts` and shared by the hero and the download page; the `/download` page itself — artifact links, mirror resolution, checksums, first-launch FAQ — is unchanged, as are the section order, nav anchors, and route shells.

--- a/changelog/unreleased/2026-08-06-model-catalog-inkling-dsv4-flash-0731.md
+++ b/changelog/unreleased/2026-08-06-model-catalog-inkling-dsv4-flash-0731.md
@@ -1,0 +1,15 @@
+# Models: Inkling and Fireworks DeepSeek V4 Flash 0731 join; gateway GLM-5.1 delisted
+
+Prices and specs read from each model's provider page on 2026-08-06.
+
+## New models
+
+Thinking Machines Lab's Inkling (released 2026-07-14: 1M context, multimodal image + audio input) joins on two gateways: OpenRouter `thinkingmachines/inkling` ($0.95 input / $4.05 output per mtok; the page publishes no cached-input price, so `cache_read` stores the input price per the group's no-discount convention) and Fireworks AI `accounts/fireworks/models/inkling` ($0.17 cached / $1 uncached input / $4.05 output). Fireworks AI also gains `accounts/fireworks/models/deepseek-v4-flash-0731` ($0.028 / $0.14 / $0.28), placed ahead of the undated flash row per the newer-versions-first ordering rule.
+
+## Delisted
+
+The OpenRouter `z-ai/glm-5.1` and SiliconFlow `Pro/zai-org/GLM-5.1` gateway listings are removed; the Z.AI direct `glm-5.1` stays. Existing Project configs keep working — model entries are copied into `.project_config.toml` at creation and nothing rewrites them on upgrade; delisted presets simply stop being re-added by the models page's "sync presets" action.
+
+## Docs and skills
+
+The agenthub-models skill (v11) adds the Inkling and Fireworks 0731 spellings and stops naming the delisted GLM-5.1 gateway ids; the README (en/zh) supported-models tables gain the Inkling family (OpenRouter, Fireworks AI).

--- a/changelog/unreleased/2026-08-06-release-version-guard.md
+++ b/changelog/unreleased/2026-08-06-release-version-guard.md
@@ -1,0 +1,7 @@
+# Release tooling: the repo version can no longer drift behind a shipped release
+
+v0.2.1 was tagged from a repo still versioned 0.2.0 — its prep PR moved the changelog and wrote RELEASE.md but skipped the version bump that 0.2.0's prep performed — so every dev/source build compared itself against the published v0.2.1 and prompted about an update indefinitely, while release artifacts (stamped from the tag at build time) looked fine.
+
+- Root and every `packages/*/package.json` version, plus core's `VERSION` constant, are bumped to 0.2.1 to match the shipped release.
+- Both `release.yml` stamp steps (the release job and the parallel npm publish job) now refuse a tag push whose version does not match the repo's `package.json`, with the fix spelled out in the error. Manual `workflow_dispatch` only warns, so a legacy tag whose Release went missing can still be rebuilt from its own source; the installer-test fixtures self-skip the check (no `package.json` in the replay dirs), keeping the stamp block replayable by `scripts/test-installer.sh`.
+- `CONTRIBUTING.md` documents the version bump as an explicit release-prep step alongside the changelog rename and RELEASE.md.

--- a/changelog/unreleased/2026-08-06-system-proxy-switch.md
+++ b/changelog/unreleased/2026-08-06-system-proxy-switch.md
@@ -1,0 +1,9 @@
+# Admin "use system HTTP proxy" switch
+
+The sidebar user menu gains an admin-only, server-global "Use system HTTP proxy" switch (default on, saved immediately, stored in a new `server_settings` table and served by `GET/PUT /api/admin/settings`), implementing the long-specced 出网与系统代理 design.
+
+- On: the server honors `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` (both spellings). Node's built-in fetch ignores those variables, so the server now routes all of its own outbound traffic — LLM provider requests, the update check, image downloads — through an undici global dispatcher and fetch, installed once at the entry.
+- Off: the server always connects directly, and the proxy variables (including `ALL_PROXY`; `NO_PROXY` kept) are stripped from agent command subprocesses via a new optional `stripProxyEnv` getter threaded through the SDK's `CreateAgentOptions` → `Environment` (absent = proxy allowed, so standalone SDK/CLI behavior is unchanged).
+- Either way the effective `NO_PROXY` always includes `localhost,127.0.0.1,::1`, keeping loopback traffic — readiness probes, SSE, workspace previews — off any proxy.
+- Toggling rebuilds the dispatcher for new connections immediately; no restart. The CLI-hosted server (`penguin web`) inherits the same coverage since it imports the server entry in-process.
+- Desktop: the shell resolves the OS proxy at launch (Electron `resolveProxy`; PAC `PROXY`/`HTTPS` results, SOCKS deliberately skipped — undici speaks HTTP(S) proxies only) and injects it into the embedded server's environment without overriding explicitly configured values.

--- a/changelog/unreleased/2026-08-06-web-app.md
+++ b/changelog/unreleased/2026-08-06-web-app.md
@@ -1,0 +1,21 @@
+# Web App: directory browsing de-raced, Project defaults reach new drafts, update dot explained, focused model catalog, "temporary workspace" unified
+
+## Directory browsing no longer mis-navigates under repeated clicks
+
+While a listing was loading, clicking a folder row again in the files panel compounded path segments (`home` → `home/home` → `home/home/home/home`) and stranded the user on "path not found"; the workspace picker could also be silently relocated when a slow directory response landed after a newer one. Listings are now bound to the directory they were fetched for (a double-click recomputes the same target regardless of timing), in-flight navigation disables rows and breadcrumbs, picker requests are sequenced so only the newest response wins (the editable path row included), and the `dir_not_found` server error renders localized copy instead of the raw English message with the malformed path in it.
+
+## Saving Project new-chat defaults resets the new-conversation draft
+
+Opening `/chat/new` once pinned the then-current Agent / workspace / approval mode into the per-user draft cache, and that stale draft shadowed any later change to the Project's new-chat defaults. Saving the defaults now strips the corresponding cached pins — typed-but-unsent text, staged skills and chips survive — and live-reseeds a draft page open in the same tab (its debounced persist would otherwise write the old values right back); other tabs pick the change up on their next visit. The model pin is still released exactly when the default model itself changes, keeping the "switch becomes default" carry-over intact.
+
+## The avatar update dot explains itself
+
+The sidebar avatar's update indicator now names the available release in a hover tooltip and accessible label (the update row's exact wording), and the collapsed icon rail's avatar shows the same indicator — previously the dot was unlabeled and the rail showed nothing. A passive subscriber gap in the version-info cache was fixed along the way so the rail sees results that land while it is mounted.
+
+## Model catalog opens focused on DeepSeek
+
+The models page now expands only the DeepSeek group by default; other vendor groups and user-defined groups start collapsed. While a search query is active, any group holding matches is force-opened (derived, not persisted) so results can never hide inside a collapsed group; expansion state still resets per visit.
+
+## "Temporary workspace" unified
+
+The auto-created session workspace is now consistently called 临时工作区 / "temporary workspace" across the workspace picker, its hints, the schedule form, server/SDK error messages, docs, and the penguin-sdk skill (v19) — replacing the mixed "auto temp directory" wording. Persisted keys, ids and the on-disk `workspaces/tmp-<8hex>` shape are untouched.

--- a/changelog/unreleased/README.md
+++ b/changelog/unreleased/README.md
@@ -1,0 +1,13 @@
+# Unreleased
+
+- [2026-08-06] Desktop app: penguin brand icons on every platform, task-completion system notifications (renderer-only, desktop sessions), explicit single-user mode (user/member management rejected with `desktop_single_user` and hidden), and a bundled `penguin` CLI on PATH (automatic on deb; menu-driven install elsewhere, no system Node needed). ([details](2026-08-06-desktop-app.md))
+
+- [2026-08-06] Admin "use system HTTP proxy" switch: server-wide proxy control (default on, live toggle, loopback exemption), off-state proxy-env stripping for agent subprocesses, OS-proxy injection on desktop. ([details](2026-08-06-system-proxy-switch.md))
+
+- [2026-08-06] Web App: directory browsing no longer compounds path segments under repeated clicks (listings bound to their own directory, sequenced picker requests, localized `dir_not_found`), saving Project new-chat defaults resets the new-conversation draft (typed text survives, open drafts reseed live), the avatar update dot gains a tooltip and reaches the collapsed rail, the model catalog opens with only DeepSeek expanded (search force-opens matching groups), and the auto-created session workspace is consistently named 临时工作区 / "temporary workspace" (penguin-sdk skill v19). ([details](2026-08-06-web-app.md))
+
+- [2026-08-06] Landing homepage leads with the desktop app: platform-aware download CTA in the hero, closing CTA repointed, CLI one-liner install moved below the fold to the quick start; `/download` page unchanged. ([details](2026-08-06-landing-desktop-first.md))
+
+- [2026-08-06] Models: Thinking Machines Lab's Inkling joins on OpenRouter and Fireworks AI, Fireworks AI gains DeepSeek V4 Flash 0731, and the OpenRouter + SiliconFlow GLM-5.1 gateway listings are delisted (Z.AI direct stays; existing Project configs unaffected); agenthub-models skill v11. ([details](2026-08-06-model-catalog-inkling-dsv4-flash-0731.md))
+
+- [2026-08-06] Release tooling: repo versions realigned with the shipped 0.2.1, and the release workflow now refuses a tag push whose version does not match `package.json` (the drift that made every dev build nag about updates); the bump is documented as a release-prep step. ([details](2026-08-06-release-version-guard.md))


### PR DESCRIPTION
Changelog batch for the 2026-08-06 merges (#219 #220 #221 #222 #223 #224 #225 #226), per the separate-batch-PR changelog convention: recreates `changelog/unreleased/` (the 0.2.1 release rename left none) with six surface-grouped entries and the index.

- Release tooling: repo version realigned with 0.2.1 + tag/version guard.
- Models: Inkling (OpenRouter + Fireworks), Fireworks DeepSeek V4 Flash 0731; gateway GLM-5.1 delisted.
- Landing: desktop-first homepage.
- Web App: directory-browsing race fix, draft reset on Project defaults save, avatar update tooltip, DeepSeek-only catalog expansion, temporary-workspace wording.
- System proxy switch (server+web+desktop).
- Desktop app: icons, completion notifications, single-user mode, bundled CLI.

## Verification

Markdown only — prettier check on the new files; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAkj9ao8kGTiBjAcsxnC1x
