### PR TITLE
feat(web): dismissible initial-password banner

### DIFF
--- a/packages/server/src/api/types.ts
+++ b/packages/server/src/api/types.ts
@@ -180,6 +180,8 @@ export interface UiPrefs {
    * scanning (#139).
    */
   showCliSessions?: boolean;
+  /** The initial-password notice banner (app layout) was permanently dismissed by the user. */
+  initialPasswordBannerDismissed?: boolean;
   [key: string]: unknown;
 }
 

--- a/packages/web/src/components/layout/app-layout.tsx
+++ b/packages/web/src/components/layout/app-layout.tsx
@@ -270,15 +270,17 @@ export function AppLayout() {
               {S.account.changeNow}
             </button>
             {/* Amber-toned twin of the shared CloseButton (same glyph + aria-label) — its hardcoded
-                gray colors would clash here. Absolutely positioned at the right edge: near-full-height
-                hit area without growing the banner and without transform (see the stacking-context
-                note in the file header); the banner's symmetric px-8 keeps the centered text clear. */}
+                gray colors would clash here. Flat: hover feedback is icon-color-only (no background
+                fill), same hover shades as the change-now link. Absolutely positioned at the right
+                edge: near-full-height hit area without growing the banner and without transform (see
+                the stacking-context note in the file header); the banner's symmetric px-8 keeps the
+                centered text clear. */}
             <button
               type="button"
               aria-label={S.common.close}
               title={S.common.close}
               onClick={dismissPasswordBanner}
-              className="absolute inset-y-0.5 right-1.5 flex items-center rounded-md px-1 text-amber-500 transition-colors duration-150 hover:bg-amber-100 hover:text-amber-800 dark:text-amber-400/70 dark:hover:bg-amber-900/40 dark:hover:text-amber-200"
+              className="absolute inset-y-0.5 right-1.5 flex items-center rounded-md px-1 text-amber-500 transition-colors duration-150 hover:text-amber-950 dark:text-amber-400/70 dark:hover:text-amber-100"
             >
               <svg
                 width="12"

--- a/packages/web/src/components/layout/app-layout.tsx
+++ b/packages/web/src/components/layout/app-layout.tsx
@@ -4,8 +4,9 @@
  * - <md: top thin bar (hamburger -> sidebar drawer + brand name) + main content.
  * All chrome uses solid backgrounds and avoids stacking contexts (frosted-glass/transform would trap overlay z-index).
  */
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { NavLink, Outlet, useMatch, useNavigate } from "react-router";
+import * as api from "../../api/endpoints";
 import { S } from "../../lib/strings";
 import { latestConversation } from "../../lib/session-grouping";
 import { useVersionInfo } from "../../lib/use-version-info";
@@ -175,6 +176,34 @@ export function AppLayout() {
   useCompletionNotifications();
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [changePasswordOpen, setChangePasswordOpen] = useState(false);
+  // Initial-password banner dismissal: server-persisted per user (ui_prefs). null = prefs not
+  // hydrated yet — the banner stays unrendered until the stored answer arrives, so an already
+  // dismissed banner never flashes before disappearing. Hydration only runs when the banner
+  // would show at all; unreachable prefs fail open (treated as not dismissed, banner shows).
+  const [passwordBannerDismissed, setPasswordBannerDismissed] = useState<boolean | null>(null);
+  const passwordBannerRelevant = Boolean(user?.passwordIsInitial) && !desktopMode;
+  useEffect(() => {
+    if (!passwordBannerRelevant) return;
+    let cancelled = false;
+    void api
+      .getPrefs()
+      .then((res) => {
+        if (!cancelled)
+          setPasswordBannerDismissed(res.prefs.initialPasswordBannerDismissed === true);
+      })
+      .catch(() => {
+        if (!cancelled) setPasswordBannerDismissed(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [passwordBannerRelevant]);
+  const dismissPasswordBanner = () => {
+    setPasswordBannerDismissed(true);
+    // Fire-and-forget: PUT /me/prefs merges shallowly; a lost write only costs persistence,
+    // the banner is already hidden for this tab.
+    void api.putPrefs({ initialPasswordBannerDismissed: true }).catch(() => undefined);
+  };
   // Desktop sidebar collapse (persisted): collapsed state leaves a narrow rail to expand from.
   const [collapsed, setCollapsed] = useState(
     () => localStorage.getItem("penguin.sidebarCollapsed") === "1",
@@ -227,9 +256,11 @@ export function AppLayout() {
         </header>
 
         {/* Initial-password notice banner (seed/admin-set password): disappears once passwordIsInitial clears after a successful change.
-            Hidden in desktop mode — the seed password there is random and never shown, so "change it" is meaningless nagging. */}
-        {user?.passwordIsInitial && !desktopMode && (
-          <div className="flex shrink-0 items-center justify-center gap-3 border-b border-amber-200 bg-amber-50 px-3 py-1.5 text-xs text-amber-800 dark:border-amber-900/60 dark:bg-amber-950/40 dark:text-amber-300">
+            Hidden in desktop mode — the seed password there is random and never shown, so "change it" is meaningless nagging.
+            Permanently dismissible via the X on the right (per-user ui_prefs); only rendered once
+            hydrated prefs confirm it was never dismissed, so it does not flash-then-vanish on load. */}
+        {passwordBannerRelevant && passwordBannerDismissed === false && (
+          <div className="relative flex shrink-0 items-center justify-center gap-3 border-b border-amber-200 bg-amber-50 px-8 py-1.5 text-xs text-amber-800 dark:border-amber-900/60 dark:bg-amber-950/40 dark:text-amber-300">
             <span>{S.account.initialPasswordBanner}</span>
             <button
               type="button"
@@ -237,6 +268,28 @@ export function AppLayout() {
               onClick={() => setChangePasswordOpen(true)}
             >
               {S.account.changeNow}
+            </button>
+            {/* Amber-toned twin of the shared CloseButton (same glyph + aria-label) — its hardcoded
+                gray colors would clash here. Absolutely positioned at the right edge: near-full-height
+                hit area without growing the banner and without transform (see the stacking-context
+                note in the file header); the banner's symmetric px-8 keeps the centered text clear. */}
+            <button
+              type="button"
+              aria-label={S.common.close}
+              title={S.common.close}
+              onClick={dismissPasswordBanner}
+              className="absolute inset-y-0.5 right-1.5 flex items-center rounded-md px-1 text-amber-500 transition-colors duration-150 hover:bg-amber-100 hover:text-amber-800 dark:text-amber-400/70 dark:hover:bg-amber-900/40 dark:hover:text-amber-200"
+            >
+              <svg
+                width="12"
+                height="12"
+                viewBox="0 0 14 14"
+                fill="none"
+                stroke="currentColor"
+                aria-hidden
+              >
+                <path d="M2 2l10 10M12 2L2 12" strokeWidth="1.5" strokeLinecap="round" />
+              </svg>
             </button>
           </div>
         )}


### PR DESCRIPTION
## Motivation

The initial-password notice banner (shown while `passwordIsInitial` is set, outside desktop mode) could not be dismissed — it nagged on every page until the password was changed. Users who understand and accept the risk can now permanently close it. The choice is persisted per-user in `ui_prefs` (new optional key `initialPasswordBannerDismissed`; the free-form prefs table needs no server route/storage change or migration).

## Behavior

- A small amber-toned close (X) button sits at the right edge of the banner. It reuses the shared `CloseButton` glyph and `aria-label` (`S.common.close`, no new i18n keys); the shared component itself hardcodes gray hover colors that clash with the amber banner, hence the local twin.
- Clicking it hides the banner immediately and fire-and-forgets `PUT /api/me/prefs { initialPasswordBannerDismissed: true }` (shallow merge; a lost write only costs persistence).
- **Hydrate before render to avoid flash**: the banner renders only after `GET /api/me/prefs` confirms the key is not `true`, so an already-dismissed banner never flashes and vanishes on load. The hydrate effect runs only when the banner would show at all (`passwordIsInitial && !desktopMode`), with a cancelled guard.
- **Fail-open on prefs error**: if the prefs fetch fails, the banner shows as before.

## Changes

- `packages/server/src/api/types.ts`: declare optional `initialPasswordBannerDismissed?: boolean` on `UiPrefs` (type-only; table is free-form).
- `packages/web/src/components/layout/app-layout.tsx`: hydrate state, dismiss handler, and the close button on the banner.

## Verification

All run at the repo root on Node v24:

- `pnpm -r build` — pass
- `pnpm typecheck` — pass (all packages)
- `pnpm test` — pass (exit 0; e.g. web 646/646, desktop 48/48)
- `pnpm format` + `pnpm format:check` — clean ("All matched files use Prettier code style!")

🤖 Generated with [Claude Code](https://claude.com/claude-code)