### PR TITLE
docs(release): macOS 0.2.2 builds are signed and notarized

### DIFF
--- a/changelog/0.2.2/RELEASE.md
+++ b/changelog/0.2.2/RELEASE.md
@@ -2,7 +2,7 @@ PenguinHarness 0.2.2 — agents that remember and reach further: long-term Memor
 
 ## Install
 
-**Desktop app**: grab your platform's installer from [penguin.ooo/download](https://penguin.ooo/download) — served from the OSS mirror when it is reachable, GitHub otherwise. Current builds are unsigned: on first launch use right-click → Open on macOS, and "More info → Run anyway" past Windows SmartScreen.
+**Desktop app**: grab your platform's installer from [penguin.ooo/download](https://penguin.ooo/download) — served from the OSS mirror when it is reachable, GitHub otherwise. The macOS builds are signed and notarized as of this release, so Gatekeeper opens them directly; Windows builds remain unsigned ("More info → Run anyway" past SmartScreen).
 
 CLI / server (Linux, macOS; bundled Node runtime):
 

--- a/packages/landing/content/blog/penguinharness-0-2-2.en.md
+++ b/packages/landing/content/blog/penguinharness-0-2-2.en.md
@@ -53,7 +53,7 @@ The model catalog adds Thinking Machines Lab's Inkling on OpenRouter and Firewor
 
 ## Install or upgrade
 
-Desktop: grab your platform's installer at [penguin.ooo/download](https://penguin.ooo/download).
+Desktop: grab your platform's installer at [penguin.ooo/download](https://penguin.ooo/download). As of this release the macOS builds are signed and notarized, so Gatekeeper opens them directly; Windows builds remain unsigned ("More info → Run anyway" past SmartScreen).
 
 CLI / server:
 

--- a/packages/landing/content/blog/penguinharness-0-2-2.zh.md
+++ b/packages/landing/content/blog/penguinharness-0-2-2.zh.md
@@ -53,7 +53,7 @@ Web 应用这一个月的积累不少，拣要紧的说。对话头部的统计�
 
 ## 安装或升级
 
-桌面端：前往 [penguin.ooo/download](https://penguin.ooo/download) 下载对应平台安装包。
+桌面端：前往 [penguin.ooo/download](https://penguin.ooo/download) 下载对应平台安装包。本版起 macOS 安装包已签名并公证，Gatekeeper 直接放行；Windows 构建仍未签名，SmartScreen 里选「更多信息 → 仍要运行」。
 
 CLI / 服务端：
 


### PR DESCRIPTION
The published RELEASE.md carried 0.2.1's "current builds are unsigned" caveat, but v0.2.2's `apple-signing` job ran with real credentials (after #266) — the macOS dmg/zip are signed and notarized. Corrects RELEASE.md and adds the note to the bilingual blog install sections; the Windows SmartScreen caveat stays. The published GitHub Release body is updated separately via `gh release edit` from the corrected file.

Verification: `prettier --check` clean on all three files (markdown-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)