### PR TITLE
fix(models): refresh OpenRouter prices from the models API (inkling cache price)

### DIFF
--- a/packages/core/src/state/model-catalog.ts
+++ b/packages/core/src/state/model-catalog.ts
@@ -222,9 +222,9 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     supportsVision: false,
   },
   // -- OpenRouter (gateway: OpenAI-compatible protocol, preset base URL). Prices re-read in
-  // one pass on 2026-08-03 from the models API (/api/v1/models): cache_read stores the
-  // published input_cache_read (falling back to the input price for the few rows without
-  // one — qwen3.6-35b-a3b, thinkingmachines/inkling and the :free rows); cache_write stores
+  // one pass on 2026-08-07 from the models API (/api/v1/models; the API is authoritative
+  // where a model's web page disagrees): cache_read stores the published input_cache_read
+  // (falling back to the input price for the few rows without one — the :free rows); cache_write stores
   // input_cache_write only when it is a genuine per-token write premium (the Anthropic, GPT
   // and qwen3.8-max rows, 1.25x input) —
   // Gemini's field is an hourly cache-STORAGE rate, not a per-token price, so those rows
@@ -297,7 +297,7 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     displayName: "DeepSeek V4 Flash",
     provider: "openrouter",
     contextWindow: 1000000,
-    pricing: usd(0.028, 0.14, 0.28),
+    pricing: usd(0.01764, 0.0882, 0.1764),
     supportsVision: false,
     clientType: "openai",
     baseUrl: OPENROUTER_BASE_URL,
@@ -387,7 +387,7 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     displayName: "Kimi K2.6",
     provider: "openrouter",
     contextWindow: 262144,
-    pricing: usd(0.2, 0.6, 3.41),
+    pricing: usd(0.0992, 0.589, 2.48),
     supportsVision: true,
     clientType: "openai",
     baseUrl: OPENROUTER_BASE_URL,
@@ -473,13 +473,11 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     baseUrl: OPENROUTER_BASE_URL,
   },
   {
-    // Neither the OpenRouter page nor AgentHub's registry publishes a cache price for this
-    // model, so cache_read repeats the input price (no discount assumed).
     modelId: "qwen/qwen3.6-35b-a3b",
     displayName: "Qwen 3.6 35B A3B",
     provider: "openrouter",
     contextWindow: 262144,
-    pricing: usd(0.14, 0.14, 1),
+    pricing: usd(0.05, 0.14, 1),
     supportsVision: true,
     clientType: "openai",
     baseUrl: OPENROUTER_BASE_URL,
@@ -507,14 +505,13 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
   },
   {
     // Thinking Machines Lab's Inkling (released 2026-07-14): multimodal (image + audio
-    // input). Specs and pricing from its OpenRouter page (2026-08-06), which publishes no
-    // cached-input price, so cache_read repeats the input price (no discount assumed; see
-    // the block comment above).
+    // input). Specs from its OpenRouter page; pricing from the models API (2026-08-07),
+    // which publishes $1 input (the page shows $0.95) and a $0.17 cached-input price.
     modelId: "thinkingmachines/inkling",
     displayName: "Inkling",
     provider: "openrouter",
     contextWindow: 1000000,
-    pricing: usd(0.95, 0.95, 4.05),
+    pricing: usd(0.17, 1, 4.05),
     supportsVision: true,
     clientType: "openai",
     baseUrl: OPENROUTER_BASE_URL,
@@ -544,7 +541,7 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     displayName: "GLM-5.2",
     provider: "openrouter",
     contextWindow: 1000000,
-    pricing: usd(0.221, 1.19, 3.74),
+    pricing: usd(0.1261, 0.679, 2.134),
     supportsVision: false,
     clientType: "openai",
     baseUrl: OPENROUTER_BASE_URL,


### PR DESCRIPTION
## What

Follow-up to #220 per user feedback: OpenRouter publishes cached-input prices via its models API, and the new `thinkingmachines/inkling` row had been priced from the web page instead (which omits the cache price and shows a different input price).

- `thinkingmachines/inkling`: `usd(0.95, 0.95, 4.05)` → **`usd(0.17, 1, 4.05)`** — the API publishes `input_cache_read` $0.17/mtok and $1 input (page says $0.95; per the group's provenance rule the API is authoritative, now stated in the block comment).
- Re-reading the whole OpenRouter group in one pass (2026-08-07, the documented maintenance operation) caught real drift since the 2026-08-03 sweep: `deepseek/deepseek-v4-flash` `usd(0.028, 0.14, 0.28)` → `usd(0.01764, 0.0882, 0.1764)`, `moonshotai/kimi-k2.6` `usd(0.2, 0.6, 3.41)` → `usd(0.0992, 0.589, 2.48)`, `qwen/qwen3.6-35b-a3b` cache-read `0.14` → `0.05` (the API now publishes it; its no-cache-price row comment is removed), `z-ai/glm-5.2` `usd(0.221, 1.19, 3.74)` → `usd(0.1261, 0.679, 2.134)`.
- Provenance block comment updated (date, API-authoritative note, fallback list now only the `:free` rows). No row gains a cache-write premium; the premium list (Anthropic/GPT/qwen3.8-max) is unchanged.
- Observed but deliberately not acted on: `inclusionai/ling-3.0-flash:free` no longer appears in the models API listing — delisting it would be a product decision, flagged to the maintainer instead. Gemini rows intentionally keep the input price for cache_write (the API field is an hourly storage rate — documented carve-out).

## Verification

`pnpm install --frozen-lockfile`, `pnpm -r build`, `pnpm typecheck`, `pnpm -r test`, `pnpm format` + `format:check` — all green. Pricing is not literal-asserted in tests (only >0 + structural invariants), so no test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAkj9ao8kGTiBjAcsxnC1x