### PR TITLE
Add Windows EVSign release signing

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -7,8 +7,9 @@
 # run on any branch.
 #
 # macOS release artifacts are Developer ID signed and notarized when release.yml calls
-# this workflow with require_macos_signing=true. Standalone dry-runs can still build
-# unsigned artifacts when signing secrets are absent.
+# this workflow with require_macos_signing=true. Windows release installers are signed
+# with EVSign when release.yml calls this workflow with require_windows_signing=true.
+# Standalone dry-runs can still build unsigned artifacts when signing secrets are absent.
 name: Desktop packages
 
 on:
@@ -29,13 +30,19 @@ on:
         required: false
         type: boolean
         default: false
-    # No `secrets:` declarations here, deliberately. The signing secrets live in the
-    # `apple-signing` GitHub environment referenced by the macOS matrix job, and
-    # environment secrets resolve inside the job itself — in reusable-workflow calls
-    # included. Declaring them as workflow_call secrets rebinds those names to the
-    # caller-passed values, which are empty when the caller passes none, shadowing the
-    # environment's real values: exactly the v0.2.2 release failure ("Missing macOS
-    # signing secrets" with all six configured).
+      require_windows_signing:
+        description: "Sign Windows installers with EVSign, failing the job if credentials are missing."
+        required: false
+        type: boolean
+        default: false
+    # No `secrets:` declarations here, deliberately. Signing secrets live in the
+    # job environments referenced by the matrix, and environment secrets resolve
+    # inside the job itself — in reusable-workflow calls included. Declaring them
+    # as workflow_call secrets rebinds those names to caller-passed values, which
+    # are empty when the caller passes none, shadowing the environment's real
+    # values: exactly the v0.2.2 release failure ("Missing macOS signing secrets"
+    # with all six configured). release.yml still passes `secrets: inherit` so
+    # repo-level secrets, if any, also remain visible.
   workflow_dispatch:
     inputs:
       ref:
@@ -50,6 +57,11 @@ on:
         default: ""
       require_macos_signing:
         description: "Sign/notarize macOS artifacts, failing the job if credentials are missing."
+        required: false
+        type: boolean
+        default: false
+      require_windows_signing:
+        description: "Sign Windows installers with EVSign, failing the job if credentials are missing."
         required: false
         type: boolean
         default: false
@@ -205,8 +217,134 @@ jobs:
             fi
           } >> "$GITHUB_ENV"
 
+      - name: Prepare Windows signing credentials
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          REQUIRE_WINDOWS_SIGNING: ${{ inputs.require_windows_signing && 'true' || 'false' }}
+          EVSIGN_KEY: ${{ secrets.EVSIGN_KEY }}
+        run: |
+          $ErrorActionPreference = "Stop"
+
+          "EVSIGN_REQUIRE=$($env:REQUIRE_WINDOWS_SIGNING)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+          if ([string]::IsNullOrWhiteSpace($env:EVSIGN_KEY)) {
+            if ($env:REQUIRE_WINDOWS_SIGNING -eq "true") {
+              Write-Error "Missing EVSIGN_KEY secret required for Windows release signing."
+            }
+
+            Write-Host "EVSIGN_KEY is not configured; Windows dry-run artifacts will remain unsigned."
+            exit 0
+          }
+
+          Write-Output "::add-mask::$env:EVSIGN_KEY"
+
+          $client = Join-Path $env:RUNNER_TEMP "evsign-client.exe"
+          $expectedSigner = "Keroro Software Ltd"
+
+          # Keep using the vendor's latest CLI so compatible updates roll forward,
+          # but authenticate the downloaded executable before passing it EVSIGN_KEY.
+          Invoke-WebRequest `
+            -Uri "https://mc.evsign.cn/evsign-client-cli-windows-latest" `
+            -OutFile $client `
+            -MaximumRedirection 5 `
+            -TimeoutSec 120
+
+          if (-not (Test-Path -LiteralPath $client)) {
+            Write-Error "EVSign CLI was not downloaded to $client."
+          }
+
+          $hash = (Get-FileHash -LiteralPath $client -Algorithm SHA256).Hash
+          Write-Host "EVSign CLI SHA256: $hash"
+
+          $signature = Get-AuthenticodeSignature -LiteralPath $client
+          $signature | Format-List `
+            Status, `
+            StatusMessage, `
+            @{Label="SignerSubject"; Expression={$_.SignerCertificate.Subject}}, `
+            @{Label="SignerIssuer"; Expression={$_.SignerCertificate.Issuer}}
+
+          if ($signature.Status -ne "Valid") {
+            Write-Error "EVSign CLI Authenticode signature is not valid: $($signature.Status) $($signature.StatusMessage)"
+          }
+
+          if ($null -eq $signature.SignerCertificate -or $signature.SignerCertificate.Subject -notlike "*$expectedSigner*") {
+            Write-Error "EVSign CLI signer does not contain expected publisher '$expectedSigner'."
+          }
+
+          "EVSIGN_CLIENT=$client" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Build packages
+        env:
+          EVSIGN_REQUIRE: ${{ runner.os == 'Windows' && inputs.require_windows_signing && 'true' || 'false' }}
+          EVSIGN_KEY: ${{ runner.os == 'Windows' && secrets.EVSIGN_KEY || '' }}
         run: pnpm --dir packages/desktop exec electron-builder ${{ matrix.args }} --publish never ${{ runner.os == 'macOS' && inputs.require_macos_signing && '-c.mac.forceCodeSigning=true' || '' }}
