### PR TITLE
feat(server): track session lastActiveAt with migration and backfill

### DIFF
--- a/packages/server/src/api/types.ts
+++ b/packages/server/src/api/types.ts
@@ -747,10 +747,19 @@ export interface SessionInfo {
   source?: SessionSource;
   createdAt: string;
   /**
-   * Last meaningful activity (ISO 8601, same convention as createdAt): initialized to
-   * createdAt at creation, stamped by the server at each driven run's start and end
-   * (task, goal round, compaction). Legacy rows are backfilled once at startup from the
-   * session's most recent request timestamp, falling back to createdAt.
+   * Last activity the server drove for this Session (ISO 8601, same convention as
+   * createdAt), monotonic — it never moves backwards. Set to createdAt at creation, then
+   * stamped when a run starts and again when it ends; a run here is one Task, one
+   * compaction, or one whole goal loop (every round of a goal belongs to a single run, so
+   * an N-round goal stamps twice, not 2N times).
+   *
+   * Two kinds of row therefore stay at createdAt no matter how busy they look: Sessions
+   * adopted from a CLI Trace (this server drives none of their runs) and subagent rows
+   * (their work is driven through the parent Session's entry). Reading real activity for
+   * those would mean consulting the Trace tree, which this field deliberately does not do.
+   *
+   * Rows that predate the field are backfilled once at startup from the Session's most
+   * recent request timestamp, falling back to createdAt.
    */
   lastActiveAt: string;
   status: SessionStatus;

--- a/packages/server/src/api/types.ts
+++ b/packages/server/src/api/types.ts
@@ -746,6 +746,13 @@ export interface SessionInfo {
   /** Session source (for list badges/folders), derived from core session_meta — the single source of truth (not stored in the DB); unset for user-created sessions. */
   source?: SessionSource;
   createdAt: string;
+  /**
+   * Last meaningful activity (ISO 8601, same convention as createdAt): initialized to
+   * createdAt at creation, stamped by the server at each driven run's start and end
+   * (task, goal round, compaction). Legacy rows are backfilled once at startup from the
+   * session's most recent request timestamp, falling back to createdAt.
+   */
+  lastActiveAt: string;
   status: SessionStatus;
   /** Number of approvals awaiting human decision (a persisted count outside server events, for list badges). */
   pendingApprovalCount: number;

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -236,6 +236,7 @@ export function buildAppDeps(config: ServerConfig, overrides: BuildDepsOverrides
     titles,
     log,
     goals: goalsRepo,
+    ...(overrides.now ? { now: overrides.now } : {}),
   });
   managerRef = manager;
 

--- a/packages/server/src/db/database.ts
+++ b/packages/server/src/db/database.ts
@@ -29,8 +29,20 @@ export function openDatabase(dbPath: string): DatabaseSync {
   // schema.ts; drop entries only in a release allowed to break existing web.db files.
   ensureColumn(db, "sessions", "client", "TEXT");
   ensureColumn(db, "sessions", "has_trace", "INTEGER NOT NULL DEFAULT 0");
+  ensureColumn(db, "sessions", "last_active_at", "TEXT");
   ensureColumn(db, "auth_sessions", "via", "TEXT");
   ensureColumn(db, "trace_files", "page_stats", "TEXT");
+  // last_active_at backfill for rows formed before the column existed: the session's most
+  // recent request timestamp (usage_records, served by idx_usage_session — the closest
+  // persisted proxy for "last Trace activity"), else created_at. Guarded by IS NULL so it
+  // is idempotent — a backfilled database matches 0 rows, and a crash between the ALTER
+  // above and this UPDATE heals on the next open.
+  db.exec(
+    `UPDATE sessions SET last_active_at = COALESCE(
+       (SELECT MAX(ts) FROM usage_records WHERE usage_records.session_id = sessions.session_id),
+       created_at
+     ) WHERE last_active_at IS NULL`,
+  );
   return db;
 }
 

--- a/packages/server/src/db/database.ts
+++ b/packages/server/src/db/database.ts
@@ -29,26 +29,52 @@ export function openDatabase(dbPath: string): DatabaseSync {
   // schema.ts; drop entries only in a release allowed to break existing web.db files.
   ensureColumn(db, "sessions", "client", "TEXT");
   ensureColumn(db, "sessions", "has_trace", "INTEGER NOT NULL DEFAULT 0");
-  ensureColumn(db, "sessions", "last_active_at", "TEXT");
   ensureColumn(db, "auth_sessions", "via", "TEXT");
   ensureColumn(db, "trace_files", "page_stats", "TEXT");
-  // last_active_at backfill for rows formed before the column existed: the session's most
-  // recent request timestamp (usage_records, served by idx_usage_session — the closest
-  // persisted proxy for "last Trace activity"), else created_at. Guarded by IS NULL so it
-  // is idempotent — a backfilled database matches 0 rows, and a crash between the ALTER
-  // above and this UPDATE heals on the next open.
-  db.exec(
-    `UPDATE sessions SET last_active_at = COALESCE(
-       (SELECT MAX(ts) FROM usage_records WHERE usage_records.session_id = sessions.session_id),
-       created_at
-     ) WHERE last_active_at IS NULL`,
-  );
+  // Superseded by idx_usage_session_ts (session_id, ts), which SCHEMA_SQL just created on
+  // this database: the old index is a strict prefix of it, so every query it served is
+  // served identically. Dropping is safe — an index is derived, never data.
+  db.exec("DROP INDEX IF EXISTS idx_usage_session");
+  upgradeLastActiveAt(db);
   return db;
 }
 
-/** Idempotent per-column upgrade for databases formed before the column existed. */
-function ensureColumn(db: DatabaseSync, table: string, column: string, ddl: string): void {
+/**
+ * One-time `sessions.last_active_at` upgrade, ALTER + backfill in a single transaction.
+ *
+ * The backfill runs **only in the open that actually adds the column** (SQLite's ALTER
+ * TABLE ADD COLUMN is transactional, so a crash mid-upgrade rolls back to "no column" and
+ * the next open redoes both halves — never a half-migrated table, and never a full
+ * `sessions` scan on the millions of opens that follow). Legacy rows take the session's
+ * most recent request timestamp — usage_records, covered by idx_usage_session_ts, the
+ * closest persisted proxy for "last Trace activity" — else their own created_at.
+ */
+function upgradeLastActiveAt(db: DatabaseSync): void {
+  db.exec("BEGIN");
+  try {
+    if (ensureColumn(db, "sessions", "last_active_at", "TEXT")) {
+      db.exec(
+        `UPDATE sessions SET last_active_at = COALESCE(
+           (SELECT MAX(ts) FROM usage_records WHERE usage_records.session_id = sessions.session_id),
+           created_at
+         )`,
+      );
+    }
+    db.exec("COMMIT");
+  } catch (err) {
+    db.exec("ROLLBACK");
+    throw err;
+  }
+}
+
+/**
+ * Idempotent per-column upgrade for databases formed before the column existed.
+ * Returns whether this call actually ALTERed the table (false = the column was already
+ * there), so a caller can gate one-time backfill work on it.
+ */
+function ensureColumn(db: DatabaseSync, table: string, column: string, ddl: string): boolean {
   const cols = db.prepare(`PRAGMA table_info(${table})`).all() as { name: string }[];
-  if (cols.some((c) => c.name === column)) return;
+  if (cols.some((c) => c.name === column)) return false;
   db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${ddl}`);
+  return true;
 }

--- a/packages/server/src/db/repos/sessions.ts
+++ b/packages/server/src/db/repos/sessions.ts
@@ -30,11 +30,14 @@ export interface SessionRow {
   /** Cache: a Trace record exists (set at task start / adoption / subagent registration; backfilled by list hydration). */
   hasTrace?: boolean;
   /**
-   * Last meaningful activity, ISO (bumped at each driven run's start and end — task, goal
-   * round, compaction; see SessionManager.drive). Always present on rows read from the DB
-   * (openDatabase backfills legacy rows once); omitting on insert defaults to createdAt.
+   * Last activity this server drove for the session, ISO: stamped once when a run starts
+   * and once when it ends (see SessionManager.drive — a goal run is ONE drive over all its
+   * rounds, so it stamps twice, not per round). Set to createdAt at insert, and only ever
+   * moves forward (markDriven/touchLastActive clamp with MAX, so a backwards clock step
+   * cannot regress it). Rows this server never drives — CLI-adopted Sessions, subagent
+   * rows (their activity is driven through the parent's entry) — keep createdAt.
    */
-  lastActiveAt?: string;
+  lastActiveAt: string;
   createdAt: string;
 }
 
@@ -62,33 +65,27 @@ export class SessionsRepo {
   constructor(private readonly db: DatabaseSync) {}
 
   insert(row: SessionRow): void {
-    this.db
-      .prepare(
-        `INSERT INTO sessions (session_id, project_id, agent_id, provider, model_id, workspace, approval_mode, title, client, has_trace, last_active_at, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      )
-      .run(
-        row.sessionId,
-        row.projectId,
-        row.agentId,
-        row.provider,
-        row.modelId,
-        row.workspace,
-        row.approvalMode,
-        row.title,
-        row.client ?? null,
-        row.hasTrace ? 1 : 0,
-        row.lastActiveAt ?? row.createdAt,
-        row.createdAt,
-      );
+    this.runInsert("INSERT", row);
   }
 
   /** Idempotent insert: used when Trace directory discovery backfills a row (concurrent listing discovering the same Session no longer triggers a UNIQUE violation). */
   insertOrIgnore(row: SessionRow): void {
+    this.runInsert("INSERT OR IGNORE", row);
+  }
+
+  /**
+   * The two inserts' shared column list and binding order (they differ only in conflict
+   * handling). `last_active_at` defaults **in SQL** (`COALESCE(?, ?)` over the row's own
+   * created_at, bound twice — SQLite forbids referencing a sibling column inside VALUES,
+   * and a column added by ALTER TABLE cannot be given a DEFAULT): the column is nullable
+   * for legacy reasons, so this is the one place that can guarantee it is never written
+   * NULL, whatever a caller passes.
+   */
+  private runInsert(verb: "INSERT" | "INSERT OR IGNORE", row: SessionRow): void {
     this.db
       .prepare(
-        `INSERT OR IGNORE INTO sessions (session_id, project_id, agent_id, provider, model_id, workspace, approval_mode, title, client, has_trace, last_active_at, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        `${verb} INTO sessions (session_id, project_id, agent_id, provider, model_id, workspace, approval_mode, title, client, has_trace, last_active_at, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, ?), ?)`,
       )
       .run(
         row.sessionId,
@@ -101,20 +98,39 @@ export class SessionsRepo {
         row.title,
         row.client ?? null,
         row.hasTrace ? 1 : 0,
-        row.lastActiveAt ?? row.createdAt,
+        row.lastActiveAt ?? null,
+        row.createdAt,
         row.createdAt,
       );
   }
 
-  /** Flip the has_trace cache once a Trace record exists (task start / discovery hydration); idempotent. */
+  /** Flip the has_trace cache once a Trace record exists (discovery hydration); idempotent. */
   markHasTrace(sessionId: string): void {
     this.db.prepare("UPDATE sessions SET has_trace = 1 WHERE session_id = ?").run(sessionId);
   }
 
-  /** Bump last_active_at (drive's run start/end — one write per run boundary, never per streamed message). */
+  /**
+   * A driven run touched this Session: flip the has_trace cache and stamp last_active_at in
+   * ONE statement (drive's run start — one WAL commit instead of two).
+   * `MAX(COALESCE(...))` keeps the stamp monotonic: a backwards clock step (NTP, resume
+   * from suspend) leaves the stored value alone rather than regressing the row.
+   */
+  markDriven(sessionId: string, at: string): void {
+    this.db
+      .prepare(
+        `UPDATE sessions SET has_trace = 1, last_active_at = MAX(COALESCE(last_active_at, ''), ?)
+         WHERE session_id = ?`,
+      )
+      .run(at, sessionId);
+  }
+
+  /** Stamp last_active_at alone (drive's run end); monotonic like markDriven. */
   touchLastActive(sessionId: string, at: string): void {
     this.db
-      .prepare("UPDATE sessions SET last_active_at = ? WHERE session_id = ?")
+      .prepare(
+        `UPDATE sessions SET last_active_at = MAX(COALESCE(last_active_at, ''), ?)
+         WHERE session_id = ?`,
+      )
       .run(at, sessionId);
   }
 

--- a/packages/server/src/db/repos/sessions.ts
+++ b/packages/server/src/db/repos/sessions.ts
@@ -29,6 +29,12 @@ export interface SessionRow {
   client?: "web" | "cli" | null;
   /** Cache: a Trace record exists (set at task start / adoption / subagent registration; backfilled by list hydration). */
   hasTrace?: boolean;
+  /**
+   * Last meaningful activity, ISO (bumped at each driven run's start and end — task, goal
+   * round, compaction; see SessionManager.drive). Always present on rows read from the DB
+   * (openDatabase backfills legacy rows once); omitting on insert defaults to createdAt.
+   */
+  lastActiveAt?: string;
   createdAt: string;
 }
 
@@ -45,6 +51,9 @@ function mapRow(r: Record<string, unknown>): SessionRow {
     archivedAt: (r.archived_at as string | null) ?? null,
     client: (r.client as "web" | "cli" | null) ?? null,
     hasTrace: (r.has_trace as number) === 1,
+    // The open-time backfill leaves no NULLs; the coalesce only hardens against a row
+    // somehow inserted as NULL (degrades to createdAt instead of surfacing undefined).
+    lastActiveAt: (r.last_active_at as string | null) ?? (r.created_at as string),
     createdAt: r.created_at as string,
   };
 }
@@ -55,8 +64,8 @@ export class SessionsRepo {
   insert(row: SessionRow): void {
     this.db
       .prepare(
-        `INSERT INTO sessions (session_id, project_id, agent_id, provider, model_id, workspace, approval_mode, title, client, has_trace, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO sessions (session_id, project_id, agent_id, provider, model_id, workspace, approval_mode, title, client, has_trace, last_active_at, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .run(
         row.sessionId,
@@ -69,6 +78,7 @@ export class SessionsRepo {
         row.title,
         row.client ?? null,
         row.hasTrace ? 1 : 0,
+        row.lastActiveAt ?? row.createdAt,
         row.createdAt,
       );
   }
@@ -77,8 +87,8 @@ export class SessionsRepo {
   insertOrIgnore(row: SessionRow): void {
     this.db
       .prepare(
-        `INSERT OR IGNORE INTO sessions (session_id, project_id, agent_id, provider, model_id, workspace, approval_mode, title, client, has_trace, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT OR IGNORE INTO sessions (session_id, project_id, agent_id, provider, model_id, workspace, approval_mode, title, client, has_trace, last_active_at, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .run(
         row.sessionId,
@@ -91,6 +101,7 @@ export class SessionsRepo {
         row.title,
         row.client ?? null,
         row.hasTrace ? 1 : 0,
+        row.lastActiveAt ?? row.createdAt,
         row.createdAt,
       );
   }
@@ -98,6 +109,13 @@ export class SessionsRepo {
   /** Flip the has_trace cache once a Trace record exists (task start / discovery hydration); idempotent. */
   markHasTrace(sessionId: string): void {
     this.db.prepare("UPDATE sessions SET has_trace = 1 WHERE session_id = ?").run(sessionId);
+  }
+
+  /** Bump last_active_at (drive's run start/end — one write per run boundary, never per streamed message). */
+  touchLastActive(sessionId: string, at: string): void {
+    this.db
+      .prepare("UPDATE sessions SET last_active_at = ? WHERE session_id = ?")
+      .run(at, sessionId);
   }
 
   findById(sessionId: string): SessionRow | null {

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -7,7 +7,9 @@
  * Product not yet released: no migration branches — everything is CREATE IF NOT EXISTS, formed
  * once. The one exception: columns added to an existing table after release of a web.db are
  * ALTERed in by the idempotent per-column guard in database.ts (ensureColumn), since CREATE
- * TABLE IF NOT EXISTS never touches an existing table.
+ * TABLE IF NOT EXISTS never touches an existing table. A *reshaped* index follows the same
+ * rule under a new name, with the superseded one dropped on open (idx_usage_session →
+ * idx_usage_session_ts): CREATE INDEX IF NOT EXISTS never rebuilds an existing index either.
  */
 
 export const SCHEMA_SQL = `
@@ -54,7 +56,7 @@ CREATE TABLE IF NOT EXISTS sessions (
   archived_at   TEXT,                                -- archive time; NULL=not archived (shown by default; archived ones move under "Archived")
   client        TEXT,                                -- creating client: 'web' (created via the Web App) | 'cli' (adopted from a CLI Trace); NULL = legacy row, treated as web
   has_trace     INTEGER NOT NULL DEFAULT 0,          -- cache: a Trace record exists (set at task start / adoption / subagent registration; lazily backfilled by list hydration)
-  last_active_at TEXT,                               -- last meaningful activity (ISO; bumped at each driven run's start and end, initialized to created_at); NULL only before openDatabase's one-time backfill
+  last_active_at TEXT,                               -- last activity this server drove for the session (ISO; stamped once when a run starts and once when it ends, initialized to created_at); monotonic, never moves backwards; NULL only before openDatabase's one-time backfill
   created_at    TEXT NOT NULL
 );                                            -- the schedule/subagent SOURCE is NOT stored: session_meta in the Trace is the single source of truth (see runtime/session-sources.ts); "client" is a different, DB-only axis (who created the row)
 CREATE INDEX IF NOT EXISTS idx_sessions_agent_created ON sessions(project_id, agent_id, created_at DESC);
@@ -75,7 +77,7 @@ CREATE TABLE IF NOT EXISTS usage_records (
   status            TEXT NOT NULL DEFAULT 'completed'  -- request outcome: completed=success (with tokens); others=failure (0 tokens, for success rate)
 );                                            -- cost is not stored: computed at query time from current pricing
 CREATE INDEX IF NOT EXISTS idx_usage_project_date ON usage_records(project_id, date);
-CREATE INDEX IF NOT EXISTS idx_usage_session ON usage_records(session_id);
+CREATE INDEX IF NOT EXISTS idx_usage_session_ts ON usage_records(session_id, ts);  -- (session_id) alone was idx_usage_session (dropped on open): ts makes the last_active_at backfill's MAX(ts) a covering index scan instead of a random row lookup per usage record
 CREATE TABLE IF NOT EXISTS error_records (     -- server-side error capture (the Costs page's "Errors" tab)
   id         INTEGER PRIMARY KEY AUTOINCREMENT,
   ts         TEXT NOT NULL,

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -54,6 +54,7 @@ CREATE TABLE IF NOT EXISTS sessions (
   archived_at   TEXT,                                -- archive time; NULL=not archived (shown by default; archived ones move under "Archived")
   client        TEXT,                                -- creating client: 'web' (created via the Web App) | 'cli' (adopted from a CLI Trace); NULL = legacy row, treated as web
   has_trace     INTEGER NOT NULL DEFAULT 0,          -- cache: a Trace record exists (set at task start / adoption / subagent registration; lazily backfilled by list hydration)
+  last_active_at TEXT,                               -- last meaningful activity (ISO; bumped at each driven run's start and end, initialized to created_at); NULL only before openDatabase's one-time backfill
   created_at    TEXT NOT NULL
 );                                            -- the schedule/subagent SOURCE is NOT stored: session_meta in the Trace is the single source of truth (see runtime/session-sources.ts); "client" is a different, DB-only axis (who created the row)
 CREATE INDEX IF NOT EXISTS idx_sessions_agent_created ON sessions(project_id, agent_id, created_at DESC);

--- a/packages/server/src/http/routes/sessions.ts
+++ b/packages/server/src/http/routes/sessions.ts
@@ -460,8 +460,14 @@ export function sessionsRoutes(deps: AppDeps): Hono<AppEnv> {
       updated = { ...updated, archivedAt: at };
     }
     const hasTrace = await deps.sessionService.hasTrace(updated);
+    // Re-read after the writes (and after the awaits above): a run finishing anywhere in
+    // this window advances last_active_at, and `updated` is a snapshot taken before the
+    // PATCH even started. Returning it would hand back a REGRESSED value that the web
+    // store swaps in wholesale, rolling the row backwards with no event to repair it.
+    // Falls back to the snapshot if the Session was deleted meanwhile.
+    const fresh = deps.sessionsRepo.findById(row.sessionId) ?? updated;
     return c.json({
-      session: await deps.sessionService.toInfo(updated, hasTrace),
+      session: await deps.sessionService.toInfo(fresh, hasTrace),
     } satisfies SessionResponse);
   });
 

--- a/packages/server/src/runtime/session-manager.ts
+++ b/packages/server/src/runtime/session-manager.ts
@@ -1194,8 +1194,12 @@ export class SessionManager {
   ): Promise<void> {
     // Every driven run (task, goal round, compaction) writes Trace lines: flip the row's
     // has_trace cache here, the single choke point, so listing can serve it from the DB
-    // without a directory walk (see SessionService.listSessions).
+    // without a directory walk (see SessionService.listSessions). The same choke point
+    // stamps last_active_at — once per run boundary (here and in the finally below), never
+    // per streamed message, so activity during the run (steering, approvals, follow-up
+    // queueing) is covered by the run-end stamp without any hot-loop writes.
     this.deps.sessions.markHasTrace(entry.sessionId);
+    this.deps.sessions.touchLastActive(entry.sessionId, new Date().toISOString());
     let earlyTitleFired = false;
     let mainBodyChars = 0;
     const ctx: UsageContext = {
@@ -1371,6 +1375,9 @@ export class SessionManager {
       // now-empty state.
       entry.pendingSteering = [];
       entry.lastActivityMs = Date.now();
+      // Run-end stamp (see the run-start counterpart at the top of drive). A no-op UPDATE
+      // when the row is mid-deletion — the DELETE already won.
+      this.deps.sessions.touchLastActive(entry.sessionId, new Date().toISOString());
       this.publishState(entry, "idle");
       if (titleSource && titleSource.userExcerpt.trim()) {
         // Attempt generation whenever there's user material; whether generation is

--- a/packages/server/src/runtime/session-manager.ts
+++ b/packages/server/src/runtime/session-manager.ts
@@ -222,6 +222,12 @@ export interface SessionManagerDeps {
   log?: (line: string) => void;
   /** Goal run-state persistence (optional like `titles`: without it, goals run but leave no restorable record). */
   goals?: GoalsRepo;
+  /**
+   * Clock for persisted timestamps (last_active_at). Injected like the other services' so a
+   * stubbed clock moves this and `usage_records.ts` together — the pairing the legacy
+   * backfill assumes when it reads MAX(ts) as a session's last activity.
+   */
+  now?: () => Date;
 }
 
 /** One queued follow-up task (`queueIfBusy`): the task input plus the per-turn thinking level it was posted with. */
@@ -396,9 +402,12 @@ export class SessionManager {
   /** Open streaming fragments of running sessions (fed by drive, served to GET /messages; see live-tail.ts). */
   private readonly liveTail = new LiveTailTracker();
   private readonly sweepTimer: NodeJS.Timeout;
+  /** Clock for persisted timestamps (see SessionManagerDeps.now); wall clock unless injected. */
+  private readonly now: () => Date;
 
   constructor(private readonly deps: SessionManagerDeps) {
     this.log = deps.log ?? ((line) => console.error(line));
+    this.now = deps.now ?? (() => new Date());
     this.sweepTimer = setInterval(() => this.sweepIdle(), ENTRY_SWEEP_INTERVAL_MS);
     this.sweepTimer.unref?.();
   }
@@ -1192,14 +1201,6 @@ export class SessionManager {
     gen: AsyncGenerator<OmniMessage>,
     titleSource?: { userExcerpt: string },
   ): Promise<void> {
-    // Every driven run (task, goal round, compaction) writes Trace lines: flip the row's
-    // has_trace cache here, the single choke point, so listing can serve it from the DB
-    // without a directory walk (see SessionService.listSessions). The same choke point
-    // stamps last_active_at — once per run boundary (here and in the finally below), never
-    // per streamed message, so activity during the run (steering, approvals, follow-up
-    // queueing) is covered by the run-end stamp without any hot-loop writes.
-    this.deps.sessions.markHasTrace(entry.sessionId);
-    this.deps.sessions.touchLastActive(entry.sessionId, new Date().toISOString());
     let earlyTitleFired = false;
     let mainBodyChars = 0;
     const ctx: UsageContext = {
@@ -1209,6 +1210,17 @@ export class SessionManager {
       provider: entry.provider,
       modelId: entry.modelId,
     };
+    // Every driven run (a Task, a compaction, or a whole goal loop — startGoal hands all of
+    // its rounds to ONE drive) writes Trace lines: flip the row's has_trace cache here, the
+    // single choke point, so listing can serve it from the DB without a directory walk (see
+    // SessionService.listSessions). The same statement stamps last_active_at, so a run costs
+    // one row write here and one more when it ends (see the finally) — never one per streamed
+    // message; activity during the run (steering, approvals, queued follow-ups) rides on the
+    // run-end stamp. Guarded: this runs BEFORE the try below, so an unexpected DB failure
+    // (a closed handle after shutdown) would otherwise reject drive() with no finally to
+    // reach — leaving the entry pinned "running" and every later Task 409ing for the
+    // process's lifetime.
+    this.touchRow(ctx, (repo, at) => repo.markDriven(ctx.sessionId, at));
     // LLM request failures and tool execution failures aren't expressed via throw (core
     // converges them into the message stream), so the try/catch below can't catch them:
     // the watcher inspects messages one by one and fishes them out for persistence
@@ -1375,9 +1387,14 @@ export class SessionManager {
       // now-empty state.
       entry.pendingSteering = [];
       entry.lastActivityMs = Date.now();
-      // Run-end stamp (see the run-start counterpart at the top of drive). A no-op UPDATE
-      // when the row is mid-deletion — the DELETE already won.
-      this.deps.sessions.touchLastActive(entry.sessionId, new Date().toISOString());
+      // Run-end stamp (see the run-start counterpart at the top of drive). Guarded like
+      // every other write in this finally: what follows — the idle broadcast, title
+      // generation, and the auto-start of queued follow-ups (this is its only call site) —
+      // must not be skippable by a DB failure, or SSE clients would sit on "running"
+      // forever with their queue stranded. A no-op UPDATE when the row is already gone:
+      // deletion normally awaits the drive first, so that only happens once its 5s wait
+      // times out.
+      this.touchRow(ctx, (repo, at) => repo.touchLastActive(ctx.sessionId, at));
       this.publishState(entry, "idle");
       if (titleSource && titleSource.userExcerpt.trim()) {
         // Attempt generation whenever there's user material; whether generation is
@@ -1445,6 +1462,7 @@ export class SessionManager {
     // row deliberately stores no source column.
     const source = asSessionSource(p.source) ?? "subagent";
     this.deps.sources.set(childSid, source);
+    const createdAt = this.now().toISOString();
     this.deps.sessions.insertOrIgnore({
       sessionId: childSid,
       projectId: entry.projectId,
@@ -1458,7 +1476,10 @@ export class SessionManager {
       title: null,
       // Spawned by this server's run (client NULL = web); its Trace exists by construction.
       hasTrace: true,
-      createdAt: new Date().toISOString(),
+      // A subagent's own runs are driven through the PARENT entry's drive, so nothing ever
+      // stamps this row: it stays at its registration time (see SessionRow.lastActiveAt).
+      lastActiveAt: createdAt,
+      createdAt,
     });
     // Make the subagent appear immediately in the sidebar: notify via the parent
     // Session's channel (a frontend currently watching the parent run refreshes its list in place).
@@ -1478,6 +1499,25 @@ export class SessionManager {
     };
     children.set(childSid, child);
     return child;
+  }
+
+  /**
+   * Runs one `sessions` row write for a driven run's bookkeeping (has_trace /
+   * last_active_at), swallowing failures the same way the per-message `recorder.record`
+   * call does: bookkeeping must never take down a run's lifecycle. The two call sites both
+   * sit outside a covering try — the run-start write precedes drive's try block, the
+   * run-end one lives in its finally — and the realistic failure (the DatabaseSync handle
+   * closed by shutdown while a run outlived its drain window) throws ERR_INVALID_STATE.
+   */
+  private touchRow(ctx: UsageContext, write: (repo: SessionsRepo, at: string) => void): void {
+    try {
+      write(this.deps.sessions, this.now().toISOString());
+    } catch (err) {
+      this.log(
+        `[session] last-active bookkeeping failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      this.deps.errors?.record({ source: "session", err, ctx, code: "session_touch_failed" });
+    }
   }
 
   private publishState(entry: RuntimeEntry, state: SessionStatus): void {

--- a/packages/server/src/services/session-service.ts
+++ b/packages/server/src/services/session-service.ts
@@ -82,7 +82,7 @@ export class SessionService {
       ...(row.title !== null ? { title: row.title } : {}),
       ...(source !== undefined ? { source } : {}),
       createdAt: row.createdAt,
-      lastActiveAt: row.lastActiveAt ?? row.createdAt,
+      lastActiveAt: row.lastActiveAt,
       status: this.deps.manager.statusOf(row.sessionId),
       pendingApprovalCount: this.deps.manager.pendingApprovalCount(row.sessionId),
       pendingFollowUpCount: this.deps.manager.pendingFollowUpCount(row.sessionId),
@@ -357,6 +357,7 @@ export class SessionService {
       session.sessionId,
       isSessionMeta(metaMsg) ? (asSessionSource(metaMsg.payload.source) ?? null) : null,
     );
+    const createdAt = new Date().toISOString();
     const row: SessionRow = {
       sessionId: session.sessionId,
       projectId: args.projectId,
@@ -369,7 +370,9 @@ export class SessionService {
       // Everything created through this service is the Web App's (schedule runs included);
       // "cli" is stamped only by Trace adoption. NULL means a legacy row, treated as web.
       client: "web",
-      createdAt: new Date().toISOString(),
+      // Creation is the first activity; the first driven run advances it (see SessionManager.drive).
+      lastActiveAt: createdAt,
+      createdAt,
     };
     this.deps.sessions.insert(row);
     this.deps.manager.adopt(row, session);
@@ -438,6 +441,7 @@ export class SessionService {
     if (facts.provider === null || facts.modelId === null) return null;
     // Registration already narrowed the origin; record it in the registry (single source of truth).
     this.deps.sources.set(sessionId, facts.source);
+    const createdAt = sessionIdCreatedAt(sessionId) ?? facts.firstTs ?? new Date().toISOString();
     const row: SessionRow = {
       sessionId,
       projectId,
@@ -452,7 +456,11 @@ export class SessionService {
       // (web-only) excludes these rows; the "show CLI sessions" preference includes them.
       client: "cli",
       hasTrace: true,
-      createdAt: sessionIdCreatedAt(sessionId) ?? facts.firstTs ?? new Date().toISOString(),
+      createdAt,
+      // The CLI's own activity leaves no mark on this row (this server drives none of its
+      // runs), so an adopted Session reads as last-active at its creation time until it is
+      // resumed here; the Trace tail is not consulted (see SessionRow.lastActiveAt).
+      lastActiveAt: createdAt,
     };
     // Idempotent backfill: concurrent list calls may discover the same Session for the first time simultaneously (consistent with AgentsRepo's convention).
     this.deps.sessions.insertOrIgnore(row);

--- a/packages/server/src/services/session-service.ts
+++ b/packages/server/src/services/session-service.ts
@@ -82,6 +82,7 @@ export class SessionService {
       ...(row.title !== null ? { title: row.title } : {}),
       ...(source !== undefined ? { source } : {}),
       createdAt: row.createdAt,
+      lastActiveAt: row.lastActiveAt ?? row.createdAt,
       status: this.deps.manager.statusOf(row.sessionId),
       pendingApprovalCount: this.deps.manager.pendingApprovalCount(row.sessionId),
       pendingFollowUpCount: this.deps.manager.pendingFollowUpCount(row.sessionId),

--- a/packages/server/test/agent-trace-detail.test.ts
+++ b/packages/server/test/agent-trace-detail.test.ts
@@ -145,6 +145,7 @@ describe("agent-trace-detail", () => {
       title: "已生成的标题",
       client: "cli",
       createdAt: "2026-07-06T09:00:00.000Z",
+      lastActiveAt: "2026-07-06T09:00:00.000Z",
     });
     const titled = (await (
       await owner.get(`${base()}?limit=10&cli=1`)

--- a/packages/server/test/body-limit.test.ts
+++ b/packages/server/test/body-limit.test.ts
@@ -82,6 +82,7 @@ describe("request body cap", () => {
       approvalMode: "allow-all",
       title: null,
       createdAt: new Date().toISOString(),
+      lastActiveAt: new Date().toISOString(),
     };
     t.deps.sessionsRepo.insert(row);
     runs = [];

--- a/packages/server/test/db-upgrade.test.ts
+++ b/packages/server/test/db-upgrade.test.ts
@@ -8,8 +8,11 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
 import { openDatabase } from "../src/db/database.js";
+import { SCHEMA_SQL } from "../src/db/schema.js";
 import { SessionsRepo } from "../src/db/repos/sessions.js";
+import type { SessionRow } from "../src/db/repos/sessions.js";
 
 const sqlite = process.getBuiltinModule("node:sqlite");
 
@@ -19,8 +22,37 @@ beforeEach(async () => {
   dir = await mkdtemp(path.join(tmpdir(), "penguin-db-upgrade-"));
 });
 afterEach(async () => {
-  await rm(dir, { recursive: true, force: true });
+  // maxRetries for the same reason helpers.ts documents: on Windows a handle that is
+  // closing can hold the directory briefly, and an unretried rm turns that into a failure.
+  await rm(dir, { recursive: true, force: true, maxRetries: 10 });
 });
+
+/**
+ * Seeds a database in the shape it had **before** last_active_at existed, derived from the
+ * real SCHEMA_SQL rather than a hand-copied DDL replica (a copy silently forks from the
+ * schema it is supposed to imitate): create today's schema, then undo exactly the two
+ * things this change introduced — the column, and the reshaped usage index.
+ */
+function seedPreLastActiveDb(dbPath: string, seed: (db: DatabaseSync) => void): void {
+  const db = new sqlite.DatabaseSync(dbPath);
+  try {
+    db.exec(SCHEMA_SQL);
+    db.exec("ALTER TABLE sessions DROP COLUMN last_active_at");
+    db.exec("DROP INDEX IF EXISTS idx_usage_session_ts");
+    db.exec("CREATE INDEX IF NOT EXISTS idx_usage_session ON usage_records(session_id)");
+    seed(db);
+  } finally {
+    db.close();
+  }
+}
+
+/** Reads the stored cell directly, bypassing mapRow's coalesce (which would mask a NULL). */
+function rawLastActive(db: DatabaseSync, sessionId: string): unknown {
+  const r = db
+    .prepare("SELECT last_active_at AS v FROM sessions WHERE session_id = ?")
+    .get(sessionId) as { v: unknown } | undefined;
+  return r?.v;
+}
 
 describe("openDatabase column upgrade", () => {
   it("adds client/has_trace to a sessions table formed before the columns existed", () => {
@@ -74,6 +106,7 @@ describe("openDatabase column upgrade", () => {
         client: "cli",
         hasTrace: true,
         createdAt: "2026-01-02T00:00:00.000Z",
+        lastActiveAt: "2026-01-02T00:00:00.000Z",
       });
       expect(repo.findById("session-new")!.client).toBe("cli");
       expect(repo.listByAgent("p1", "a1", { webOnly: true }).map((r) => r.sessionId)).toEqual([
@@ -102,62 +135,40 @@ describe("openDatabase column upgrade", () => {
 
   it("backfills last_active_at once: last request timestamp when the session has usage, else created_at", () => {
     const dbPath = path.join(dir, "web.db");
-    // A database formed by the immediately-previous schema: sessions (client/has_trace
-    // present) without last_active_at, plus usage_records as it already existed.
-    const old = new sqlite.DatabaseSync(dbPath);
-    old.exec(`CREATE TABLE sessions (
-      session_id    TEXT PRIMARY KEY,
-      project_id    TEXT NOT NULL,
-      agent_id      TEXT NOT NULL,
-      provider      TEXT NOT NULL,
-      model_id      TEXT NOT NULL,
-      workspace     TEXT NOT NULL,
-      approval_mode TEXT NOT NULL DEFAULT 'allow-all',
-      title         TEXT,
-      archived_at   TEXT,
-      client        TEXT,
-      has_trace     INTEGER NOT NULL DEFAULT 0,
-      created_at    TEXT NOT NULL
-    );`);
-    old.exec(`CREATE TABLE usage_records (
-      id                INTEGER PRIMARY KEY AUTOINCREMENT,
-      ts                TEXT NOT NULL,
-      date              TEXT NOT NULL,
-      project_id        TEXT NOT NULL,
-      agent_id          TEXT NOT NULL,
-      session_id        TEXT NOT NULL,
-      origin_session_id TEXT,
-      provider          TEXT NOT NULL,
-      model_id          TEXT NOT NULL,
-      cache_read        INTEGER NOT NULL,
-      cache_write       INTEGER NOT NULL,
-      output            INTEGER NOT NULL,
-      total             INTEGER NOT NULL,
-      status            TEXT NOT NULL DEFAULT 'completed'
-    );`);
-    const insertSession = old.prepare(
-      `INSERT INTO sessions (session_id, project_id, agent_id, provider, model_id, workspace, created_at)
-       VALUES (?, 'p1', 'a1', 'custom', 'm1', '/w', ?)`,
-    );
-    insertSession.run("session-used", "2026-01-01T00:00:00.000Z");
-    insertSession.run("session-quiet", "2026-01-02T00:00:00.000Z");
-    const insertUsage = old.prepare(
-      `INSERT INTO usage_records (ts, date, project_id, agent_id, session_id, provider, model_id, cache_read, cache_write, output, total)
-       VALUES (?, ?, 'p1', 'a1', 'session-used', 'custom', 'm1', 0, 0, 1, 1)`,
-    );
-    insertUsage.run("2026-02-01T10:00:00.000Z", "2026-02-01");
-    insertUsage.run("2026-02-03T09:30:00.000Z", "2026-02-03");
-    old.close();
+    seedPreLastActiveDb(dbPath, (old) => {
+      const insertSession = old.prepare(
+        `INSERT INTO sessions (session_id, project_id, agent_id, provider, model_id, workspace, created_at)
+         VALUES (?, 'p1', 'a1', 'custom', 'm1', '/w', ?)`,
+      );
+      insertSession.run("session-used", "2026-01-01T00:00:00.000Z");
+      insertSession.run("session-quiet", "2026-01-02T00:00:00.000Z");
+      const insertUsage = old.prepare(
+        `INSERT INTO usage_records (ts, date, project_id, agent_id, session_id, provider, model_id, cache_read, cache_write, output, total)
+         VALUES (?, ?, 'p1', 'a1', 'session-used', 'custom', 'm1', 0, 0, 1, 1)`,
+      );
+      insertUsage.run("2026-02-01T10:00:00.000Z", "2026-02-01");
+      insertUsage.run("2026-02-03T09:30:00.000Z", "2026-02-03");
+    });
 
     const db = openDatabase(dbPath);
     try {
       const repo = new SessionsRepo(db);
-      // The most recent request timestamp is the closest persisted proxy for last Trace activity.
+      // The most recent request timestamp is the closest persisted proxy for last Trace
+      // activity. Read raw as well: mapRow would report created_at for a row the backfill
+      // never touched, hiding a no-op migration behind a plausible-looking value.
+      expect(rawLastActive(db, "session-used")).toBe("2026-02-03T09:30:00.000Z");
       expect(repo.findById("session-used")!.lastActiveAt).toBe("2026-02-03T09:30:00.000Z");
       // No usage rows: falls back to the row's own created_at.
-      expect(repo.findById("session-quiet")!.lastActiveAt).toBe("2026-01-02T00:00:00.000Z");
-      // A live value written after the upgrade must survive reopens (the IS NULL guard
-      // makes the backfill one-time, never a reopen-time reset).
+      expect(rawLastActive(db, "session-quiet")).toBe("2026-01-02T00:00:00.000Z");
+      // The reshaped usage index is in place and the superseded one is gone.
+      const indexes = (
+        db
+          .prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND name LIKE 'idx_usage%'")
+          .all() as { name: string }[]
+      ).map((r) => r.name);
+      expect(indexes).toContain("idx_usage_session_ts");
+      expect(indexes).not.toContain("idx_usage_session");
+      // A live value written after the upgrade must survive reopens.
       repo.touchLastActive("session-quiet", "2026-03-01T00:00:00.000Z");
     } finally {
       db.close();
@@ -168,21 +179,100 @@ describe("openDatabase column upgrade", () => {
       const repo = new SessionsRepo(reopened);
       expect(repo.findById("session-used")!.lastActiveAt).toBe("2026-02-03T09:30:00.000Z");
       expect(repo.findById("session-quiet")!.lastActiveAt).toBe("2026-03-01T00:00:00.000Z");
-      // Insert without lastActiveAt on an upgraded database: defaults to createdAt.
-      repo.insert({
-        sessionId: "session-fresh",
-        projectId: "p1",
-        agentId: "a1",
-        provider: "custom",
-        modelId: "m1",
-        workspace: "/w",
-        approvalMode: "allow-all",
-        title: null,
-        createdAt: "2026-04-01T00:00:00.000Z",
-      });
-      expect(repo.findById("session-fresh")!.lastActiveAt).toBe("2026-04-01T00:00:00.000Z");
     } finally {
       reopened.close();
     }
+  });
+
+  it("the backfill is gated on the ALTER: a later open neither re-runs it nor rewrites a row", () => {
+    const dbPath = path.join(dir, "web.db");
+    seedPreLastActiveDb(dbPath, (old) => {
+      old
+        .prepare(
+          `INSERT INTO sessions (session_id, project_id, agent_id, provider, model_id, workspace, created_at)
+           VALUES ('session-1', 'p1', 'a1', 'custom', 'm1', '/w', '2026-01-01T00:00:00.000Z')`,
+        )
+        .run();
+    });
+    const first = openDatabase(dbPath);
+    // Blank the cell by hand: only a re-running backfill would fill it in again, so this
+    // pins that the migration is scoped to the open that actually adds the column (a
+    // `sessions` full scan on every open forever is the cost of getting this wrong).
+    first.exec("UPDATE sessions SET last_active_at = NULL");
+    first.close();
+
+    const db = openDatabase(dbPath);
+    try {
+      expect(rawLastActive(db, "session-1")).toBeNull();
+      // ...and mapRow's coalesce is what keeps that invisible to callers: the safety net,
+      // not the mechanism (nothing else can repair a NULL once the gate has closed).
+      expect(new SessionsRepo(db).findById("session-1")!.lastActiveAt).toBe(
+        "2026-01-01T00:00:00.000Z",
+      );
+    } finally {
+      db.close();
+    }
+  });
+});
+
+describe("SessionsRepo last_active_at writes", () => {
+  let db: DatabaseSync;
+  let repo: SessionsRepo;
+  const base = {
+    projectId: "p1",
+    agentId: "a1",
+    provider: "custom",
+    modelId: "m1",
+    workspace: "/w",
+    approvalMode: "allow-all" as const,
+    title: null,
+    createdAt: "2026-05-01T00:00:00.000Z",
+  };
+
+  beforeEach(() => {
+    db = openDatabase(":memory:");
+    repo = new SessionsRepo(db);
+  });
+  afterEach(() => {
+    db.close();
+  });
+
+  it("both insert paths store a non-NULL cell, defaulting to created_at in SQL", () => {
+    repo.insert({ ...base, sessionId: "s-insert", lastActiveAt: base.createdAt });
+    repo.insertOrIgnore({ ...base, sessionId: "s-ignore", lastActiveAt: base.createdAt });
+    // The column is nullable (ALTER TABLE cannot add a DEFAULT), so the statement's own
+    // COALESCE is the guarantee — a caller reaching the repo without the field (JS, or a
+    // row shape built before it existed) must still leave a usable cell behind. Asserted
+    // on the raw cells: every mapped read coalesces, so a NULL would look identical there.
+    repo.insert({ ...base, sessionId: "s-missing" } as SessionRow);
+    repo.insertOrIgnore({ ...base, sessionId: "s-missing-ignore" } as SessionRow);
+    for (const id of ["s-insert", "s-ignore", "s-missing", "s-missing-ignore"]) {
+      expect(rawLastActive(db, id)).toBe(base.createdAt);
+    }
+    // An explicit value is stored as given, not overwritten by the default.
+    repo.insert({ ...base, sessionId: "s-explicit", lastActiveAt: "2026-06-01T00:00:00.000Z" });
+    expect(rawLastActive(db, "s-explicit")).toBe("2026-06-01T00:00:00.000Z");
+  });
+
+  it("markDriven and touchLastActive only ever move the stamp forward", () => {
+    repo.insert({ ...base, sessionId: "s1", lastActiveAt: base.createdAt });
+    repo.markDriven("s1", "2026-05-02T00:00:00.000Z");
+    expect(repo.findById("s1")!.lastActiveAt).toBe("2026-05-02T00:00:00.000Z");
+    expect(repo.findById("s1")!.hasTrace).toBe(true); // markDriven folds in the has_trace flip
+    repo.touchLastActive("s1", "2026-05-03T00:00:00.000Z");
+    expect(repo.findById("s1")!.lastActiveAt).toBe("2026-05-03T00:00:00.000Z");
+    // A backwards clock (NTP step, resume from suspend) must not regress the row.
+    repo.touchLastActive("s1", "2026-05-01T12:00:00.000Z");
+    repo.markDriven("s1", "2026-04-01T00:00:00.000Z");
+    expect(repo.findById("s1")!.lastActiveAt).toBe("2026-05-03T00:00:00.000Z");
+  });
+
+  it("writes for one Session leave every other row alone", () => {
+    repo.insert({ ...base, sessionId: "s1", lastActiveAt: base.createdAt });
+    repo.insert({ ...base, sessionId: "s2", lastActiveAt: base.createdAt });
+    repo.markDriven("s1", "2026-05-09T00:00:00.000Z");
+    repo.touchLastActive("s1", "2026-05-10T00:00:00.000Z");
+    expect(repo.findById("s2")!.lastActiveAt).toBe(base.createdAt);
+    expect(repo.findById("s2")!.hasTrace).toBe(false);
   });
 });

--- a/packages/server/test/db-upgrade.test.ts
+++ b/packages/server/test/db-upgrade.test.ts
@@ -56,6 +56,8 @@ describe("openDatabase column upgrade", () => {
       expect(legacy).not.toBeNull();
       expect(legacy!.client).toBeNull();
       expect(legacy!.hasTrace).toBe(false);
+      // last_active_at is ALTERed in too; with no usage_records the backfill falls to created_at.
+      expect(legacy!.lastActiveAt).toBe("2026-01-01T00:00:00.000Z");
       expect(repo.listByAgent("p1", "a1", { webOnly: true }).map((r) => r.sessionId)).toEqual([
         "session-legacy",
       ]);
@@ -92,8 +94,95 @@ describe("openDatabase column upgrade", () => {
       const cols = db.prepare("PRAGMA table_info(sessions)").all() as { name: string }[];
       expect(cols.filter((c) => c.name === "client")).toHaveLength(1);
       expect(cols.filter((c) => c.name === "has_trace")).toHaveLength(1);
+      expect(cols.filter((c) => c.name === "last_active_at")).toHaveLength(1);
     } finally {
       db.close();
+    }
+  });
+
+  it("backfills last_active_at once: last request timestamp when the session has usage, else created_at", () => {
+    const dbPath = path.join(dir, "web.db");
+    // A database formed by the immediately-previous schema: sessions (client/has_trace
+    // present) without last_active_at, plus usage_records as it already existed.
+    const old = new sqlite.DatabaseSync(dbPath);
+    old.exec(`CREATE TABLE sessions (
+      session_id    TEXT PRIMARY KEY,
+      project_id    TEXT NOT NULL,
+      agent_id      TEXT NOT NULL,
+      provider      TEXT NOT NULL,
+      model_id      TEXT NOT NULL,
+      workspace     TEXT NOT NULL,
+      approval_mode TEXT NOT NULL DEFAULT 'allow-all',
+      title         TEXT,
+      archived_at   TEXT,
+      client        TEXT,
+      has_trace     INTEGER NOT NULL DEFAULT 0,
+      created_at    TEXT NOT NULL
+    );`);
+    old.exec(`CREATE TABLE usage_records (
+      id                INTEGER PRIMARY KEY AUTOINCREMENT,
+      ts                TEXT NOT NULL,
+      date              TEXT NOT NULL,
+      project_id        TEXT NOT NULL,
+      agent_id          TEXT NOT NULL,
+      session_id        TEXT NOT NULL,
+      origin_session_id TEXT,
+      provider          TEXT NOT NULL,
+      model_id          TEXT NOT NULL,
+      cache_read        INTEGER NOT NULL,
+      cache_write       INTEGER NOT NULL,
+      output            INTEGER NOT NULL,
+      total             INTEGER NOT NULL,
+      status            TEXT NOT NULL DEFAULT 'completed'
+    );`);
+    const insertSession = old.prepare(
+      `INSERT INTO sessions (session_id, project_id, agent_id, provider, model_id, workspace, created_at)
+       VALUES (?, 'p1', 'a1', 'custom', 'm1', '/w', ?)`,
+    );
+    insertSession.run("session-used", "2026-01-01T00:00:00.000Z");
+    insertSession.run("session-quiet", "2026-01-02T00:00:00.000Z");
+    const insertUsage = old.prepare(
+      `INSERT INTO usage_records (ts, date, project_id, agent_id, session_id, provider, model_id, cache_read, cache_write, output, total)
+       VALUES (?, ?, 'p1', 'a1', 'session-used', 'custom', 'm1', 0, 0, 1, 1)`,
+    );
+    insertUsage.run("2026-02-01T10:00:00.000Z", "2026-02-01");
+    insertUsage.run("2026-02-03T09:30:00.000Z", "2026-02-03");
+    old.close();
+
+    const db = openDatabase(dbPath);
+    try {
+      const repo = new SessionsRepo(db);
+      // The most recent request timestamp is the closest persisted proxy for last Trace activity.
+      expect(repo.findById("session-used")!.lastActiveAt).toBe("2026-02-03T09:30:00.000Z");
+      // No usage rows: falls back to the row's own created_at.
+      expect(repo.findById("session-quiet")!.lastActiveAt).toBe("2026-01-02T00:00:00.000Z");
+      // A live value written after the upgrade must survive reopens (the IS NULL guard
+      // makes the backfill one-time, never a reopen-time reset).
+      repo.touchLastActive("session-quiet", "2026-03-01T00:00:00.000Z");
+    } finally {
+      db.close();
+    }
+
+    const reopened = openDatabase(dbPath);
+    try {
+      const repo = new SessionsRepo(reopened);
+      expect(repo.findById("session-used")!.lastActiveAt).toBe("2026-02-03T09:30:00.000Z");
+      expect(repo.findById("session-quiet")!.lastActiveAt).toBe("2026-03-01T00:00:00.000Z");
+      // Insert without lastActiveAt on an upgraded database: defaults to createdAt.
+      repo.insert({
+        sessionId: "session-fresh",
+        projectId: "p1",
+        agentId: "a1",
+        provider: "custom",
+        modelId: "m1",
+        workspace: "/w",
+        approvalMode: "allow-all",
+        title: null,
+        createdAt: "2026-04-01T00:00:00.000Z",
+      });
+      expect(repo.findById("session-fresh")!.lastActiveAt).toBe("2026-04-01T00:00:00.000Z");
+    } finally {
+      reopened.close();
     }
   });
 });

--- a/packages/server/test/followup.test.ts
+++ b/packages/server/test/followup.test.ts
@@ -57,6 +57,7 @@ describe("follow-up queue route", () => {
       approvalMode: "always-ask",
       title: null,
       createdAt: new Date().toISOString(),
+      lastActiveAt: new Date().toISOString(),
     };
     t.deps.sessionsRepo.insert(row);
     runs = [];

--- a/packages/server/test/goals.test.ts
+++ b/packages/server/test/goals.test.ts
@@ -36,6 +36,7 @@ const ROW: SessionRow = {
   approvalMode: "allow-all",
   title: null,
   createdAt: "2026-07-06T00:00:00.000Z",
+  lastActiveAt: "2026-07-06T00:00:00.000Z",
 };
 
 function usage(total: number): TokenCounts {

--- a/packages/server/test/messages-live.test.ts
+++ b/packages/server/test/messages-live.test.ts
@@ -82,6 +82,7 @@ describe("messages live tail", () => {
       approvalMode: "always-ask",
       title: null,
       createdAt: new Date().toISOString(),
+      lastActiveAt: new Date().toISOString(),
     };
     t.deps.sessionsRepo.insert(row);
   });

--- a/packages/server/test/messages-pending-input.test.ts
+++ b/packages/server/test/messages-pending-input.test.ts
@@ -77,6 +77,7 @@ describe("GET /messages serves the running task's pending inputs", () => {
       approvalMode: "always-ask",
       title: null,
       createdAt: new Date().toISOString(),
+      lastActiveAt: new Date().toISOString(),
     };
     t.deps.sessionsRepo.insert(row);
     const bootstrapGate = new Promise<void>((resolve) => {
@@ -165,6 +166,7 @@ describe("GET /messages serves the running task's pending inputs", () => {
       approvalMode: "always-ask",
       title: null,
       createdAt: new Date().toISOString(),
+      lastActiveAt: new Date().toISOString(),
     };
     t.deps.sessionsRepo.insert(row);
     // First run: connect aborted before any request (the core cancels the bootstrap and

--- a/packages/server/test/models.test.ts
+++ b/packages/server/test/models.test.ts
@@ -619,6 +619,7 @@ describe("models update reaches loaded sessions (invalidation + live unlock)", (
       approvalMode: "allow-all",
       title: null,
       createdAt: new Date().toISOString(),
+      lastActiveAt: new Date().toISOString(),
     });
   };
 

--- a/packages/server/test/retry-now.test.ts
+++ b/packages/server/test/retry-now.test.ts
@@ -62,6 +62,7 @@ describe("retry-now route", () => {
       approvalMode: "always-ask",
       title: null,
       createdAt: new Date().toISOString(),
+      lastActiveAt: new Date().toISOString(),
     };
     t.deps.sessionsRepo.insert(row);
     skips = [];

--- a/packages/server/test/scheduler.test.ts
+++ b/packages/server/test/scheduler.test.ts
@@ -124,6 +124,7 @@ describe("scheduler", () => {
       approvalMode: "allow-all",
       title: null,
       createdAt: new Date(nowMs).toISOString(),
+      lastActiveAt: new Date(nowMs).toISOString(),
     });
   }
 

--- a/packages/server/test/session-index.test.ts
+++ b/packages/server/test/session-index.test.ts
@@ -119,6 +119,29 @@ describe("session-index", () => {
       await api.get(`/api/sessions/${session.sessionId}`)
     ).json()) as SessionResponse;
     expect(got.session.lastActiveAt).toBe(session.createdAt);
+
+    // The real creation path must leave a stored cell, not just a value the read layer
+    // computes: every mapped read coalesces to created_at, so a row written NULL would
+    // answer all three assertions above identically.
+    const stored = t.deps.db
+      .prepare("SELECT last_active_at AS v FROM sessions WHERE session_id = ?")
+      .get(session.sessionId) as { v: unknown } | undefined;
+    expect(stored?.v).toBe(session.createdAt);
+  });
+
+  it("PATCH answers with the row as it stands after the write, not the pre-PATCH snapshot", async () => {
+    await configureModels();
+    const { session } = (await (await api.post(base(), {})).json()) as SessionCreateResponse;
+    // Stand in for a run that advanced the stamp while the PATCH was in flight: the route
+    // reads its row before awaiting, so without a re-read the response would carry — and
+    // the web store would adopt — a value older than what is on disk.
+    const advanced = "2027-01-01T00:00:00.000Z";
+    t.deps.sessionsRepo.touchLastActive(session.sessionId, advanced);
+    const patched = (await (
+      await api.patch(`/api/sessions/${session.sessionId}`, { title: "renamed" })
+    ).json()) as SessionResponse;
+    expect(patched.session.title).toBe("renamed");
+    expect(patched.session.lastActiveAt).toBe(advanced);
   });
 
   it("schedule-created Session: source derives from session_meta (registry), never from the DB row; user sessions carry none", async () => {
@@ -159,6 +182,7 @@ describe("session-index", () => {
       approvalMode: "allow-all",
       title: null,
       createdAt: "2026-07-02T09:00:00.000Z",
+      lastActiveAt: "2026-07-02T09:00:00.000Z",
     });
     const meta: SessionMetaPayload = {
       session_id: sid,
@@ -228,6 +252,7 @@ describe("session-index", () => {
       approvalMode: "allow-all" as const,
       title: null,
       createdAt: `2026-07-0${n}T08:00:00.000Z`,
+      lastActiveAt: `2026-07-0${n}T08:00:00.000Z`,
     });
     for (const n of [1, 2, 3]) t.deps.sessionsRepo.insert(mk(n));
 
@@ -286,6 +311,7 @@ describe("session-index", () => {
       approvalMode: "allow-all",
       title: null,
       createdAt: "2026-07-02T09:30:00.000Z",
+      lastActiveAt: "2026-07-02T09:30:00.000Z",
     });
     await writeTraceFile(t.root, projectId, "default_agent", "2026-07-02", subagentE, 1, [
       sessionMeta({
@@ -446,6 +472,7 @@ describe("session-index", () => {
       approvalMode: "allow-all",
       title: null,
       createdAt: "2026-07-02T09:00:00.000Z",
+      lastActiveAt: "2026-07-02T09:00:00.000Z",
     });
     const list = (await (await api.get(base())).json()) as SessionsResponse;
     expect(list.sessions.find((s) => s.sessionId === legacy)).toBeDefined();
@@ -548,6 +575,7 @@ describe("session-index", () => {
   });
 
   it("insertOrIgnore is idempotent: concurrent first discovery of one Session doesn't throw on the UNIQUE constraint", async () => {
+    const createdAt = new Date().toISOString();
     const row = {
       sessionId: "session-2026-07-02-00-00-00-11223344",
       projectId,
@@ -557,7 +585,8 @@ describe("session-index", () => {
       workspace: "/tmp/w",
       approvalMode: "always-ask" as const,
       title: null,
-      createdAt: new Date().toISOString(),
+      createdAt,
+      lastActiveAt: createdAt,
     };
     t.deps.sessionsRepo.insertOrIgnore(row);
     // A second insert with different fields for the same id: silently ignored, no throw, first-inserted value is kept.

--- a/packages/server/test/session-index.test.ts
+++ b/packages/server/test/session-index.test.ts
@@ -103,6 +103,24 @@ describe("session-index", () => {
     expect(list.sessions.map((s) => s.sessionId)).toContain(session.sessionId);
   });
 
+  it("SessionInfo carries lastActiveAt (ISO, = createdAt at creation) through create, list, and single GET", async () => {
+    await configureModels();
+    const res = await api.post(base(), {});
+    expect(res.status).toBe(201);
+    const { session } = (await res.json()) as SessionCreateResponse;
+    expect(session.lastActiveAt).toBe(session.createdAt);
+    expect(session.lastActiveAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+
+    const list = (await (await api.get(base())).json()) as SessionsResponse;
+    const listed = list.sessions.find((s) => s.sessionId === session.sessionId);
+    expect(listed?.lastActiveAt).toBe(session.createdAt);
+
+    const got = (await (
+      await api.get(`/api/sessions/${session.sessionId}`)
+    ).json()) as SessionResponse;
+    expect(got.session.lastActiveAt).toBe(session.createdAt);
+  });
+
   it("schedule-created Session: source derives from session_meta (registry), never from the DB row; user sessions carry none", async () => {
     await configureModels();
     // The scheduler goes through SessionService.createSession directly (no HTTP route exposes source).

--- a/packages/server/test/session-loader.test.ts
+++ b/packages/server/test/session-loader.test.ts
@@ -43,6 +43,7 @@ function row(workspace: string): SessionRow {
     approvalMode: "always-ask",
     title: null,
     createdAt: new Date().toISOString(),
+    lastActiveAt: new Date().toISOString(),
   };
 }
 

--- a/packages/server/test/session-manager.test.ts
+++ b/packages/server/test/session-manager.test.ts
@@ -49,6 +49,7 @@ const ROW: SessionRow = {
   approvalMode: "always-ask",
   title: null,
   createdAt: "2026-07-06T00:00:00.000Z",
+  lastActiveAt: "2026-07-06T00:00:00.000Z",
 };
 
 /** A simple, scriptable fake Session: run yields one tool_call and requests approval for it. */
@@ -78,6 +79,24 @@ function approvalFakeSession(sessionId: string, toolName = "write_file"): Runtim
   };
 }
 
+/**
+ * A repo whose last-active writes always throw — the realistic failure being a
+ * DatabaseSync handle closed by shutdown while a run outlived its drain window. Everything
+ * else behaves normally, so a test can assert that the run's wrap-up survives it.
+ */
+function brokenTouchRepo(repo: SessionsRepo): SessionsRepo {
+  return new Proxy(repo, {
+    get(target, prop, receiver): unknown {
+      if (prop === "markDriven" || prop === "touchLastActive") {
+        return () => {
+          throw new Error("database is not open");
+        };
+      }
+      return Reflect.get(target, prop, receiver) as unknown;
+    },
+  });
+}
+
 describe("session-manager", () => {
   let db: DatabaseSync;
   let sessions: SessionsRepo;
@@ -86,7 +105,12 @@ describe("session-manager", () => {
   let recorded: OmniMessage[];
   let recordedCtx: UsageContext[];
 
-  const makeManager = (loader: SessionLoader, errors?: ErrorSink): SessionManager =>
+  const makeManager = (
+    loader: SessionLoader,
+    errors?: ErrorSink,
+    /** Stubbed clock for persisted timestamps (see the last_active_at test). */
+    now?: () => Date,
+  ): SessionManager =>
     new SessionManager({
       sessions,
       channels,
@@ -99,6 +123,7 @@ describe("session-manager", () => {
         },
       },
       ...(errors ? { errors } : {}),
+      ...(now ? { now } : {}),
       log: () => {},
     });
 
@@ -160,26 +185,80 @@ describe("session-manager", () => {
     });
   });
 
-  it("drive stamps last_active_at: created rows start at createdAt, a run advances it, unrelated sessions untouched", async () => {
-    sessions.insert({ ...ROW, sessionId: "session-other", createdAt: "2026-07-07T00:00:00.000Z" });
-    sessions.updateApprovalMode("session-1", "allow-all");
+  it("drive stamps last_active_at twice per run — once at the start, once at the end — and leaves other rows alone", async () => {
+    sessions.insert({
+      ...ROW,
+      sessionId: "session-other",
+      createdAt: "2026-07-07T00:00:00.000Z",
+      lastActiveAt: "2026-07-07T00:00:00.000Z",
+    });
+    // A stubbed clock, one second per read, so each stamp has an exact expected value:
+    // sampling only after the run (when both stamps have landed) cannot tell the two
+    // apart, and a run-end stamp that stops happening would still look "advanced".
+    let tick = 0;
+    const at = (n: number): string => `2026-07-10T00:00:0${n}.000Z`;
+    const manager = makeManager(loaderOf(approvalFakeSession("session-1")), undefined, () => {
+      const d = new Date(at(tick));
+      tick += 1;
+      return d;
+    });
+    const lastActive = (id: string): string => sessions.findById(id)!.lastActiveAt;
     // Insert default: last_active_at = created_at until the first driven run.
-    expect(sessions.findById("session-1")!.lastActiveAt).toBe(ROW.createdAt);
-    const before = new Date().toISOString();
-    const manager = makeManager(loaderOf(approvalFakeSession("session-1")));
+    expect(lastActive("session-1")).toBe(ROW.createdAt);
+
+    // The session pauses mid-run on the always-ask approval — the one moment where the
+    // run-start stamp is observable on its own.
     await manager.startTask("session-1", [userText("hello")]);
+    await waitFor(() => manager.pendingApprovalCount("session-1") === 1);
+    const midRun = lastActive("session-1");
+    expect(midRun).toBe(at(0));
+    expect(midRun > ROW.createdAt).toBe(true);
+
+    manager.decideApproval("session-1", "tc-1", "allow");
     await waitFor(() => manager.statusOf("session-1") === "idle");
-    const afterTask = sessions.findById("session-1")!.lastActiveAt!;
-    // Stamped with the server clock in the same ISO shape as created_at, past the pre-run instant.
-    expect(afterTask).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
-    expect(afterTask >= before).toBe(true);
-    expect(afterTask > ROW.createdAt).toBe(true);
-    // Compaction is a driven run too: the same choke point advances the stamp again.
+    // Strictly greater: the run END must have its own stamp, or a long Task would report
+    // the moment it began as its last activity for as long as it runs.
+    expect(lastActive("session-1")).toBe(at(1));
+    expect(lastActive("session-1") > midRun).toBe(true);
+
+    // A compaction is a driven run too, and stamps its own pair.
     await manager.startCompact("session-1");
     await waitFor(() => manager.statusOf("session-1") === "idle");
-    expect(sessions.findById("session-1")!.lastActiveAt! >= afterTask).toBe(true);
+    expect(lastActive("session-1")).toBe(at(3));
     // A session with no activity keeps its creation stamp.
-    expect(sessions.findById("session-other")!.lastActiveAt).toBe("2026-07-07T00:00:00.000Z");
+    expect(lastActive("session-other")).toBe("2026-07-07T00:00:00.000Z");
+  });
+
+  it("a failing last-active write cannot strand a run: idle is still published and queued follow-ups still start", async () => {
+    sessions.updateApprovalMode("session-1", "allow-all");
+    const logs: string[] = [];
+    const recordedErrors: ErrorRecordArgs[] = [];
+    const manager = new SessionManager({
+      sessions: brokenTouchRepo(sessions),
+      channels,
+      sources,
+      loader: loaderOf(approvalFakeSession("session-1")),
+      recorder: { record: async () => {} },
+      errors: { record: (args) => recordedErrors.push(args) },
+      log: (line) => logs.push(line),
+    });
+    const events = capture("session-1");
+    await manager.startTask("session-1", [userText("hello")]);
+    // Queue a follow-up while the first run is in flight: its auto-start lives in the same
+    // finally, AFTER the stamp — a throw there would stall it forever.
+    await manager.startTask("session-1", [userText("second")], { queueIfBusy: true });
+    await waitFor(() => manager.statusOf("session-1") === "idle" && logs.length >= 4);
+    const states = serverEvents(events)
+      .filter((e) => e.type === "task_state")
+      .map((s) => s.state);
+    // Two runs reached their wrap-up — the queued one only ever starts from inside the
+    // finally, after the failing write — and the session ends up idle, not stuck running.
+    expect(states.filter((s) => s === "idle")).toHaveLength(2);
+    expect(states.at(-1)).toBe("idle");
+    expect(manager.pendingFollowUpCount("session-1")).toBe(0);
+    // The failure is reported, not silent.
+    expect(logs.some((l) => l.includes("last-active bookkeeping failed"))).toBe(true);
+    expect(recordedErrors.map((e) => e.code)).toContain("session_touch_failed");
   });
 
   it("startTask forwards thinkingLevel into session.run options (per-turn, this Task only)", async () => {

--- a/packages/server/test/session-manager.test.ts
+++ b/packages/server/test/session-manager.test.ts
@@ -160,6 +160,28 @@ describe("session-manager", () => {
     });
   });
 
+  it("drive stamps last_active_at: created rows start at createdAt, a run advances it, unrelated sessions untouched", async () => {
+    sessions.insert({ ...ROW, sessionId: "session-other", createdAt: "2026-07-07T00:00:00.000Z" });
+    sessions.updateApprovalMode("session-1", "allow-all");
+    // Insert default: last_active_at = created_at until the first driven run.
+    expect(sessions.findById("session-1")!.lastActiveAt).toBe(ROW.createdAt);
+    const before = new Date().toISOString();
+    const manager = makeManager(loaderOf(approvalFakeSession("session-1")));
+    await manager.startTask("session-1", [userText("hello")]);
+    await waitFor(() => manager.statusOf("session-1") === "idle");
+    const afterTask = sessions.findById("session-1")!.lastActiveAt!;
+    // Stamped with the server clock in the same ISO shape as created_at, past the pre-run instant.
+    expect(afterTask).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    expect(afterTask >= before).toBe(true);
+    expect(afterTask > ROW.createdAt).toBe(true);
+    // Compaction is a driven run too: the same choke point advances the stamp again.
+    await manager.startCompact("session-1");
+    await waitFor(() => manager.statusOf("session-1") === "idle");
+    expect(sessions.findById("session-1")!.lastActiveAt! >= afterTask).toBe(true);
+    // A session with no activity keeps its creation stamp.
+    expect(sessions.findById("session-other")!.lastActiveAt).toBe("2026-07-07T00:00:00.000Z");
+  });
+
   it("startTask forwards thinkingLevel into session.run options (per-turn, this Task only)", async () => {
     sessions.updateApprovalMode("session-1", "allow-all");
     const seen: (string | undefined)[] = [];

--- a/packages/server/test/sse-stream.test.ts
+++ b/packages/server/test/sse-stream.test.ts
@@ -96,6 +96,7 @@ describe("sse-stream", () => {
       approvalMode: "always-ask",
       title: null,
       createdAt: new Date().toISOString(),
+      lastActiveAt: new Date().toISOString(),
     };
     t.deps.sessionsRepo.insert(row);
   });

--- a/packages/server/test/steer.test.ts
+++ b/packages/server/test/steer.test.ts
@@ -79,6 +79,7 @@ describe("steer route", () => {
       approvalMode: "always-ask",
       title: null,
       createdAt: new Date().toISOString(),
+      lastActiveAt: new Date().toISOString(),
     };
     t.deps.sessionsRepo.insert(row);
     steered = [];

--- a/packages/server/test/task-attachments.test.ts
+++ b/packages/server/test/task-attachments.test.ts
@@ -98,6 +98,7 @@ describe("task input file attachments", () => {
       approvalMode: "allow-all",
       title: null,
       createdAt: new Date().toISOString(),
+      lastActiveAt: new Date().toISOString(),
     };
     t.deps.sessionsRepo.insert(row);
     runs = [];
@@ -384,6 +385,7 @@ describe("task attachments are removed when the Task never starts", () => {
       approvalMode: "allow-all",
       title: null,
       createdAt: new Date().toISOString(),
+      lastActiveAt: new Date().toISOString(),
     });
     dir = path.join(scratchpadDir(t.root, PID, "default_agent"), FAIL_SID);
   });
@@ -426,6 +428,7 @@ describe("scratchpad directory containment", () => {
       approvalMode: "allow-all",
       title: null,
       createdAt: new Date().toISOString(),
+      lastActiveAt: new Date().toISOString(),
     });
     t.deps.manager.adopt(
       t.deps.sessionsRepo.findById(LINK_SID)!,

--- a/packages/server/test/title-generator.test.ts
+++ b/packages/server/test/title-generator.test.ts
@@ -30,6 +30,7 @@ const ROW: SessionRow = {
   approvalMode: "always-ask",
   title: null,
   createdAt: "2026-07-07T00:00:00.000Z",
+  lastActiveAt: "2026-07-07T00:00:00.000Z",
 };
 
 const CTX: UsageContext = {

--- a/packages/server/test/trace-service.test.ts
+++ b/packages/server/test/trace-service.test.ts
@@ -76,6 +76,7 @@ function dbRow(over: Partial<SessionRow> & { sessionId: string }): SessionRow {
     approvalMode: "allow-all",
     title: null,
     createdAt: "2026-07-05T10:00:00.000Z",
+    lastActiveAt: "2026-07-05T10:00:00.000Z",
     ...over,
   };
 }

--- a/packages/server/test/vault.test.ts
+++ b/packages/server/test/vault.test.ts
@@ -150,6 +150,7 @@ describe("vault api", () => {
       approvalMode: "allow-all",
       title: null,
       createdAt: new Date().toISOString(),
+      lastActiveAt: new Date().toISOString(),
     });
     const idle = () => t.deps.manager.statusOf("vault-sess-1") === "idle";
 

--- a/packages/web/test/session-grouping.test.ts
+++ b/packages/web/test/session-grouping.test.ts
@@ -46,6 +46,7 @@ function session(
     workspace,
     approvalMode: "allow-all",
     createdAt,
+    lastActiveAt: createdAt,
     status: "idle",
     pendingApprovalCount: 0,
     pendingFollowUpCount: 0,


### PR DESCRIPTION
## What / why

Sessions persisted only `createdAt`; rows now carry a server-maintained `lastActiveAt` so session lists can reflect real last activity (user-approved design). The sidebar display/sorting switch is deliberately NOT in this PR — that lands later via PR #277.

## Design

- **Schema**: new `last_active_at TEXT` column on `sessions` (ISO 8601, same convention as `created_at`), in both the fresh-DB `CREATE TABLE` and `openDatabase`'s idempotent `ensureColumn` ALTER-on-open list — the repo's existing migration mechanism. The value is **monotonic**: both writes clamp with `MAX(COALESCE(last_active_at, ''), ?)`, so a backwards clock step (NTP, resume from suspend) can never regress a row below its previous value or its `created_at`.
- **Write chokepoint**: `SessionManager.drive()` — the one place every driven run passes through (the same spot that already flipped `has_trace`). A run stamps exactly twice: once at start, once at end. A "run" is one Task, one compaction, or one **whole goal loop** (`startGoal` hands all rounds to a single `drive`), so an N-round goal stamps twice, not 2N times. Mid-run activity (steering, approvals, queued follow-ups) rides on the run-end stamp; nothing writes per streamed message. The run-start write is folded into `SessionsRepo.markDriven` (`has_trace` + stamp in one statement: one WAL commit, not two), and both writes are guarded — they sit outside `drive`'s covering try (one before it, one in its `finally`), where an `ERR_INVALID_STATE` from a handle closed by shutdown would otherwise pin the entry at `running` or skip the idle broadcast, title generation, and the auto-start of queued follow-ups.
- **Creation**: `SessionRow.lastActiveAt` is required and set explicitly at every insert site, so no layer computes its own default independently of what was stored. The inserts additionally default it **in SQL** (`COALESCE(?, ?)` over the row's own `created_at`, bound twice — SQLite forbids sibling-column references inside `VALUES`, and a column added by `ALTER TABLE` cannot be given a `DEFAULT`); that statement is the only place able to guarantee the cell is never written NULL.
- **Backfill choice**: one-time, inside the same transaction as the ALTER, and **gated on the ALTER actually happening** (so it never re-scans `sessions` on subsequent opens). Legacy rows take `MAX(usage_records.ts)` for their session — the most recent request timestamp, the closest persisted proxy for last Trace activity — falling back to `created_at`. True Trace-tail timestamps were deliberately not read: neither `trace_files` nor `trace_sessions` stores a last-event timestamp (only date-granularity shard dates / `first_ts`), so deriving them would mean scanning every session's shard files at startup.
- **Index**: `idx_usage_session (session_id)` is reshaped to `idx_usage_session_ts (session_id, ts)` so the backfill's correlated `MAX(ts)` becomes a covering-index scan (`EXPLAIN QUERY PLAN`: `SEARCH usage_records USING COVERING INDEX idx_usage_session_ts`) instead of a random table lookup per usage row — this runs synchronously before the HTTP listener binds, so an unindexed scan would show up as a dead server on the first launch after upgrade. The superseded index is dropped on open, since `CREATE INDEX IF NOT EXISTS` never reshapes an existing one; `(session_id)` is a strict prefix of the new shape, so every query it served is served identically.
- **API**: `SessionInfo.lastActiveAt: string` (additive) flows through create / list / single-GET / PATCH. PATCH re-reads the row after its writes — it previously answered from a snapshot taken before two awaits, so a run finishing in that window returned a regressed value that the web store adopts wholesale. The web app consumes the type from `@prismshadow/penguin-server/api`, so no web source changes were needed (one web test factory gained the field). List ordering is unchanged (`createdAt` desc); switching it to `lastActiveAt` is PR #277's job.
- **Known limitation (documented in the type)**: rows this server never drives keep `createdAt` — Sessions adopted from a CLI Trace, and subagent rows (their work is driven through the parent Session's entry). Making those track real activity means consulting the Trace tree; it changes what the field means, so it is left as a separate decision.

## Backward compatibility

- **Old shape handled**: `web.db` files whose `sessions` table predates the `last_active_at` column, and whose usage index is the older `idx_usage_session (session_id)`.
- **What the migration does**: on the first open after upgrading, `openDatabase` creates `idx_usage_session_ts` and drops the superseded `idx_usage_session`, then ALTERs the column in (`ensureColumn`, guarded by a `PRAGMA table_info` check) and backfills every existing row once — from the session's most recent request timestamp in `usage_records`, else its `created_at`. ALTER and backfill share one transaction, and the backfill only runs in the open that actually adds the column, so the whole path is idempotent: a fresh DB and an already-migrated DB do no work, later opens never rewrite live values, and a crash mid-upgrade rolls back to "no column" and is redone on the next open (never a half-migrated table). An index is derived data, so the reshape costs at most one rebuild, never information.
- **User action**: none — the migration is automatic and silent. Large existing databases pay a one-time index build plus a single indexed pass over `sessions` on that first open.
- **How long the migration code must live**: the `upgradeLastActiveAt` helper (ALTER + gated backfill) and the `DROP INDEX IF EXISTS idx_usage_session` line in `packages/server/src/db/database.ts` must stay until a DB-schema floor is declared — a release explicitly allowed to break pre-floor `web.db` files, per the standing note in `database.ts`. Their removal needs an explicit future decision; flagged here for the changelog summary PR.

## Verification

All commands run at the worktree root with Node 24:

```
pnpm install --frozen-lockfile   # OK
pnpm -r build                    # all packages built
pnpm typecheck                   # all packages clean
pnpm test                        # exit 0: core 792 passed (5 skipped), server 62 files / 603 tests,
                                 # cli 235, web 650, desktop 48, skills 21, docs 32, landing 39 — all
                                 # green (Playwright e2e is a separate script, not part of pnpm test)
pnpm format && pnpm format:check # all matched files use Prettier code style
```

Tests (server):

- `db-upgrade.test.ts` — backfill from last request ts vs `created_at` (asserted on the **raw** column, not the coalesced read); the gate, proven by blanking a cell and reopening (it stays NULL, and `mapRow`'s coalesce is what keeps that invisible); the index reshape (new one present, old one gone); both insert paths storing a non-NULL cell including when a caller supplies nothing; the monotonic clamp under a backwards clock; and per-row isolation. The old-shape fixture is derived from `SCHEMA_SQL` (+ `ALTER TABLE … DROP COLUMN`) instead of a hand-copied DDL replica.
- `session-manager.test.ts` — the two stamps pinned **independently** under a stubbed clock: sampled mid-run at the approval pause (run-start stamp alone) and again after idle with a strict `>` (run-end stamp); compaction stamps its own pair; unrelated rows untouched. Plus a guarded-finally test: with a repo whose stamp writes always throw, both runs still reach idle, the queued follow-up still auto-starts, and the failure is logged and recorded as `session_touch_failed`.
- `session-index.test.ts` — `lastActiveAt` equals `createdAt` at creation (ISO 8601) through create, list, and single GET, with the stored cell read straight from SQLite; and PATCH answering with the post-write row rather than its pre-PATCH snapshot.

Mutation-checked (each of these now fails the suite, and each passed it before this round): deleting the run-end stamp; removing the SQL-side insert default; ungating the backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
