### PR TITLE
feat(core): web search tip in default system prompt

### DIFF
--- a/packages/core/src/state/default-config.ts
+++ b/packages/core/src/state/default-config.ts
@@ -394,6 +394,7 @@ Communicate with the user precisely and concisely, yet with warmth, and always r
 # Tool use
 - Prefer solving problems with your tools: inspect the real files and environment and run real commands instead of answering from memory or guessing.
 - For anything on the internet, browse with your shell tool: prefer Playwright when it is installed — it handles dynamic sites — otherwise \`curl\` for pages and APIs.
+- For web searches, \`curl -sG 'https://html.duckduckgo.com/html/' -A 'Mozilla/5.0' --data-urlencode 'q=your query'\` is the most reliable first stop, and \`curl -sGL 'https://news.google.com/rss/search' --data-urlencode 'q=your query'\` the fallback (best for news) — together they cover most research.
 
 # System markers
 Some messages carry system-synthesized \`[tag]...[/tag]\` blocks — not user text to answer:

--- a/packages/core/src/state/default-config.ts
+++ b/packages/core/src/state/default-config.ts
@@ -394,7 +394,7 @@ Communicate with the user precisely and concisely, yet with warmth, and always r
 # Tool use
 - Prefer solving problems with your tools: inspect the real files and environment and run real commands instead of answering from memory or guessing.
 - For anything on the internet, browse with your shell tool: prefer Playwright when it is installed — it handles dynamic sites — otherwise \`curl\` for pages and APIs.
-- For web searches, \`curl -sG 'https://html.duckduckgo.com/html/' -A 'Mozilla/5.0' --data-urlencode 'q=your query'\` is the most reliable first stop, and \`curl -sGL 'https://news.google.com/rss/search' --data-urlencode 'q=your query'\` the fallback (best for news) — together they cover most research.
+- For web searches, \`curl -sG 'https://html.duckduckgo.com/html/' -A 'Mozilla/5.0' --data-urlencode 'q=your query'\` is the most reliable first stop, and \`curl -sGL 'https://news.google.com/rss/search' --data-urlencode 'q=your query'\` the fallback (best for news) — together they cover most research. DuckDuckGo sometimes answers with a CAPTCHA/bot-check page instead of results; when it does, run the search through a Playwright-driven browser instead.
 
 # System markers
 Some messages carry system-synthesized \`[tag]...[/tag]\` blocks — not user text to answer:

--- a/packages/core/src/state/kernel-history.ts
+++ b/packages/core/src/state/kernel-history.ts
@@ -137,9 +137,15 @@ export function isKernelOutdated(kernelVersion: string | null | undefined): bool
  *   legacy # Vault / # Skills sections instead of the `{{VAULT}}` / `{{SKILLS}}` /
  *   `{{SCHEDULES}}` placeholders. The date is a retroactive label (configs of that era carry
  *   no stamp, so the key never has to match anything on disk; matching is purely by hash).
- *   The test suite proves these hashes equal a byte-exact reconstruction of that era's
- *   defaults from the frozen LEGACY_* constants.
- * - `"2026-08-11"` (current) — the toggles generation, pinned by the guard test.
+ *   At seeding time these hashes were proven equal to a byte-exact reconstruction of that
+ *   era's defaults from the frozen LEGACY_* constants; that reconstruction is snapshotted as
+ *   the test fixture `core/test/fixtures/pre-toggles-default-config.json`, which the proof
+ *   test asserts against permanently (the recipe read the *current* defaults, so it stopped
+ *   reproducing this era the first time the template evolved past the toggles generation).
+ * - `"2026-08-11"` (current) — the toggles generation, pinned by the guard test. Revised in
+ *   place the same day when the web-search tip joined the default template — the same-day
+ *   rule in action: no later generation exists, so the entry is not yet frozen and the
+ *   superseded hash simply disappears (nothing in the wild was stamped with it).
  *
  * Generations older than the seeded ones cannot be fully reconstructed; their values match
  * no recorded hash and are conservatively kept by a kernel update (restore-default-config is
@@ -177,7 +183,7 @@ export const KERNEL_HASH_HISTORY: Readonly<Record<string, Readonly<Record<string
       "fad6d0cdd483eb53b5d243c0508024ab3b708ce6d3c81933acd291f05d4a265f",
   },
   "2026-08-11": {
-    system_prompt: "de8952daede04db17400c5cd59b279eccf523cf2d8a0ecedfa37a96de7925b44",
+    system_prompt: "c5be0d4b5627ebf23e953923a27df971d3836486494127c8bfba68d368ad45ea",
     max_turns: "1bad6b8cf97131fceab8543e81f7757195fbb1d36b376ee994ad1cf17699c464",
     "model.max_tokens": "492f431bae35265f2e5f4ed49bd8c58dda912431be561504846988d00d05d117",
     "model.thinking_level": "60d4c90eee5e731df8d3ef2891de541d2e755ff8ee9db358e26bdec49f6e0db9",

--- a/packages/core/src/state/kernel-history.ts
+++ b/packages/core/src/state/kernel-history.ts
@@ -143,9 +143,10 @@ export function isKernelOutdated(kernelVersion: string | null | undefined): bool
  *   test asserts against permanently (the recipe read the *current* defaults, so it stopped
  *   reproducing this era the first time the template evolved past the toggles generation).
  * - `"2026-08-11"` (current) — the toggles generation, pinned by the guard test. Revised in
- *   place the same day when the web-search tip joined the default template — the same-day
- *   rule in action: no later generation exists, so the entry is not yet frozen and the
- *   superseded hash simply disappears (nothing in the wild was stamped with it).
+ *   place the same day as the web-search tip joined the default template (and again as the
+ *   tip gained its CAPTCHA/Playwright fallback note) — the same-day rule in action: no later
+ *   generation exists, so the entry is not yet frozen and each superseded hash simply
+ *   disappears (nothing in the wild was stamped with it).
  *
  * Generations older than the seeded ones cannot be fully reconstructed; their values match
  * no recorded hash and are conservatively kept by a kernel update (restore-default-config is
@@ -183,7 +184,7 @@ export const KERNEL_HASH_HISTORY: Readonly<Record<string, Readonly<Record<string
       "fad6d0cdd483eb53b5d243c0508024ab3b708ce6d3c81933acd291f05d4a265f",
   },
   "2026-08-11": {
-    system_prompt: "c5be0d4b5627ebf23e953923a27df971d3836486494127c8bfba68d368ad45ea",
+    system_prompt: "7018eb4c52623e9f79d9b979b0b0773cc56e465e1f7d5c3d60baa10c26067455",
     max_turns: "1bad6b8cf97131fceab8543e81f7757195fbb1d36b376ee994ad1cf17699c464",
     "model.max_tokens": "492f431bae35265f2e5f4ed49bd8c58dda912431be561504846988d00d05d117",
     "model.thinking_level": "60d4c90eee5e731df8d3ef2891de541d2e755ff8ee9db358e26bdec49f6e0db9",

--- a/packages/core/test/fixtures/pre-toggles-default-config.json
+++ b/packages/core/test/fixtures/pre-toggles-default-config.json
@@ -1,0 +1,269 @@
+{
+  "version": 1,
+  "system_prompt": "# Role\nYou are PenguinHarness, an agent that completes the user's requests on their machine with the tools available to you.\n\n# Personality\nCommunicate with the user precisely and concisely, yet with warmth, and always reply in the user's language — code, identifiers and commit messages keep their own conventions. Do not repeatedly explain your tools or restate their results.\n\n# Success criteria\n- Before delivering the result, check that every problem in the request has been solved.\n- Verify your work through every available means; never claim a result you did not observe.\n\n# Constraints\n- Make the smallest change that satisfies the request; do not modify unrelated files.\n- Destructive operations are forbidden.\n- Never kill a process you did not start, PenguinHarness's own services included, unless the user asks; never take a PenguinHarness service port, and when a port you want is busy, pick another free port.\n- If a tool call fails, read the error, adjust, and retry; never repeat the same failing input.\n\n# Stop rules\n- Stop and give the final answer once the success criteria are met.\n- If the request is ambiguous, stop and ask the user for clarification instead of guessing their intent.\n- If you hit an error you cannot resolve, stop and report the blocker to the user. An API auth/key error (401/403, missing or invalid key) is one of them: retry at most once, then stop calling tools and ask the user to update the key in the agent's vault or the model settings outside the chat — the secret must never be pasted into the conversation, and a new key only takes effect in the next conversation.\n\n# Tool use\n- Prefer solving problems with your tools: inspect the real files and environment and run real commands instead of answering from memory or guessing.\n- For anything on the internet, browse with your shell tool: prefer Playwright when it is installed — it handles dynamic sites — otherwise `curl` for pages and APIs.\n\n# System markers\nSome messages carry system-synthesized `[tag]...[/tag]` blocks — not user text to answer:\n- `[turn_aborted]`: the previous round was interrupted; inside are the request, your partial output, and the tool calls already run with their results. Continue from there, and do not re-run them.\n- `[turn_retried]`: the previous attempt failed on its own (timeout, disconnect, malformed response, provider error — the user did NOT interrupt) and this is the automatic retry; same contents, same rule.\n- `[context_summary]`: earlier conversation was compacted. The summary is its only record — treat it as established context and continue from it.\n- `[user_steering]`: a user message sent mid-run, delivered between turns. Not a new task: incorporate it immediately and adjust course within the current one.\n\n# File system\n- Angle-bracket names such as `<app_data_dir>` and `<session_id>` are placeholders — substitute the values from the Environment section.\n- You work inside the user's folder (`CWD`). For each file you create or update there, mention its workspace-relative path in backticks (e.g. `src/app.py`) so the user can open it.\n- The App Data Dir is PenguinHarness's data root — every agent's files and the project-level data, none of it supplied by the user, so never treat it as task input. `CWD` may itself be a temporary Workspace inside it: that one folder is the task's, the rest is not.\n- Your Agent State is `<app_data_dir>/agents/<agent_id>/agent_state/`; it holds `skills/`, and its `AGENTS.md` is already in your context. Another agent's is the same path under its id — reach it directly.\n- Keep intermediates in this Session's scratchpad, `<app_data_dir>/agents/<agent_id>/scratchpad/<session_id>/`, but always place final deliverables in the workspace (under `CWD`) — what stays in the scratchpad is not part of your output.\n- Install into the project's own environment when it has one. Otherwise keep reusable ones — Python virtualenvs, model and package caches — under `<app_data_dir>/agents/<agent_id>/shared_env/<name>/` and reuse them across Sessions. For Node, prefer pnpm in the project itself: its shared store keeps repeated installs from duplicating on disk.\n- Never read, copy or print `.project_config.toml` or any agent's `agent_state/.vault.toml` — they hold the user's secrets. Configuration is CLI-only (`penguin config ...`); if a task seems to need them, say so and ask the user instead.\n\n# Suggested workflows\nRecommendations, not requirements — adapt them to the task.\n- For a long-horizon task, first write a plan (task overview + itemized steps) to `PLAN.md` in this Session's scratchpad, and update it as each step lands.\n- Delegate self-contained subtasks with `run_subagent`, and dispatch independent ones in parallel — that is the fastest way through a large task. Open each prompt with your own agent id (e.g. \"Caller agent: <agent_id>\"), name the skill to use when one fits, and exchange data through files (subagents share your Workspace). If `run_subagent` is not in your tool list, you are the subagent: do the work yourself.\n- Prefer React when building a web app or frontend.\n\n[developer_instructions]\nCustom instructions from the developer-editable AGENTS.md.\n\n{{AGENTS_MD}}\n[/developer_instructions]\n\n# Vault\nThe vault holds this agent's per-agent secrets (agent_state/.vault.toml). Each entry is injected into your shell subprocesses as an environment variable — values never appear in your context. Use the variable names below in commands when a task needs them.\n{{VAULT_KEYS}}\n\n# Skills\nSkills are reusable instruction packages at `<app_data_dir>/agents/<agent_id>/agent_state/skills/<skill_name>/SKILL.md`. When a task matches one below, or the user asks for one (the message may start with a [use_skills] block naming them), read that SKILL.md in full with read_file, then follow it. If a request names a skill without a concrete task, ask the user what they need first.\n{{SKILL_METADATA}}\n\n{{MEMORY}}\n\n# Environment\n- Platform: {{PLATFORM}}\n- OS Version: {{OS_VERSION}}\n- Shell: {{SHELL}}\n- Date: {{DATE}}\n- App Data Dir: {{PROJECT_DIR}}\n- Agent ID: {{AGENT_ID}}\n- CWD: {{CWD}}\n- Provider: {{PROVIDER}}\n- Model ID: {{MODEL_ID}}\n- Session ID: {{SESSION_ID}}",
+  "max_turns": -1,
+  "model": {
+    "max_tokens": 32000,
+    "thinking_level": "medium",
+    "timeoutMs": 120000
+  },
+  "compaction": {
+    "max_context_length": 128000,
+    "max_session_turns": -1,
+    "mode": "summarize",
+    "prompt": "Summarize the task transcript above. The summary will replace the transcript as its only record, so include everything needed to continue the task — the original request, current state, next steps, and any learnings. Do not call any tools; reply with text only, in exactly this format and nothing after it:\n\n[summary]put the summary text here...[/summary]"
+  },
+  "memory": {
+    "enabled": true,
+    "prompt": "# Memory\nYour long-term record across sessions: Markdown files you maintain with the file tools, in the memory directories named below (they already exist). One file per fact, with frontmatter:\n\n```markdown\n---\nname: <kebab-case-slug, matching the file name>\ndescription: <one line — used to decide relevance during recall>\nupdated_at: <YYYY-MM-DD>\n---\n\n<the fact; for corrections and decisions add **Why:** and **How to apply:** lines. Link related memories with [[their-name]] — a name that doesn't exist yet is fine. Write dates absolute.>\n```\n\nWorth saving: who the user is (role, expertise, preferences) and how they want you to work, with the why; ongoing work, goals and constraints not derivable from the code; pointers to external resources.\n\nEach directory's `MEMORY.md` is its index, injected below: one line per memory, under ~150 characters (`- [Title](file.md) — hook`), no content, updated in the same round as the file — deletions included. Only the first 200 lines of an index are injected — keep it well under that: merge overlapping entries, drop stale ones, move detail into the topic files. Before saving, check the index and update the file that already covers the subject instead of duplicating; delete memories that prove wrong. Never save what code, config or git history already states, task progress, secrets, unconfirmed guesses, or transcript excerpts — if asked to, save the non-obvious part instead. Memory is readable by everyone who can reach this agent: no sensitive personal data.\n\n## User memory\nWhat holds wherever you work; every one of your sessions reads it.\n\nUser Memory Dir: `<app_data_dir>/agents/<agent_id>/agent_state/memory/user`\n\nIndex:\n{{USER_MEMORY_INDEX}}",
+    "workspace_prompt": "## Workspace memory\nFacts about the workspace you are working in now. What would still hold in a different project goes in user memory; when unsure, write here.\n\nWorkspace Memory Dir: `{{WORKSPACE_MEMORY_DIR}}`\n\nIndex:\n{{WORKSPACE_MEMORY_INDEX}}"
+  },
+  "tools": {
+    "builtin": [
+      {
+        "name": "read_file",
+        "description": "Read a text file and return its content with line numbers (cat -n style) — the preferred way to inspect a file. Returns up to 2000 lines starting at the given offset; for longer files call again with offset to continue. Use the image tools for images and the shell tool for binary files.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "file_path": {
+              "type": "string",
+              "description": "Path to the file to read; absolute, or relative to the workspace."
+            },
+            "offset": {
+              "type": "number",
+              "description": "1-based line number to start reading from; defaults to 1."
+            },
+            "limit": {
+              "type": "number",
+              "description": "Max lines to read; defaults to 2000."
+            }
+          },
+          "required": ["file_path"]
+        },
+        "permission": "r",
+        "timeoutMs": 30000,
+        "maxOutputLength": 64000
+      },
+      {
+        "name": "edit_file",
+        "description": "Edit a file by exact string replacement — the preferred way to make a precise change. old_string must match the file content exactly (including whitespace) and be unique unless replace_all is set; read the file first to copy the text verbatim. The result echoes a line-numbered snippet around the change for verification.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "file_path": {
+              "type": "string",
+              "description": "Path to the file to edit; absolute, or relative to the workspace."
+            },
+            "old_string": {
+              "type": "string",
+              "description": "Exact text to replace, including whitespace/indentation."
+            },
+            "new_string": {
+              "type": "string",
+              "description": "Replacement text; must differ from old_string."
+            },
+            "replace_all": {
+              "type": "boolean",
+              "description": "Replace every occurrence of old_string; defaults to false."
+            }
+          },
+          "required": ["file_path", "old_string", "new_string"]
+        },
+        "permission": "rw",
+        "timeoutMs": 30000,
+        "maxOutputLength": 16000
+      },
+      {
+        "name": "write_file",
+        "description": "Create or overwrite a file with the given content, creating parent directories as needed. Use it for new files or full rewrites; for precise changes to an existing file prefer edit_file.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "file_path": {
+              "type": "string",
+              "description": "Path to the file to write; absolute, or relative to the workspace."
+            },
+            "content": {
+              "type": "string",
+              "description": "Full file content to write; an empty string creates an empty file."
+            }
+          },
+          "required": ["file_path", "content"]
+        },
+        "permission": "rw",
+        "timeoutMs": 30000,
+        "maxOutputLength": 16000
+      },
+      {
+        "name": "exec_command",
+        "description": "Run a shell command in the workspace to run programs, search, install dependencies, and everything the file tools don't cover. Run long-lived commands (servers, watchers, builds) in the foreground: past yield_time_ms they keep running in the background with a process_id. Do not background them with `&` — the whole process group is cleaned up when the foreground command exits.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "description": {
+              "type": "string",
+              "description": "Required, and emit it first, before the other arguments: it is shown to the user while the call runs. One short sentence describing what this call is doing and why, written in the user's language."
+            },
+            "cmd": {
+              "type": "string",
+              "description": "Shell command to execute."
+            },
+            "workdir": {
+              "type": "string",
+              "description": "Working directory for the command; defaults to the cwd. Optionally a path relative to the cwd, or an absolute path."
+            },
+            "yield_time_ms": {
+              "type": "number",
+              "description": "How long to wait for the command before yielding. If it is still running when this elapses, the tool returns the output so far plus a process_id, and the command keeps running in the background (drive it with input_command). Defaults to 60000; minimum 250, capped below the tool timeout."
+            }
+          },
+          "required": ["description", "cmd"]
+        },
+        "permission": "rw",
+        "call_description": true,
+        "timeoutMs": 120000,
+        "maxOutputLength": 16000
+      },
+      {
+        "name": "input_command",
+        "description": "Interact with a running command session started by exec_command: write to its stdin, send Ctrl-C, or poll for new output. Identify the session with its process_id.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "description": {
+              "type": "string",
+              "description": "Required, and emit it first, before the other arguments: it is shown to the user while the call runs. One short sentence describing what this call is doing and why, written in the user's language."
+            },
+            "process_id": {
+              "type": "string",
+              "description": "The process_id returned by exec_command for the running command session."
+            },
+            "chars": {
+              "type": "string",
+              "description": "Characters to write to the command's stdin. Send \"\\u0003\" alone to deliver Ctrl-C (SIGINT); mixing it with other characters is an error. Empty (the default) writes nothing and only polls for new output and exit status."
+            },
+            "yield_time_ms": {
+              "type": "number",
+              "description": "How long to wait for new output or exit before returning. Non-empty writes default to 250; empty polls default to 5000. Minimum 250, capped below the tool timeout."
+            }
+          },
+          "required": ["description", "process_id"]
+        },
+        "permission": "rw",
+        "call_description": true,
+        "timeoutMs": 130000,
+        "maxOutputLength": 16000
+      },
+      {
+        "name": "run_subagent",
+        "description": "Delegate a self-contained subtask to a subagent that runs autonomously in the same workspace and returns its final answer. Use it for focused sub-tasks you can fully specify in one prompt. Optionally choose a specific agent via `agent_id` and a model via `model_id`. Begin the prompt by identifying yourself with your own agent id (from the Environment section), e.g. \"Caller agent: default_agent\" — the subagent cannot otherwise tell who invoked it.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "description": {
+              "type": "string",
+              "description": "Required, and emit it first, before the other arguments: it is shown to the user while the call runs. One short sentence describing what this call is doing and why, written in the user's language."
+            },
+            "prompt": {
+              "type": "string",
+              "description": "The complete task for the subagent: include all context it needs and the exact final output you expect back."
+            },
+            "agent_id": {
+              "type": "string",
+              "description": "Which agent to run as the subagent; defaults to the current agent when omitted."
+            },
+            "model_id": {
+              "type": "string",
+              "description": "Which model the subagent should use, as the upstream model id. Must be given together with provider — a model is always referenced by the pair. Omit both to inherit the parent session's model."
+            },
+            "provider": {
+              "type": "string",
+              "description": "The provider group that model_id belongs to (see the Environment section's Provider). Required whenever model_id is given."
+            },
+            "yield_time_ms": {
+              "type": "number",
+              "description": "How long to wait for the subagent before yielding. If it is still working when this elapses, the tool returns the output so far plus a subagent_id, and the subagent keeps running in the background (drive it with input_subagent). Defaults to 300000; minimum 250, capped below the tool timeout."
+            }
+          },
+          "required": ["description", "prompt"]
+        },
+        "permission": "rw",
+        "call_description": true,
+        "timeoutMs": 600000,
+        "maxOutputLength": 16000
+      },
+      {
+        "name": "input_subagent",
+        "description": "Interact with a background subagent started by run_subagent: poll for new output, or send a follow-up prompt once it is idle to continue the same subagent session. Identify the session with its subagent_id. Pending tool approvals of the subagent are surfaced while this tool is waiting.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "description": {
+              "type": "string",
+              "description": "Required, and emit it first, before the other arguments: it is shown to the user while the call runs. One short sentence describing what this call is doing and why, written in the user's language."
+            },
+            "subagent_id": {
+              "type": "string",
+              "description": "The subagent_id returned by run_subagent for the background subagent."
+            },
+            "prompt": {
+              "type": "string",
+              "description": "A follow-up task for the subagent, delivered as a new user message on the same session. Only accepted when the subagent is idle (its previous run finished). Empty (the default) sends nothing and only polls for new output and status."
+            },
+            "yield_time_ms": {
+              "type": "number",
+              "description": "How long to wait for new output or completion before returning. Follow-up prompts default to 300000; empty polls default to 10000. Minimum 250, capped below the tool timeout."
+            }
+          },
+          "required": ["description", "subagent_id"]
+        },
+        "permission": "rw",
+        "call_description": true,
+        "timeoutMs": 600000,
+        "maxOutputLength": 16000
+      },
+      {
+        "name": "read_image",
+        "forModel": "vision",
+        "description": "Read an image and return it as image content for you to view. Accepts an http(s) URL or a local file path (relative paths resolve against the workspace). Supports png/jpeg/gif/webp up to 5MB.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "source": {
+              "type": "string",
+              "description": "Image to read: an http(s) URL, or a local file path (absolute, or relative to the workspace)."
+            }
+          },
+          "required": ["source"]
+        },
+        "permission": "r",
+        "timeoutMs": 60000,
+        "maxOutputLength": 16000
+      },
+      {
+        "name": "describe_image",
+        "forModel": "text-only",
+        "description": "Describe an image and return a TEXT description of it. The current model does not accept images directly, so the image is analyzed by the project's configured vision model and you get its text answer back. Use `prompt` to ask exactly what you need to know about the image (e.g. transcribe text, describe a chart, locate a UI element). Accepts an http(s) URL or a local file path (relative paths resolve against the workspace). Supports png/jpeg/gif/webp up to 5MB.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "source": {
+              "type": "string",
+              "description": "Image to read: an http(s) URL, or a local file path (absolute, or relative to the workspace)."
+            },
+            "prompt": {
+              "type": "string",
+              "description": "What to ask about the image; the vision model answers this. Defaults to a detailed description."
+            }
+          },
+          "required": ["source"]
+        },
+        "permission": "r",
+        "timeoutMs": 90000,
+        "maxOutputLength": 16000
+      }
+    ],
+    "mcpServers": []
+  }
+}

