### PR TITLE
fix(ci): let apple-signing environment secrets reach the desktop build

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -29,19 +29,13 @@ on:
         required: false
         type: boolean
         default: false
-    secrets:
-      CSC_LINK:
-        required: false
-      CSC_KEY_PASSWORD:
-        required: false
-      APPLE_API_KEY:
-        required: false
-      APPLE_API_KEY_ID:
-        required: false
-      APPLE_API_ISSUER:
-        required: false
-      APPLE_TEAM_ID:
-        required: false
+    # No `secrets:` declarations here, deliberately. The signing secrets live in the
+    # `apple-signing` GitHub environment referenced by the macOS matrix job, and
+    # environment secrets resolve inside the job itself — in reusable-workflow calls
+    # included. Declaring them as workflow_call secrets rebinds those names to the
+    # caller-passed values, which are empty when the caller passes none, shadowing the
+    # environment's real values: exactly the v0.2.2 release failure ("Missing macOS
+    # signing secrets" with all six configured).
   workflow_dispatch:
     inputs:
       ref:
@@ -82,9 +76,11 @@ jobs:
             args: --win
             environment: desktop-build
     runs-on: ${{ matrix.os }}
+    # Plain `environment:` reference (no extra keys): the job must genuinely enter the
+    # environment for its secrets to attach; the nonstandard `deployment: false` that sat
+    # here is not part of the jobs.<id>.environment schema and risked exactly that.
     environment:
       name: ${{ matrix.environment }}
-      deployment: false
     permissions:
       contents: read
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,10 @@ jobs:
       ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
       tag: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
       require_macos_signing: true
+    # The signing secrets themselves live in the `apple-signing` environment and resolve
+    # inside the called job; `inherit` additionally forwards repo-level secrets so the
+    # called workflow never sees a name shadowed to empty (the v0.2.2 failure mode).
+    secrets: inherit
 
   release:
     needs: [check-release, desktop]


### PR DESCRIPTION
## Summary

The v0.2.2 tag run failed in `desktop / build (macos-latest, --mac, apple-signing)` with **Missing macOS signing secrets: CSC_LINK CSC_KEY_PASSWORD APPLE_API_KEY APPLE_API_KEY_ID APPLE_API_ISSUER** — while the `apple-signing` environment holds exactly those six secrets (verified via the environments API), and a `--failed` rerun reproduced it. Root cause is the reusable-call plumbing, attacked from all three angles at once since every live retry costs a release cycle:

1. `desktop-build.yml` declared the six names under `on.workflow_call.secrets`; when `release.yml` calls it without passing any, those names bind to empty values and shadow the environment's real ones. The declarations are removed (with a comment) so `secrets.*` resolves from the job's environment.
2. The job's environment reference carried a nonstandard `deployment: false` key (not part of the `jobs.<id>.environment` schema) — removed in case it interfered with environment attachment.
3. `release.yml` now passes `secrets: inherit` as a second belt.

No behavior change for the unsigned dry-run path (`require_macos_signing: false`).

## After merge

Re-dispatch the Release workflow with `tag=v0.2.2` (the 0.2.1 precedent): `check-release` gates on the Release not existing, the npm publish step is idempotent and skips already-published versions, and the desktop/release/mirror jobs complete the interrupted v0.2.2 release.

## Verification

- Both workflows parse (`yaml` package) and pass `prettier --check`.
- Not executable outside a real tag/dispatch run; the re-dispatch itself is the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)