### PR TITLE
fix(deps): force @hono/node-server >= 2.0.5 and nanoid >= 3.3.17

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,8 @@ settings:
 overrides:
   '@anthropic-ai/sdk': ^0.91.1
   esbuild: ^0.28.1
+  '@hono/node-server': '>=2.0.5'
+  nanoid: ^3.3.17
 
 importers:
 
@@ -262,7 +264,7 @@ importers:
   packages/server:
     dependencies:
       '@hono/node-server':
-        specifier: ^2.0.5
+        specifier: '>=2.0.5'
         version: 2.0.12(hono@4.12.34)
       '@prismshadow/penguin-core':
         specifier: workspace:*
@@ -818,12 +820,6 @@ packages:
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
         optional: true
-
-  '@hono/node-server@1.19.17':
-    resolution: {integrity: sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==}
-    engines: {node: '>=18.14.1'}
-    peerDependencies:
-      hono: ^4
 
   '@hono/node-server@2.0.12':
     resolution: {integrity: sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==}
@@ -2764,8 +2760,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -4309,10 +4305,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@hono/node-server@1.19.17(hono@4.12.34)':
-    dependencies:
-      hono: 4.12.34
-
   '@hono/node-server@2.0.12(hono@4.12.34)':
     dependencies:
       hono: 4.12.34
@@ -4369,7 +4361,7 @@ snapshots:
 
   '@modelcontextprotocol/node@2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.12.34)':
     dependencies:
-      '@hono/node-server': 1.19.17(hono@4.12.34)
+      '@hono/node-server': 2.0.12(hono@4.12.34)
       '@modelcontextprotocol/server': 2.0.0
     optionalDependencies:
       hono: 4.12.34
@@ -6687,7 +6679,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   negotiator@0.6.3: {}
 
@@ -6847,7 +6839,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,14 @@ packages:
 overrides:
   "@anthropic-ai/sdk": "^0.91.1"
   esbuild: "^0.28.1"
+  # GHSA-frvp-7c67-39w9: @hono/node-server < 2.0.5 path traversal (serve-static on
+  # Windows). Our direct dep is already ^2.0.5; this forces the transitive copy pulled
+  # by @modelcontextprotocol/node (which pins ^1.19.9, no fixed upstream release yet).
+  # Remove once @modelcontextprotocol/node depends on @hono/node-server >= 2.0.5.
+  "@hono/node-server": ">=2.0.5"
+  # nanoid < 3.3.17 high (custom generators can loop indefinitely on size 0); only
+  # 3.x copies exist here (transitive). Remove once no dependent resolves < 3.3.17.
+  nanoid: "^3.3.17"
 injectWorkspacePackages: true
 syncInjectedDepsAfterScripts:
   - build


### PR DESCRIPTION
## Summary

- **Dependabot alert #20** ([GHSA-frvp-7c67-39w9](https://github.com/advisories/GHSA-frvp-7c67-39w9), medium): `@hono/node-server` < 2.0.5 path traversal in `serve-static` on Windows via encoded backslash. The server package's direct dependency was already `^2.0.5` (resolving 2.0.12); the vulnerable 1.19.17 copy came transitively from `@modelcontextprotocol/node`, which pins `^1.19.9` and has no fixed release yet. Fixed with a workspace override (`pnpm-workspace.yaml` — the only place pnpm 11 honors overrides), with a comment noting the removal condition (upstream moving to >= 2.0.5).
- **nanoid high** (< 3.3.17, custom generators can loop indefinitely when size is 0): the lockfile's only copies were 3.3.16 (transitive), so a same-major override to `^3.3.17` clears the last `pnpm audit` finding.

`pnpm audit`: **No known vulnerabilities found** after both overrides.

## Verification

- `pnpm install` regenerated the lockfile; no `@hono/node-server` < 2.0.5 or nanoid < 3.3.17 remains
- `pnpm -r build` / `pnpm typecheck` — pass
- `pnpm test` — all packages green (core 40 files incl. the MCP stdio/HTTP/SSE transport tests exercising `@modelcontextprotocol/node` against the forced @hono/node-server 2.0.12)
- `pnpm format` + `pnpm format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)