### PR TITLE
fix(web): agent list settings button icon consistency

### DIFF
--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -49,7 +49,7 @@ import type { FolderCategory, SessionPartition } from "../../lib/session-groupin
 import { Switch } from "../ui/switch";
 import { Dropdown } from "../ui/dropdown";
 import { AgentAvatar } from "../ui/agent-avatar";
-import { ChevronDown, NAV_ICONS } from "../ui/icons";
+import { ChevronDown, GEAR_ICON, NAV_ICONS } from "../ui/icons";
 import {
   FOLDER_ICON,
   FOLDER_OPEN_ICON,
@@ -88,10 +88,6 @@ import { forceUpdateCheck, updateCheckOutcome, useVersionInfo } from "../../lib/
 
 /** New-chat pencil (the pinned "New chat" button and the collapsed rail share it). */
 export const NEW_CHAT_ICON = "M12 20h9M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z";
-
-/** Standard gear (lucide settings): full tooth outline + center circle, crisp and undistorted at 16px. */
-const GEAR_ICON =
-  "M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2zM15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0z";
 
 /** Pushpin (lucide pin: head + body + stem), the group-header pin toggle / pinned indicator. */
 const PIN_ICON =

--- a/packages/web/src/components/ui/icons.tsx
+++ b/packages/web/src/components/ui/icons.tsx
@@ -143,6 +143,10 @@ export function CloseButton({
   );
 }
 
+/** Standard gear (lucide settings): full tooth outline + center circle, crisp and undistorted at 16px. */
+export const GEAR_ICON =
+  "M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2zM15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0z";
+
 /**
  * Page-nav glyphs (moved from sidebar.tsx: the sidebar nav, the collapsed rail in
  * app-layout.tsx, and cross-page jump actions — e.g. the chat info dropdown's "view

--- a/packages/web/src/features/agents/agents-page.tsx
+++ b/packages/web/src/features/agents/agents-page.tsx
@@ -34,6 +34,7 @@ import { Skeleton, SkeletonCard } from "../../components/ui/skeleton";
 import { EmptyState } from "../../components/ui/empty-state";
 import { AgentAvatar } from "../../components/ui/agent-avatar";
 import { GlyphIcon } from "../../components/ui/glyph-icon";
+import { GEAR_ICON } from "../../components/ui/icons";
 import { STAT_ICONS } from "../../lib/stat-icons";
 import { DRAFT_SESSION_ID } from "../chat/chat-page";
 import { parkActiveDraft } from "../chat/draft-sessions";
@@ -46,9 +47,6 @@ const BUILTIN_AGENT_IDS = new Set(["default_agent"]);
 const CARD_ICONS = {
   /** New chat (plus sign) */
   newChat: "M12 5v14M5 12h14",
-  /** Settings (gear, same as sidebar user menu) */
-  settings:
-    "M10.3 4.3a2 2 0 0 1 3.4 0l.5.8a2 2 0 0 0 1.8 1l1-.1a2 2 0 0 1 1.7 3l-.5.8a2 2 0 0 0 0 2l.5.8a2 2 0 0 1-1.7 3l-1-.1a2 2 0 0 0-1.8 1l-.5.8a2 2 0 0 1-3.4 0l-.5-.8a2 2 0 0 0-1.8-1l-1 .1a2 2 0 0 1-1.7-3l.5-.8a2 2 0 0 0 0-2l-.5-.8a2 2 0 0 1 1.7-3l1 .1a2 2 0 0 0 1.8-1zM12 10a2 2 0 1 0 0 4 2 2 0 0 0 0-4z",
   /** Delete (trash can) */
   trash:
     "M4 7h16M9 7V5a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2m3 0l-1 13a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2L6 7m4 4v6m4-6v6",
@@ -343,10 +341,7 @@ export function AgentsPage() {
                         navigate(`/agents/${a.agentId}`);
                       }}
                     >
-                      <GlyphIcon
-                        d={CARD_ICONS.settings}
-                        className="text-gray-600 dark:text-gray-300"
-                      />
+                      <GlyphIcon d={GEAR_ICON} />
                       {S.common.settings}
                     </Button>
                     <Button


### PR DESCRIPTION
## Problem

The Settings button on the agent list page (`agents-page.tsx`) had two visual defects:

1. **Divergent gear glyph.** The button used a hand-rolled simplified gear path in `CARD_ICONS.settings` whose comment claimed it was "same as sidebar user menu" — but it had diverged from the canonical sidebar gear (`GEAR_ICON` in `sidebar.tsx`, lucide settings) and rendered muddy at the default 13px, while the sidebar's standard gear stays crisp for the exact same navigate-to-agent-settings action.
2. **Icon dimmer than its own label.** The icon carried `text-gray-600 dark:text-gray-300` — the convention for icon-only buttons — making it a step dimmer than the button's text label (secondary Button: `text-gray-800 dark:text-gray-200`). The adjacent New Chat button's icon correctly inherits the text color.

## Fix

- Moved the canonical gear path to the shared `packages/web/src/components/ui/icons.tsx` as `GEAR_ICON` (comment preserved); `sidebar.tsx` now imports it instead of defining it locally.
- The agent list Settings button renders the shared `GEAR_ICON` via `GlyphIcon` with no color class and no explicit size, matching the New Chat button (inherits label text color, default 13px).
- Removed the divergent `CARD_ICONS.settings` path and its misleading comment.

No changes to navigation logic or to the other buttons in the row.

## Verification

- `pnpm -r build` — pass
- `pnpm typecheck` — pass
- `pnpm test` — pass (server suite flaked with worker timeouts under parallel-agent load on the first run; full pass 584/584 on rerun, and the diff is web-only)
- `pnpm format` + `pnpm format:check` — pass, no formatting drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)