--- a/packages/core/test/kernel-version.test.ts
+++ b/packages/core/test/kernel-version.test.ts
@@ -5,9 +5,11 @@
  * defaults advance, customizations and unknown generations are kept, identity fields and
  * user data are never touched, YAML comments survive, the config is re-stamped).
  */
+import { readFileSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import {
@@ -15,11 +17,6 @@ import {
   DEFAULT_PROJECT_ID,
   KERNEL_HASH_HISTORY,
   KERNEL_VERSION,
-  LEGACY_SKILLS_SECTION,
-  LEGACY_VAULT_SECTION,
-  SCHEDULES_PLACEHOLDER,
-  SKILLS_PLACEHOLDER,
-  VAULT_PLACEHOLDER,
   applyKernelUpdate,
   computeKernelHashes,
   defaultSystemConfig,
@@ -31,41 +28,35 @@ import {
   type SystemConfig,
 } from "../src/index.js";
 
-/** The two seeded generations (see KERNEL_HASH_HISTORY's doc comment). */
+/** The oldest seeded generation (see KERNEL_HASH_HISTORY's doc comment). */
 const PRE_TOGGLES_GENERATION = "2026-08-10";
-const TOGGLES_GENERATION = "2026-08-11";
+
+/**
+ * The complete pre-#257 (pre-toggles) default config, frozen at seeding time: the legacy
+ * template (hardcoded # Vault / # Skills sections, no `{{SCHEDULES}}`), no
+ * vault/skills/schedules config sections, no kernel stamp — what a `system_config.yaml` of
+ * that era carries. Originally generated from the then-current defaults via the LEGACY_*
+ * swap recipe and verified leaf-by-leaf against the pinned `PRE_TOGGLES_GENERATION` entry
+ * (see PR #260); snapshotted rather than reconstructed live because the recipe read the
+ * *current* defaults — it stopped reproducing this era the moment the template first evolved
+ * past the toggles generation (the web-search tip). Frozen like the pinned hashes
+ * themselves: never edit the fixture.
+ */
+const PRE_TOGGLES_CONFIG = JSON.parse(
+  readFileSync(
+    fileURLToPath(new URL("./fixtures/pre-toggles-default-config.json", import.meta.url)),
+    "utf8",
+  ),
+) as SystemConfig;
 
 /** A mutable plain-object clone of a config, for seeding on-disk scenarios. */
 function mutableConfig(config: SystemConfig): Record<string, unknown> {
   return structuredClone(config) as unknown as Record<string, unknown>;
 }
 
-/**
- * Reconstructs the pre-#257 (pre-toggles) default config from the current one: the frozen
- * LEGACY_* sections swapped back into the template in place of the section placeholders, no
- * `{{SCHEDULES}}` line, and no vault/skills/schedules config sections — exactly what a
- * `system_config.yaml` of that era carries (the same recipe prompt-sections.test.ts proves
- * byte-exact for the template).
- */
+/** A fresh copy of the frozen pre-toggles default config (clone: tests mutate their seeds). */
 function preTogglesDefaultConfig(): SystemConfig {
-  const current = defaultSystemConfig();
-  const {
-    vault: _vault,
-    skills: _skills,
-    schedules: _schedules,
-    kernel_version: _stamp,
-    ...rest
-  } = current;
-  return {
-    ...rest,
-    system_prompt: current.system_prompt
-      .split(VAULT_PLACEHOLDER)
-      .join(LEGACY_VAULT_SECTION)
-      .split(SKILLS_PLACEHOLDER)
-      .join(LEGACY_SKILLS_SECTION)
-      .split(`${SCHEDULES_PLACEHOLDER}\n\n`)
-      .join(""),
-  };
+  return structuredClone(PRE_TOGGLES_CONFIG);
 }
 
 describe("kernel hash history (pinned-hash guard)", () => {
@@ -95,18 +86,20 @@ describe("kernel hash history (pinned-hash guard)", () => {
     ).toEqual([]);
   });
 
-  // Anchored to the first shipped generation: the reconstruction recipe reads the *current*
-  // defaults, so it only reproduces the pre-toggles era while the current generation is
-  // still the toggles one. Once the defaults evolve past it this proof self-retires — the
-  // pinned hashes remain the frozen source of truth on their own.
-  it.runIf(KERNEL_VERSION === TOGGLES_GENERATION)(
-    "the pre-toggles generation's pinned hashes equal the LEGACY_* reconstruction",
-    () => {
-      expect(computeKernelHashes(preTogglesDefaultConfig())).toEqual(
-        KERNEL_HASH_HISTORY[PRE_TOGGLES_GENERATION],
-      );
-    },
-  );
+  // The seeding proof, in permanent form: the frozen full-config snapshot and the pinned
+  // hash entry are independent frozen artifacts (the snapshot was generated from the
+  // then-current defaults via the LEGACY_* swap recipe and verified at freeze time, see PR
+  // #260), so asserting they agree keeps the pre-toggles generation's hashes anchored to
+  // real config content — non-tautologically, and regardless of how the current defaults
+  // evolve. Originally this reconstructed from the live defaults under an
+  // `it.runIf(KERNEL_VERSION === "2026-08-11")` anchor; the first same-day template revision
+  // (the web-search tip) invalidated that recipe, per its documented design, and the
+  // snapshot replaced it.
+  it("the pre-toggles generation's pinned hashes equal the frozen config snapshot", () => {
+    expect(computeKernelHashes(preTogglesDefaultConfig())).toEqual(
+      KERNEL_HASH_HISTORY[PRE_TOGGLES_GENERATION],
+    );
+  });
 
   it("excludes identity fields and mcpServers from the managed leaves", () => {
     const paths = kernelLeafEntries({

--- a/packages/server/test/agent-kernel-update.test.ts
+++ b/packages/server/test/agent-kernel-update.test.ts
@@ -8,16 +8,7 @@
 import fs from "node:fs/promises";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
-import {
-  KERNEL_VERSION,
-  LEGACY_SKILLS_SECTION,
-  LEGACY_VAULT_SECTION,
-  SCHEDULES_PLACEHOLDER,
-  SKILLS_PLACEHOLDER,
-  VAULT_PLACEHOLDER,
-  defaultSystemConfig,
-  systemConfigPath,
-} from "@prismshadow/penguin-core";
+import { KERNEL_VERSION, defaultSystemConfig, systemConfigPath } from "@prismshadow/penguin-core";
 import type {
   AgentConfigResponse,
   AgentKernelUpdateResponse,
@@ -47,10 +38,11 @@ describe("POST agent config kernel-update", () => {
   });
 
   /**
-   * Rewrites default_agent's config on disk into a pre-toggles-era shape with one user
-   * customization: no kernel stamp, the legacy default template (LEGACY_* sections instead
-   * of the section placeholders, no {{SCHEDULES}}), no vault/skills/schedules sections, and
-   * a customized memory.prompt.
+   * Rewrites default_agent's config on disk into an aged shape with one user customization:
+   * no kernel stamp, no vault/skills/schedules sections (a config from before those existed),
+   * and a customized memory.prompt. The template stays the current default — the
+   * old-template-advance path itself is core-tested against the frozen pre-toggles snapshot
+   * (core/test/kernel-version.test.ts); here the endpoint semantics are what's under test.
    */
   async function agePersistedConfig(): Promise<void> {
     const configPath = systemConfigPath(t.root, projectId, "default_agent");
@@ -59,13 +51,6 @@ describe("POST agent config kernel-update", () => {
     delete config.vault;
     delete config.skills;
     delete config.schedules;
-    config.system_prompt = defaultSystemConfig()
-      .system_prompt.split(VAULT_PLACEHOLDER)
-      .join(LEGACY_VAULT_SECTION)
-      .split(SKILLS_PLACEHOLDER)
-      .join(LEGACY_SKILLS_SECTION)
-      .split(`${SCHEDULES_PLACEHOLDER}\n\n`)
-      .join("");
     config.memory = { ...(config.memory as object), prompt: "my memory prompt" };
     await fs.writeFile(configPath, stringifyYaml(config), "utf8");
   }
@@ -96,13 +81,17 @@ describe("POST agent config kernel-update", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as AgentKernelUpdateResponse;
     expect(body.kernelVersion).toBe(KERNEL_VERSION);
-    expect(body.advanced).toContain("system_prompt");
+    // The missing sections materialize; the untouched current-default template is not
+    // reported (nothing to advance).
     expect(body.advanced).toContain("vault.prompt");
+    expect(body.advanced).toContain("schedules.enabled");
+    expect(body.advanced).not.toContain("system_prompt");
     expect(body.kept).toEqual(["memory.prompt"]);
 
-    // Persisted: the template advanced, the customization survived, the stamp is current.
+    // Persisted: the sections advanced, the customization survived, the stamp is current.
     const after = (await (await alice.get(configUrl())).json()) as AgentConfigResponse;
     expect(after.config.systemPrompt).toBe(defaultSystemConfig().system_prompt);
+    expect(after.config.vault.enabled).toBe(true);
     expect(after.config.memory.prompt).toBe("my memory prompt");
     expect(after.config.kernelVersion).toBe(KERNEL_VERSION);
     expect(after.config.kernelOutdated).toBe(false);


### PR DESCRIPTION
Stacked on #260 (which stacks on #257); review only this PR's commits.

## What

Adds one guidance bullet to the default system prompt's **# Tool use** section, right after the browse-with-shell bullet:

```
- For web searches, `curl -sG 'https://html.duckduckgo.com/html/' -A 'Mozilla/5.0' --data-urlencode 'q=your query'` is the most reliable first stop, and `curl -sGL 'https://news.google.com/rss/search' --data-urlencode 'q=your query'` the fallback (best for news) — together they cover most research.
```

Guidance, not a mandate. Both endpoints were live-tested before wording the tip:

- **DuckDuckGo HTML** — HTTP 200, ~34 KB HTML for a real query, 10 `result__a` links with titles + redirect URLs. Works exactly as written.
- **Google News RSS search** — the bare URL 302-redirects to itself with locale params (`hl/gl/ceid`) and an empty body; with `-L` it returns HTTP 200 and a full RSS feed (102 `<item>`s for the test query). The tip therefore spells `-sGL`, and `--data-urlencode` covers the q-encoding requirement.

## Kernel bump flow (first real run of #260's mechanism)

- The pinned-hash guard went red exactly as designed (only `system_prompt` drifted) and — per the **same-day revision rule** — the `"2026-08-11"` `KERNEL_HASH_HISTORY` entry was revised in place with the new `system_prompt` hash; `KERNEL_VERSION` is unchanged. No later generation exists, so the entry was not yet frozen, and the superseded hash disappears legitimately: #260 is unmerged, nothing in the wild was ever stamped with it.
- The pre-#257 **reconstruction proof** was anchored (`it.runIf`) on a recipe that read the *current* template, which this change invalidates — handled per its documented design, upgraded rather than retired: the **complete** pre-toggles default config is now a frozen test fixture (`core/test/fixtures/pre-toggles-default-config.json`), generated from the still-unchanged toggles-generation defaults and verified leaf-by-leaf against the pinned `"2026-08-10"` entry before freezing. The proof test asserts snapshot ↔ pinned entry — two independent frozen artifacts, so it stays non-tautological and **permanently valid** however the current defaults evolve (the whole config is frozen, not just the template, so future non-template default changes cannot re-break it).
- The core merge tests seed their "old config" scenarios from the same frozen snapshot, so "an untouched pre-toggles config advances wholesale" genuinely proves the old template (hash-matching `"2026-08-10"`) advances to the **new** template.
- The server endpoint test previously aged its config via the live recipe; it now ages by de-stamping and dropping the vault/skills/schedules sections (template left at the current default), asserting section materialization + kept customization + flags — the old-template-advance path stays covered in core against the frozen snapshot.

No new `{{…}}` placeholders, so the web placeholder-parity test is untouched; docs need no change (the tip lives in the template itself).

## Verification

- `pnpm -r build` — pass
- `pnpm typecheck` — pass (8 packages)
- `pnpm test` — pass (all suites; kernel guard green against the revised entry, snapshot proof green, server endpoint tests reshaped and green)
- `pnpm format` + `pnpm format:check` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