+
+      - name: Verify Windows signing and update metadata
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          REQUIRE_WINDOWS_SIGNING: ${{ inputs.require_windows_signing && 'true' || 'false' }}
+        run: |
+          $ErrorActionPreference = "Stop"
+
+          $publisher = "RushRush Network Technology Ltd"
+          $outDir = "packages/desktop/stage/out"
+          $installer = Join-Path $outDir "penguin-desktop-win32-x64.exe"
+          $latest = Join-Path $outDir "latest.yml"
+          $blockmap = "$installer.blockmap"
+          $appExe = Join-Path $outDir "win-unpacked/PenguinHarness.exe"
+          $elevateExe = Join-Path $outDir "win-unpacked/resources/elevate.exe"
+          $appUpdate = Join-Path $outDir "win-unpacked/resources/app-update.yml"
+
+          $requiredPaths = @($installer, $latest, $blockmap, $appExe, $elevateExe, $appUpdate)
+          foreach ($path in $requiredPaths) {
+            if (-not (Test-Path -LiteralPath $path)) {
+              Write-Error "Windows build output was not produced: $path"
+            }
+          }
+
+          $signatures = @($installer, $appExe, $elevateExe)
+          foreach ($path in $signatures) {
+            $sig = Get-AuthenticodeSignature -LiteralPath $path
+            $sig | Format-List @{Label="Path"; Expression={$path}}, Status, StatusMessage, SignerCertificate, TimeStamperCertificate
+
+            if ($sig.Status -eq "NotSigned" -and $env:REQUIRE_WINDOWS_SIGNING -ne "true") {
+              Write-Host "$path is unsigned; allowed for this dry-run."
+              continue
+            }
+
+            if ($sig.Status -ne "Valid") {
+              Write-Error "$path signature is not valid: $($sig.Status) $($sig.StatusMessage)"
+            }
+
+            if ($null -eq $sig.SignerCertificate -or $sig.SignerCertificate.Subject -notlike "*$publisher*") {
+              Write-Error "$path signer does not contain expected publisher '$publisher'."
+            }
+
+            if ($null -eq $sig.TimeStamperCertificate) {
+              Write-Error "$path signature is missing a timestamp certificate."
+            }
+          }
+
+          $installerPath = (Resolve-Path -LiteralPath $installer).ProviderPath
+          $installerBytes = [System.IO.File]::ReadAllBytes($installerPath)
+          $sha512 = [Convert]::ToBase64String([System.Security.Cryptography.SHA512]::Create().ComputeHash($installerBytes))
+          $size = $installerBytes.Length
+          $latestText = Get-Content -LiteralPath $latest -Raw
+
+          if ($latestText -notmatch [Regex]::Escape("sha512: $sha512")) {
+            Write-Error "latest.yml does not match the signed Windows installer sha512."
+          }
+
+          if ($latestText -notmatch [Regex]::Escape("size: $size")) {
+            Write-Error "latest.yml does not match the signed Windows installer size."
+          }
+
+          $appUpdateText = Get-Content -LiteralPath $appUpdate -Raw -Encoding UTF8
+          if ($appUpdateText -notmatch "publisherName:" -or $appUpdateText -notmatch [Regex]::Escape($publisher)) {
+            Write-Error "app-update.yml does not include the expected Windows publisherName."
+          }
 
       - name: Notarize and staple macOS DMGs
         if: runner.os == 'macOS' && inputs.require_macos_signing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,9 +88,11 @@ jobs:
       ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
       tag: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
       require_macos_signing: true
