### PR TITLE
fix(web): carry the per-turn thinking level on queued follow-ups

### DIFF
--- a/packages/web/e2e/reloaded-followup.spec.mjs
+++ b/packages/web/e2e/reloaded-followup.spec.mjs
@@ -1,4 +1,7 @@
-/** Regression for #89: a Task posted after reloading a completed Session must execute. */
+/**
+ * Regression for #89: a Task posted after reloading a completed Session must execute — and
+ * must carry the whole draft, the per-turn thinking level included.
+ */
 import { test, expect } from "@playwright/test";
 import { provisionAndLogin } from "./auth.mjs";
 
@@ -76,6 +79,16 @@ test("a stale steer response after reload queues the follow-up instead of strand
   await expect(page.getByRole("button", { name: "停止" })).toBeVisible();
   await expect(page.getByRole("button", { name: "允许" })).toBeVisible();
 
+  // A per-turn thinking level picked mid-run must ride the queued follow-up, exactly as it
+  // rides an ordinary send: the server keeps it with the queued input and applies it when the
+  // follow-up auto-starts. The picker is only disabled while a send is in flight, so it is
+  // editable here; the pick is per-turn and does not write through to the Agent config.
+  const thinkingBtn = page.getByRole("button", { name: "思考等级" });
+  await expect(thinkingBtn).toContainText("中");
+  await thinkingBtn.click();
+  await page.getByRole("button", { name: "高", exact: true }).click();
+  await expect(thinkingBtn).toContainText("高");
+
   await composer.fill("hello after reload");
   const followUpPost = page.waitForResponse((response) =>
     response.url().endsWith(`/sessions/${sessionId}/tasks`),
@@ -83,7 +96,10 @@ test("a stale steer response after reload queues the follow-up instead of strand
   await page.getByRole("button", { name: "发送给运行中的 Agent" }).click();
   const response = await followUpPost;
   expect(response.status()).toBe(202);
-  expect(response.request().postDataJSON()).toMatchObject({ queueIfBusy: true });
+  expect(response.request().postDataJSON()).toMatchObject({
+    queueIfBusy: true,
+    thinkingLevel: "high",
+  });
   expect(await response.json()).toMatchObject({ queued: true });
   await expect(page.getByText("1 条跟进消息已排队，本轮结束后自动发送")).toBeVisible();
   await expect(composer).toHaveValue("");

--- a/packages/web/src/features/chat/chat-page.tsx
+++ b/packages/web/src/features/chat/chat-page.tsx
@@ -936,11 +936,20 @@ export function ChatPage() {
   // server-side and auto-sends it as an ordinary next task once this run finishes (the
   // "N queued" count arrives via task_state). Succeeds either way (queued or started
   // directly in the completion race), so the input area clears the draft on true.
+  // The per-turn thinking level rides along exactly as it does on onSend: the level is the
+  // one picked when the follow-up was composed, and the server keeps it with the queued
+  // input and applies it at auto-start (see TaskCreateRequest.queueIfBusy).
   const onQueueFollowUp = useCallback(
     async (input: TaskInputPart[]): Promise<boolean> => {
       if (!selected) return false;
       try {
-        const res = await api.postTask(selected.sessionId, { input, queueIfBusy: true });
+        const res = await api.postTask(selected.sessionId, {
+          input,
+          queueIfBusy: true,
+          ...(turnThinkingLevel
+            ? { thinkingLevel: turnThinkingLevel as TaskCreateRequest["thinkingLevel"] }
+            : {}),
+        });
         discardSessionDraft();
         await syncHealedSessionId(selected.sessionId, res.sessionId);
         return true;
@@ -949,7 +958,7 @@ export function ChatPage() {
         return false;
       }
     },
-    [selected, discardSessionDraft, syncHealedSessionId],
+    [selected, turnThinkingLevel, discardSessionDraft, syncHealedSessionId],
   );
 
   // Mid-run steering: the message is queued on the server and delivered between turns as a


### PR DESCRIPTION
Follow-up to #227 (review note 2).

## Problem

The per-turn thinking level picked in the composer rides an ordinary send — `onSend` puts
`thinkingLevel` on `POST /tasks` — but is silently dropped on the follow-up queue path:
`onQueueFollowUp` posts only `{ input, queueIfBusy: true }`.

Both callers of that path lose it:

- the mid-run "queue" send (follow-up mode);
- the steering completion-race fallback added in #227, where a `/steer` `409 not_running`
  re-routes the whole draft through the queue.

The picker is `disabled={busy}`, not `disabled={running}`, so a level can be picked while a
Task is running and then be lost on the very send it was picked for. The server already
accepts the parameter here: `startTask` stores `thinkingLevel` alongside the queued input and
`startQueuedFollowUp` applies it at auto-start (see the `TaskCreateRequest.queueIfBusy` doc
comment) — only the client never sent it.

## Fix

Put the same `thinkingLevel` spread `onSend` uses on `onQueueFollowUp`'s `postTask` call, with
`turnThinkingLevel` added to the callback's dependency array. The level sent is the one in
effect when the follow-up was composed, matching an ordinary send.

No server or API change.

## Tests

Extended `reloaded-followup.spec.mjs`: after the reload it picks 高 in the per-turn
thinking-level menu and asserts the queued follow-up's request body carries
`thinkingLevel: "high"` next to `queueIfBusy: true`. Verified to fail without the fix — the
field is simply absent from the body.

## Verification

Node 24, from a clean worktree on `main`:

- `pnpm install --frozen-lockfile`
- `pnpm -r build`
- `pnpm typecheck`
- `pnpm format` + `pnpm format:check`
- `pnpm test` — 178 test files, all passing (1 skipped file in core)
- `packages/web` e2e (mock LLM): `reloaded-followup.spec.mjs`, `steer-reload.spec.mjs` and
  `chat.spec.mjs` pass. Run locally because the CI e2e step self-skips without
  `DEEPSEEK_API_KEY`.

`draft.spec.mjs` fails locally at its `/model` fork banner assertion (line 377), but it fails
identically with this PR's `chat-page.tsx` change reverted to `main`, so it is pre-existing
and unrelated.
