### PR TITLE
fix(web): simplify model-locked hint and use pointer cursor

### DIFF
--- a/packages/web/src/features/chat/chat-input.tsx
+++ b/packages/web/src/features/chat/chat-input.tsx
@@ -2541,7 +2541,7 @@ export function ChatInput({
                 // button's accessible name for assistive tech and name-based test queries.
                 aria-label={`${S.chat.model} ${modelRef?.modelId ?? ""}`}
                 onClick={() => toastInfo(S.chat.modelLockedHint)}
-                className="flex h-8 min-w-0 max-w-44 shrink cursor-help items-center gap-1.5 rounded-md px-1 text-gray-400 transition-colors duration-150 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
+                className="flex h-8 min-w-0 max-w-44 shrink cursor-pointer items-center gap-1.5 rounded-md px-1 text-gray-400 transition-colors duration-150 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
               >
                 <ProviderLogo
                   provider={modelRef?.provider ?? "custom"}

--- a/packages/web/src/lib/strings-en.ts
+++ b/packages/web/src/lib/strings-en.ts
@@ -1070,8 +1070,7 @@ Scenarios:
         : "Switched model — continued from the earlier conversation",
     modelSwitchAutoMessage: "Continue this conversation on the new model",
     /** Toast when the session-state (locked) model display is clicked: points at the `/model` command. */
-    modelLockedHint:
-      "This session's model is locked — type /model to switch (sending continues this conversation in a new session)",
+    modelLockedHint: "Type /model to switch models",
     scheduledFrom: (name: string) => `Triggered by scheduled task "${name}"`,
     emptyGreeting: "Start a new conversation",
     /** Unified step-row titles (same header idiom as workRunning/workDone). */

--- a/packages/web/src/lib/strings.ts
+++ b/packages/web/src/lib/strings.ts
@@ -1044,7 +1044,7 @@ Benchmark：
     /** First message body auto-sent when `/model` is staged and the composer is empty (same convention as skillsAutoMessage). */
     modelSwitchAutoMessage: "换用新模型继续这段对话",
     /** Toast when the session-state (locked) model display is clicked: points at the `/model` command. */
-    modelLockedHint: "会话的模型已锁定：输入 /model 指令可切换模型（发送时开启新会话延续本对话）",
+    modelLockedHint: "输入 /model 切换模型",
     scheduledFrom: (name: string) => `由定时任务「${name}」触发`,
     emptyGreeting: "开始一段新对话",
     /** Unified step-row titles (same header idiom as workRunning/workDone). */


### PR DESCRIPTION
## Motivation

Two small polish items on the chat composer's locked-model button (the read-only model display shown once a session exists):

- The toast hint shown on click was verbose: "This session's model is locked — type /model to switch (sending continues this conversation in a new session)". The actionable part is just the `/model` pointer, so the hint is now simply "Type /model to switch models" (zh: 「输入 /model 切换模型」). The `/model` flow itself already explains the new-session semantics.
- The button used `cursor-help`, which shows a question-mark cursor on hover. The element is a clickable `<button>` with an `onClick`, so `cursor-help` was misleading; it now uses `cursor-pointer`. This was the only `cursor-help` occurrence in the repo.

`modelLockedHint` keys stay aligned between `strings.ts` and `strings-en.ts`; no other copy (e.g. `modelSwitchBusyHint`) is touched.

## Verification

- `pnpm -r build` — passed
- `pnpm typecheck` — passed (all packages)
- `pnpm test` — passed (all packages; web 646 tests, cli, desktop 48 tests)
- `pnpm format` — no changes
- `pnpm format:check` — "All matched files use Prettier code style!"

🤖 Generated with [Claude Code](https://claude.com/claude-code)