-    # The signing secrets themselves live in the `apple-signing` environment and resolve
-    # inside the called job; `inherit` additionally forwards repo-level secrets so the
-    # called workflow never sees a name shadowed to empty (the v0.2.2 failure mode).
+      require_windows_signing: true
+    # The signing secrets themselves live in the called workflow's matrix environments
+    # (`apple-signing` for macOS, `desktop-build` for Windows) and resolve inside those
+    # jobs; `inherit` additionally forwards repo-level secrets so the called workflow
+    # never sees a name shadowed to empty (the v0.2.2 failure mode).
     secrets: inherit
 
   release:

--- a/packages/desktop/build/evsign.cjs
+++ b/packages/desktop/build/evsign.cjs
@@ -1,0 +1,76 @@
+"use strict";
+
+const { spawn } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const SIGNED_BASENAMES = new Set([
+  "PenguinHarness.exe",
+  "elevate.exe",
+  "penguin-desktop-win32-x64.exe",
+]);
+
+function isGitBundleExecutable(file) {
+  return file.split(path.sep).includes("git");
+}
+
+function shouldSign(file) {
+  const base = path.basename(file);
+  return SIGNED_BASENAMES.has(base) || base.endsWith(".__uninstaller.exe");
+}
+
+function runEvsign(client, file, key) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(client, [file, "-key", key, "-sha256"], {
+      stdio: ["ignore", "inherit", "inherit"],
+      windowsHide: true,
+    });
+
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+
+      reject(new Error(`EVSign failed for ${path.basename(file)} with exit code ${code}.`));
+    });
+  });
+}
+
+async function evsign(configuration) {
+  const file = path.resolve(configuration.path);
+  const requireSigning = process.env.EVSIGN_REQUIRE === "true";
+  const key = process.env.EVSIGN_KEY;
+  const client =
+    process.env.EVSIGN_CLIENT ||
+    path.join(process.env.RUNNER_TEMP || os.tmpdir(), "evsign-client.exe");
+
+  if ((configuration.hash || "").toLowerCase() !== "sha256") {
+    return;
+  }
+
+  if (isGitBundleExecutable(file) || !shouldSign(file)) {
+    return;
+  }
+
+  if (!key) {
+    if (requireSigning) {
+      throw new Error("EVSIGN_KEY is required for Windows release signing.");
+    }
+
+    console.log(`[evsign] skip ${path.basename(file)} because EVSIGN_KEY is not configured.`);
+    return;
+  }
+
+  if (!fs.existsSync(client)) {
+    throw new Error(`EVSign client was not found at ${client}.`);
+  }
+
+  console.log(`[evsign] signing ${path.basename(file)}`);
+  await runEvsign(client, file, key);
+}
+
+module.exports = evsign;
+module.exports.default = evsign;

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -10,7 +10,9 @@
 # at the cost of some inodes.
 #
 # macOS release artifacts are Developer ID signed and notarized in CI when the signing
-# secrets are present; unsigned dry-run builds remain possible outside the release path.
+# secrets are present. Windows release artifacts are Authenticode-signed through EVSign
+# during packaging so update metadata is generated from the final signed bytes. Unsigned
+# dry-run builds remain possible outside the release path.
 appId: com.prismshadow.penguinharness
 productName: PenguinHarness
 # Declaring the publish target is what makes electron-builder emit the update metadata
@@ -56,6 +58,20 @@ win:
   # exe (>=256px required).
   icon: build/icon.png
   artifactName: penguin-desktop-win32-${arch}.${ext}
+  verifyUpdateCodeSignature: true
+  signExts:
+    - PenguinHarness.exe
+    - elevate.exe
+    - penguin-desktop-win32-x64.exe
+    - .__uninstaller.exe
+    - "!.exe"
+  signtoolOptions:
+    sign: build/evsign.cjs
+    signingHashAlgorithms:
+      - sha256
+    publisherName:
+      - CN=RushRush Network Technology Ltd, O=RushRush Network Technology Ltd
+      - RushRush Network Technology Ltd
   target:
     - target: nsis
       arch: [x64]

--- a/packages/desktop/src/updater.ts
+++ b/packages/desktop/src/updater.ts
@@ -12,9 +12,10 @@
  * up to date / downloading / failed), the same rule the Web App's check-for-updates row
  * follows — a manual action that answers with silence reads as broken.
  *
- * Release builds use Developer ID signing on macOS; unsigned dry-run macOS artifacts can
- * still find updates, but Gatekeeper will not apply them as trusted replacements.
- * Windows NSIS and Linux AppImage continue to work without code-signing for now.
+ * Release builds use Developer ID signing on macOS and Authenticode signing on Windows;
+ * unsigned dry-run artifacts can still find updates, but platform trust and release
+ * gates only apply to signed release builds. Linux AppImage continues without
+ * code-signing for now.
  */
 import { app, dialog, shell } from "electron";
 import type { BrowserWindow } from "electron";


### PR DESCRIPTION
﻿## Summary

Adds Windows EVSign signing to the desktop release path.

- Sign Windows desktop release artifacts during `electron-builder` packaging so `latest.yml`, blockmap output, and `app-update.yml` are generated from the final signed installer bytes.
- Add a `require_windows_signing` reusable workflow input so formal releases fail closed when Windows signing is missing, while standalone dry-runs can still build unsigned artifacts.
- Download the EVSign CLI on Windows runners, authenticate the downloaded executable with Authenticode before passing it `EVSIGN_KEY`, and log its SHA256 for release traceability.
- Verify Windows release outputs after packaging: installer/app/elevate signatures, timestamp certificates, expected publisher, `latest.yml` sha512/size, and `app-update.yml` publisherName.
- Keep the macOS environment-secret pattern intact and extend `release.yml` to require Windows signing for release runs.

## Required GitHub Configuration

Add this secret to the `desktop-build` GitHub Environment used by the Windows desktop matrix job:

- `EVSIGN_KEY`: EVSign cloud-token key used by the CLI for Windows Authenticode signing.

No `EVSIGN_PWD` is required for the current EVSign CLI flow, and `EVSIGN_CLIENT` does not need to be configured because the workflow downloads the CLI into the runner temp directory.

The workflow currently expects:

- EVSign CLI signer: `Keroro Software Ltd`
- Windows release artifact publisher: `RushRush Network Technology Ltd`

If EVSign changes its CLI signer or the signing certificate publisher changes, update the workflow/electron-builder publisher checks accordingly.

## Validation

- `pnpm format:check` passed.
- `pnpm typecheck` passed after rebuilding local ignored `packages/skills/dist` and `packages/core/dist` outputs so workspace package declarations matched source.
- `pnpm build` passed.
- `pnpm --filter @prismshadow/penguin-desktop test` passed.
- `git diff --check` passed.

Known local full-suite note: `pnpm test` still fails on unrelated existing Windows/core cases: one timing assertion in `test/exec-session.test.ts` and symlink `EPERM` failures in `test/file-tools.test.ts` / `test/memory.test.ts`. Those failures are outside this Windows signing change.
