### PR TITLE
Add speed-probed release download routing

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -501,5 +501,5 @@ jobs:
             # Update metadata: electron-updater reads latest*.yml from the Release, and
             # the blockmaps are what make differential downloads possible. Without these
             # the installers ship but nothing can auto-update.
-            packages/desktop/stage/out/*.yml
+            packages/desktop/stage/out/latest*.yml
             packages/desktop/stage/out/*.blockmap

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,12 +7,15 @@
 #   -> one program payload per target (four platform payloads bundling the official Node runtime,
 #   a win-x64 payload with runtime + MinGit, and a runtime-less universal payload) -> wrap each
 #   payload, its checksum and the native installer into the canonical installer bundle -> validate
-#   the real bundles -> upload to the Release.
+#   the real bundles -> collect desktop installers/update metadata -> generate release probes and
+#   the source-neutral download manifest -> upload to the Release.
 #   Artifacts (one shape per target, serving online and offline installs alike):
 #   penguin-{linux,darwin}-{x64,arm64}.tar.gz, penguin-universal.tar.gz, penguin-win32-x64.zip,
-#   their .sha256 files, SHA256SUMS, install.sh, and install.ps1; one version per tag, multiple
-#   versions coexist. Releases up to v0.1.5 shipped raw program archives under the same names
-#   plus *-offline wrappers; the installers keep accepting that legacy layout for pinned versions.
+#   their .sha256 files, SHA256SUMS, install.sh, install.ps1, probe-64k.bin, probe-1m.bin,
+#   release-download-manifest.tsv, and the desktop installers plus updater metadata/blockmaps;
+#   one version per tag, multiple versions coexist. Releases up to v0.1.5 shipped raw program
+#   archives under the same names plus *-offline wrappers; the installers keep accepting that
+#   legacy layout for pinned versions.
 # - publish-npm: publish the whole chain (@prismshadow/penguin-skills -> @prismshadow/penguin-core
 #   -> @prismshadow/penguin-server -> @prismshadow/penguin-cli) to npm at the tag version.
 #   skills/core serve the penguin-sdk Skill's `npm install`; server ships the built web assets inside
@@ -345,10 +348,11 @@ jobs:
           cd dist-artifacts
           sha256sum -- *.tar.gz *.zip > SHA256SUMS
 
-      # Desktop installers built by the desktop job (three-OS matrix): collected here so
-      # they are part of the Release's initial (immutable) asset set. Their checksums go
-      # in a separate SHA256SUMS.desktop, which is also how the OSS mirror script verifies
-      # them (its manifest lists the installers by their version-less names).
+      # Desktop artifacts built by the desktop job (three-OS matrix): installers plus the
+      # latest*.yml metadata and .blockmap files electron-updater needs. They are collected
+      # here so they are part of the Release's initial (immutable) asset set. Their checksums
+      # go in a separate SHA256SUMS.desktop, which is also how the OSS mirror script verifies
+      # them.
       - name: Collect desktop artifacts
         uses: actions/download-artifact@v4
         with:
@@ -359,7 +363,26 @@ jobs:
       - name: Generate desktop checksums
         run: |
           cd desktop-artifacts
-          sha256sum -- * > SHA256SUMS.desktop
+          sha256sum -- \
+            penguin-desktop-*.AppImage \
+            penguin-desktop-*.deb \
+            penguin-desktop-*.dmg \
+            penguin-desktop-*.zip \
+            penguin-desktop-*.exe \
+            latest*.yml \
+            *.blockmap > SHA256SUMS.desktop
+
+      - name: Generate release probes and download manifest
+        env:
+          TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+        run: |
+          node scripts/generate-release-download-manifest.mjs \
+            "$TAG" \
+            dist-artifacts \
+            dist-artifacts \
+            desktop-artifacts \
+            install.sh \
+            install.ps1
 
       # Release notes come from changelog/<version>/RELEASE.md, written during release preparation and
       # committed BEFORE the tag (the release job runs on the tag's checkout, so a file added afterwards
@@ -397,7 +420,16 @@ jobs:
             dist-artifacts/*.zip
             dist-artifacts/*.sha256
             dist-artifacts/SHA256SUMS
-            desktop-artifacts/*
+            dist-artifacts/probe-*.bin
+            dist-artifacts/release-download-manifest.tsv
+            desktop-artifacts/penguin-desktop-*.AppImage
+            desktop-artifacts/penguin-desktop-*.deb
+            desktop-artifacts/penguin-desktop-*.dmg
+            desktop-artifacts/penguin-desktop-*.zip
+            desktop-artifacts/penguin-desktop-*.exe
+            desktop-artifacts/latest*.yml
+            desktop-artifacts/*.blockmap
+            desktop-artifacts/SHA256SUMS.desktop
             install.sh
             install.ps1
 

--- a/install.ps1
+++ b/install.ps1
@@ -10,7 +10,7 @@
 #   $env:PENGUIN_DOWNLOAD_SOURCE = "auto|oss|github" choose the online source; default auto (OSS, then same-version GitHub)
 #   $env:PENGUIN_DOWNLOAD_BENCHMARK = "1" enable same-version OSS/GitHub probe timing in auto mode
 #   $env:PENGUIN_DOWNLOAD_BASE_URL = "https://..." exact online asset directory selected by the stable forwarder
-#   $env:PENGUIN_DOWNLOAD_FALLBACK_BASE_URL = "https://..." same-version fallback asset directory
+#   $env:PENGUIN_DOWNLOAD_FALLBACK_BASE_URL = "https://..." fallback for PENGUIN_DOWNLOAD_BASE_URL
 #
 # Each Release attaches exactly one Windows artifact: penguin-win32-x64.zip, a shallow installer
 # bundle holding install.cmd, this script, the program payload (payload.zip) and the payload's
@@ -339,6 +339,7 @@ $DownloadFallbackBaseUrl = if ($env:PENGUIN_DOWNLOAD_FALLBACK_BASE_URL) {
 } else {
   ""
 }
+if (-not $DownloadBaseUrl) { $DownloadFallbackBaseUrl = "" }
 $SourceMode = if ($env:PENGUIN_DOWNLOAD_SOURCE) {
   $env:PENGUIN_DOWNLOAD_SOURCE.ToLowerInvariant()
 } else {
@@ -378,7 +379,7 @@ $ResolvedReleaseVersion = if ($Version) {
 if ($DownloadBaseUrl) {
   Assert-HttpsUrl "PENGUIN_DOWNLOAD_BASE_URL" $DownloadBaseUrl
 }
-if ($DownloadFallbackBaseUrl) {
+if ($DownloadBaseUrl -and $DownloadFallbackBaseUrl) {
   Assert-HttpsUrl "PENGUIN_DOWNLOAD_FALLBACK_BASE_URL" $DownloadFallbackBaseUrl
 }
 

--- a/install.ps1
+++ b/install.ps1
@@ -8,7 +8,7 @@
 #   $env:PENGUIN_INSTALL_DIR = "<dir>"  install dir; default $env:USERPROFILE\.penguin
 #   $env:PENGUIN_ARCHIVE = "<file>"     install a local Release zip without network access (same as -ArchivePath)
 #   $env:PENGUIN_DOWNLOAD_SOURCE = "auto|oss|github" choose the online source; default auto (OSS, then same-version GitHub)
-#   $env:PENGUIN_DOWNLOAD_BENCHMARK = "1" enable same-version OSS/GitHub probe timing in auto mode
+#   $env:PENGUIN_DOWNLOAD_SPEED_PROBE = "1" enable same-version OSS/GitHub probe timing in auto mode
 #   $env:PENGUIN_DOWNLOAD_BASE_URL = "https://..." exact online asset directory selected by the stable forwarder
 #   $env:PENGUIN_DOWNLOAD_FALLBACK_BASE_URL = "https://..." fallback for PENGUIN_DOWNLOAD_BASE_URL
 #
@@ -43,7 +43,8 @@ $OssReleaseRoot = "$OssOrigin/releases"
 $GitHubReleaseRoot = "$Repo/releases/download"
 $GitHubLatestBase = "$Repo/releases/latest/download"
 $Asset = "penguin-win32-x64.zip"
-$BenchmarkTotalTimeoutSeconds = 5
+$SpeedProbeTotalTimeoutSeconds = 8
+$SpeedProbeGitHubMinBytesPerSecond = 262144
 $PayloadName = "payload.zip"
 # The release workflow replaces this token with the immutable tag before publishing both the
 # standalone installer and the copy sealed inside the Windows bundle.
@@ -101,7 +102,7 @@ function Try-DownloadFile([string]$Uri, [string]$OutFile, [int]$TimeoutSec) {
   }
 }
 
-function Get-BenchmarkTimeoutSec([DateTime]$Deadline, [int]$MaxSec) {
+function Get-SpeedProbeTimeoutSec([DateTime]$Deadline, [int]$MaxSec) {
   $Remaining = [int][Math]::Ceiling(($Deadline - [DateTime]::UtcNow).TotalSeconds)
   if ($Remaining -le 0) { return 0 }
   return [Math]::Min($MaxSec, $Remaining)
@@ -160,9 +161,9 @@ function Test-SafeReleaseAssetName([string]$Value) {
 
 function Read-ReleaseDownloadManifest([string]$Tag, [string]$ManifestPath, [DateTime]$Deadline) {
   Remove-Item -LiteralPath $ManifestPath -Force -ErrorAction SilentlyContinue
-  $TimeoutSec = Get-BenchmarkTimeoutSec $Deadline 2
+  $TimeoutSec = Get-SpeedProbeTimeoutSec $Deadline 2
   if ($TimeoutSec -le 0 -or -not (Try-DownloadFile "$OssReleaseRoot/$Tag/release-download-manifest.tsv" $ManifestPath $TimeoutSec)) {
-    $TimeoutSec = Get-BenchmarkTimeoutSec $Deadline 2
+    $TimeoutSec = Get-SpeedProbeTimeoutSec $Deadline 2
     if ($TimeoutSec -le 0 -or -not (Try-DownloadFile "$GitHubReleaseRoot/$Tag/release-download-manifest.tsv" $ManifestPath $TimeoutSec)) {
       return $null
     }
@@ -210,11 +211,12 @@ function Invoke-ProbeDownload(
   [object]$Probe,
   [string]$Tmp,
   [string]$Label,
-  [DateTime]$Deadline
+  [DateTime]$Deadline,
+  [int]$MaxTimeoutSec = 2
 ) {
   $ProbePath = Join-Path $Tmp "probe-$Label-$($Probe.Name)"
   Remove-Item -LiteralPath $ProbePath -Force -ErrorAction SilentlyContinue
-  $TimeoutSec = Get-BenchmarkTimeoutSec $Deadline 2
+  $TimeoutSec = Get-SpeedProbeTimeoutSec $Deadline $MaxTimeoutSec
   if ($TimeoutSec -le 0) {
     return [PSCustomObject]@{ Ok = $false; Seconds = 0.0 }
   }
@@ -241,26 +243,19 @@ function Invoke-ProbeDownload(
   [PSCustomObject]@{ Ok = $true; Seconds = $Seconds }
 }
 
-function Select-FastBenchmarkSource(
-  [object]$OssProbe,
+function Select-SpeedProbeSource(
   [object]$GitHubProbe,
-  [Int64]$ProbeSize,
-  [Int64]$AssetSize
+  [Int64]$ProbeSize
 ) {
-  if ($GitHubProbe.Ok -and -not $OssProbe.Ok) { return "github" }
-  if ($OssProbe.Ok -and -not $GitHubProbe.Ok) { return "oss" }
-  if (-not $OssProbe.Ok -and -not $GitHubProbe.Ok) { return "" }
-
-  $OssEstimate = [double]$AssetSize / ([double]$ProbeSize / [Math]::Max([double]$OssProbe.Seconds, 0.001))
-  $GitHubEstimate = [double]$AssetSize / ([double]$ProbeSize / [Math]::Max([double]$GitHubProbe.Seconds, 0.001))
-  if ($GitHubEstimate -lt $OssEstimate) {
-    return "github"
+  if ($GitHubProbe.Ok) {
+    $GitHubBytesPerSecond = [double]$ProbeSize / [Math]::Max([double]$GitHubProbe.Seconds, 0.001)
+    if ($GitHubBytesPerSecond -ge $SpeedProbeGitHubMinBytesPerSecond) { return "github" }
   }
   return "oss"
 }
 
-function Select-BenchmarkDownloadSources([string]$Tag, [string]$Tmp) {
-  $Deadline = [DateTime]::UtcNow.AddSeconds($BenchmarkTotalTimeoutSeconds)
+function Select-SpeedProbeDownloadSources([string]$Tag, [string]$Tmp) {
+  $Deadline = [DateTime]::UtcNow.AddSeconds($SpeedProbeTotalTimeoutSeconds)
   $Manifest = Read-ReleaseDownloadManifest $Tag (Join-Path $Tmp "release-download-manifest.tsv") $Deadline
   if (-not $Manifest) { return $null }
 
@@ -285,15 +280,14 @@ function Select-BenchmarkDownloadSources([string]$Tag, [string]$Tmp) {
     return [PSCustomObject]@{ BaseUrl = $OssBase; FallbackBaseUrl = $GitHubBase }
   }
 
-  $OssLarge = Invoke-ProbeDownload $OssBase $Manifest.LargeProbe $Tmp "oss-large" $Deadline
-  $GitHubLarge = Invoke-ProbeDownload $GitHubBase $Manifest.LargeProbe $Tmp "github-large" $Deadline
-  $Choice = Select-FastBenchmarkSource $OssLarge $GitHubLarge $Manifest.LargeProbe.Size $Manifest.AssetSize
+  $GitHubLarge = Invoke-ProbeDownload $GitHubBase $Manifest.LargeProbe $Tmp "github-large" $Deadline 5
+  $Choice = Select-SpeedProbeSource $GitHubLarge $Manifest.LargeProbe.Size
   if ($Choice -eq "github") {
-    Write-Host "Selected GitHub (shorter estimated download time)."
+    Write-Host "Selected GitHub (meets minimum download speed)."
     return [PSCustomObject]@{ BaseUrl = $GitHubBase; FallbackBaseUrl = $OssBase }
   }
   if ($Choice -eq "oss") {
-    Write-Host "Selected OSS mirror (shorter or equal estimated download time)."
+    Write-Host "Selected OSS mirror (GitHub did not meet minimum download speed)."
     return [PSCustomObject]@{ BaseUrl = $OssBase; FallbackBaseUrl = $GitHubBase }
   }
   return $null
@@ -345,8 +339,8 @@ $SourceMode = if ($env:PENGUIN_DOWNLOAD_SOURCE) {
 } else {
   "auto"
 }
-$DownloadBenchmark = if ($env:PENGUIN_DOWNLOAD_BENCHMARK) {
-  $env:PENGUIN_DOWNLOAD_BENCHMARK
+$DownloadSpeedProbe = if ($env:PENGUIN_DOWNLOAD_SPEED_PROBE) {
+  $env:PENGUIN_DOWNLOAD_SPEED_PROBE
 } else {
   "0"
 }
@@ -366,8 +360,8 @@ if ($Version -and -not (Test-ReleaseTag $Version)) {
 if ($SourceMode -notin @("auto", "oss", "github")) {
   Fail "PENGUIN_DOWNLOAD_SOURCE must be auto, oss, or github"
 }
-if ($DownloadBenchmark -notin @("0", "1")) {
-  Fail "PENGUIN_DOWNLOAD_BENCHMARK must be 0 or 1"
+if ($DownloadSpeedProbe -notin @("0", "1")) {
+  Fail "PENGUIN_DOWNLOAD_SPEED_PROBE must be 0 or 1"
 }
 $ResolvedReleaseVersion = if ($Version) {
   $Version
@@ -441,11 +435,11 @@ try {
         if ($SourceMode -eq "auto" -and -not $FallbackBaseUrl) {
           $FallbackBaseUrl = "$GitHubReleaseRoot/$SelectedTag"
         }
-        if ($SourceMode -eq "auto" -and $DownloadBenchmark -eq "1" -and -not $DownloadBaseUrl) {
-          $BenchmarkSources = Select-BenchmarkDownloadSources $SelectedTag $Tmp
-          if ($BenchmarkSources) {
-            $BaseUrl = $BenchmarkSources.BaseUrl
-            $FallbackBaseUrl = $BenchmarkSources.FallbackBaseUrl
+        if ($SourceMode -eq "auto" -and $DownloadSpeedProbe -eq "1" -and -not $DownloadBaseUrl) {
+          $SpeedProbeSources = Select-SpeedProbeDownloadSources $SelectedTag $Tmp
+          if ($SpeedProbeSources) {
+            $BaseUrl = $SpeedProbeSources.BaseUrl
+            $FallbackBaseUrl = $SpeedProbeSources.FallbackBaseUrl
           } else {
             Write-Host "Download source test was inconclusive; using OSS with same-version GitHub fallback."
           }

--- a/install.ps1
+++ b/install.ps1
@@ -8,6 +8,7 @@
 #   $env:PENGUIN_INSTALL_DIR = "<dir>"  install dir; default $env:USERPROFILE\.penguin
 #   $env:PENGUIN_ARCHIVE = "<file>"     install a local Release zip without network access (same as -ArchivePath)
 #   $env:PENGUIN_DOWNLOAD_SOURCE = "auto|oss|github" choose the online source; default auto (OSS, then same-version GitHub)
+#   $env:PENGUIN_DOWNLOAD_BENCHMARK = "1" enable same-version OSS/GitHub probe timing in auto mode
 #   $env:PENGUIN_DOWNLOAD_BASE_URL = "https://..." exact online asset directory selected by the stable forwarder
 #   $env:PENGUIN_DOWNLOAD_FALLBACK_BASE_URL = "https://..." same-version fallback asset directory
 #
@@ -89,6 +90,16 @@ function Test-ReleaseTag([string]$Value) {
   return $Value -match '^v[0-9A-Za-z][0-9A-Za-z._-]*$'
 }
 
+function Try-DownloadFile([string]$Uri, [string]$OutFile, [int]$TimeoutSec) {
+  try {
+    Invoke-WebRequest -Uri $Uri -OutFile $OutFile -UseBasicParsing -TimeoutSec $TimeoutSec | Out-Null
+    return $true
+  } catch {
+    Remove-Item -LiteralPath $OutFile -Force -ErrorAction SilentlyContinue
+    return $false
+  }
+}
+
 function Get-OssLatestTag([string]$ManifestPath) {
   Remove-Item -LiteralPath $ManifestPath -Force -ErrorAction SilentlyContinue
   try {
@@ -136,6 +147,143 @@ function Get-ReleasePair(
   }
 }
 
+function Test-SafeReleaseAssetName([string]$Value) {
+  return $Value -match '^[A-Za-z0-9._+-]+$' -and -not $Value.Contains('..')
+}
+
+function Read-ReleaseDownloadManifest([string]$Tag, [string]$ManifestPath) {
+  Remove-Item -LiteralPath $ManifestPath -Force -ErrorAction SilentlyContinue
+  if (-not (Try-DownloadFile "$OssReleaseRoot/$Tag/release-download-manifest.tsv" $ManifestPath 4)) {
+    if (-not (Try-DownloadFile "$GitHubReleaseRoot/$Tag/release-download-manifest.tsv" $ManifestPath 4)) {
+      return $null
+    }
+  }
+
+  $Lines = [IO.File]::ReadAllLines($ManifestPath, [Text.UTF8Encoding]::new($false))
+  if ($Lines.Count -lt 4) { return $null }
+  if ($Lines[0] -ne "penguin-release-download-manifest`t1`t$Tag") { return $null }
+
+  $SmallProbe = $null
+  $LargeProbe = $null
+  $AssetSize = 0L
+  foreach ($Line in $Lines | Select-Object -Skip 1) {
+    if (-not $Line) { return $null }
+    $Fields = $Line -split "`t"
+    if ($Fields[0] -eq "probe") {
+      if ($Fields.Count -ne 5) { return $null }
+      $Probe = [PSCustomObject]@{
+        Name = [string]$Fields[2]
+        Size = 0L
+        Sha256 = [string]$Fields[4]
+      }
+      if (-not (Test-SafeReleaseAssetName $Probe.Name)) { return $null }
+      $ProbeSize = 0L
+      if (-not [Int64]::TryParse([string]$Fields[3], [ref]$ProbeSize) -or $ProbeSize -le 0) { return $null }
+      $Probe.Size = $ProbeSize
+      if ($Probe.Sha256 -notmatch '^[0-9a-f]{64}$') { return $null }
+      if ($Fields[1] -eq "small") { $SmallProbe = $Probe }
+      if ($Fields[1] -eq "large") { $LargeProbe = $Probe }
+    } elseif ($Fields[0] -eq "asset" -and $Fields.Count -eq 4 -and $Fields[1] -eq $Asset) {
+      if (-not [Int64]::TryParse([string]$Fields[2], [ref]$AssetSize) -or $AssetSize -le 0) { return $null }
+    }
+  }
+
+  if (-not $SmallProbe -or -not $LargeProbe -or $AssetSize -le 0) { return $null }
+  [PSCustomObject]@{
+    SmallProbe = $SmallProbe
+    LargeProbe = $LargeProbe
+    AssetSize = $AssetSize
+  }
+}
+
+function Invoke-ProbeDownload(
+  [string]$BaseUrl,
+  [object]$Probe,
+  [string]$Tmp,
+  [string]$Label
+) {
+  $ProbePath = Join-Path $Tmp "probe-$Label-$($Probe.Name)"
+  Remove-Item -LiteralPath $ProbePath -Force -ErrorAction SilentlyContinue
+  $Succeeded = $false
+  $Elapsed = Measure-Command {
+    $Succeeded = Try-DownloadFile "$BaseUrl/$($Probe.Name)" $ProbePath 5
+  }
+  if (-not $Succeeded) {
+    return [PSCustomObject]@{ Ok = $false; Seconds = 0.0 }
+  }
+  try {
+    $Item = Get-Item -LiteralPath $ProbePath -ErrorAction Stop
+    if ($Item.Length -ne $Probe.Size) {
+      return [PSCustomObject]@{ Ok = $false; Seconds = 0.0 }
+    }
+    $ActualHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $ProbePath).Hash.ToLowerInvariant()
+    if ($ActualHash -ne $Probe.Sha256) {
+      return [PSCustomObject]@{ Ok = $false; Seconds = 0.0 }
+    }
+  } catch {
+    return [PSCustomObject]@{ Ok = $false; Seconds = 0.0 }
+  }
+  $Seconds = [Math]::Max($Elapsed.TotalSeconds, 0.001)
+  [PSCustomObject]@{ Ok = $true; Seconds = $Seconds }
+}
+
+function Select-FastBenchmarkSource(
+  [object]$OssProbe,
+  [object]$GitHubProbe,
+  [Int64]$ProbeSize,
+  [Int64]$AssetSize
+) {
+  if ($GitHubProbe.Ok -and -not $OssProbe.Ok) { return "github" }
+  if ($OssProbe.Ok -and -not $GitHubProbe.Ok) { return "oss" }
+  if (-not $OssProbe.Ok -and -not $GitHubProbe.Ok) { return "" }
+
+  $OssEstimate = [double]$AssetSize / ([double]$ProbeSize / [Math]::Max([double]$OssProbe.Seconds, 0.001))
+  $GitHubEstimate = [double]$AssetSize / ([double]$ProbeSize / [Math]::Max([double]$GitHubProbe.Seconds, 0.001))
+  if ($GitHubEstimate -le ($OssEstimate * 0.80) -and ($OssEstimate - $GitHubEstimate) -ge 2.0) {
+    return "github"
+  }
+  return "oss"
+}
+
+function Select-BenchmarkDownloadSources([string]$Tag, [string]$Tmp) {
+  $Manifest = Read-ReleaseDownloadManifest $Tag (Join-Path $Tmp "release-download-manifest.tsv")
+  if (-not $Manifest) { return $null }
+
+  Write-Host "Testing OSS mirror and GitHub download sources ..."
+  $OssBase = "$OssReleaseRoot/$Tag"
+  $GitHubBase = "$GitHubReleaseRoot/$Tag"
+  $OssSmall = Invoke-ProbeDownload $OssBase $Manifest.SmallProbe $Tmp "oss-small"
+  $GitHubSmall = Invoke-ProbeDownload $GitHubBase $Manifest.SmallProbe $Tmp "github-small"
+
+  if ($GitHubSmall.Ok -and -not $OssSmall.Ok) {
+    Write-Host "Selected GitHub (OSS mirror probe unavailable)."
+    return [PSCustomObject]@{ BaseUrl = $GitHubBase; FallbackBaseUrl = $OssBase }
+  }
+  if ($OssSmall.Ok -and -not $GitHubSmall.Ok) {
+    Write-Host "Selected OSS mirror (GitHub probe unavailable)."
+    return [PSCustomObject]@{ BaseUrl = $OssBase; FallbackBaseUrl = $GitHubBase }
+  }
+  if (-not $OssSmall.Ok -and -not $GitHubSmall.Ok) { return $null }
+
+  if ($Manifest.AssetSize -lt 33554432) {
+    Write-Host "Selected OSS mirror (download source test did not need throughput probing)."
+    return [PSCustomObject]@{ BaseUrl = $OssBase; FallbackBaseUrl = $GitHubBase }
+  }
+
+  $OssLarge = Invoke-ProbeDownload $OssBase $Manifest.LargeProbe $Tmp "oss-large"
+  $GitHubLarge = Invoke-ProbeDownload $GitHubBase $Manifest.LargeProbe $Tmp "github-large"
+  $Choice = Select-FastBenchmarkSource $OssLarge $GitHubLarge $Manifest.LargeProbe.Size $Manifest.AssetSize
+  if ($Choice -eq "github") {
+    Write-Host "Selected GitHub (faster probe result)."
+    return [PSCustomObject]@{ BaseUrl = $GitHubBase; FallbackBaseUrl = $OssBase }
+  }
+  if ($Choice -eq "oss") {
+    Write-Host "Selected OSS mirror (default or faster probe result)."
+    return [PSCustomObject]@{ BaseUrl = $OssBase; FallbackBaseUrl = $GitHubBase }
+  }
+  return $null
+}
+
 function Restore-PreviousInstall(
   [string]$InstallDir,
   [string]$OldDir,
@@ -181,6 +329,11 @@ $SourceMode = if ($env:PENGUIN_DOWNLOAD_SOURCE) {
 } else {
   "auto"
 }
+$DownloadBenchmark = if ($env:PENGUIN_DOWNLOAD_BENCHMARK) {
+  $env:PENGUIN_DOWNLOAD_BENCHMARK
+} else {
+  "0"
+}
 # An extracted installer bundle keeps install.cmd, this script, payload.zip and its checksum
 # together. `$PSScriptRoot` is empty for the documented `irm ... | iex` path, so online installs
 # do not accidentally pick up an unrelated archive from the caller's current directory.
@@ -196,6 +349,9 @@ if ($Version -and -not (Test-ReleaseTag $Version)) {
 }
 if ($SourceMode -notin @("auto", "oss", "github")) {
   Fail "PENGUIN_DOWNLOAD_SOURCE must be auto, oss, or github"
+}
+if ($DownloadBenchmark -notin @("0", "1")) {
+  Fail "PENGUIN_DOWNLOAD_BENCHMARK must be 0 or 1"
 }
 $ResolvedReleaseVersion = if ($Version) {
   $Version
@@ -268,6 +424,15 @@ try {
         $BaseUrl = "$OssReleaseRoot/$SelectedTag"
         if ($SourceMode -eq "auto" -and -not $FallbackBaseUrl) {
           $FallbackBaseUrl = "$GitHubReleaseRoot/$SelectedTag"
+        }
+        if ($SourceMode -eq "auto" -and $DownloadBenchmark -eq "1" -and -not $DownloadBaseUrl) {
+          $BenchmarkSources = Select-BenchmarkDownloadSources $SelectedTag $Tmp
+          if ($BenchmarkSources) {
+            $BaseUrl = $BenchmarkSources.BaseUrl
+            $FallbackBaseUrl = $BenchmarkSources.FallbackBaseUrl
+          } else {
+            Write-Host "Download source test was inconclusive; using OSS with same-version GitHub fallback."
+          }
         }
       } elseif ($SourceMode -eq "oss") {
         Fail "the OSS mirror is unavailable or its release metadata is invalid."

--- a/install.ps1
+++ b/install.ps1
@@ -253,7 +253,7 @@ function Select-FastBenchmarkSource(
 
   $OssEstimate = [double]$AssetSize / ([double]$ProbeSize / [Math]::Max([double]$OssProbe.Seconds, 0.001))
   $GitHubEstimate = [double]$AssetSize / ([double]$ProbeSize / [Math]::Max([double]$GitHubProbe.Seconds, 0.001))
-  if ($GitHubEstimate -le ($OssEstimate * 0.80) -and ($OssEstimate - $GitHubEstimate) -ge 2.0) {
+  if ($GitHubEstimate -lt $OssEstimate) {
     return "github"
   }
   return "oss"
@@ -289,11 +289,11 @@ function Select-BenchmarkDownloadSources([string]$Tag, [string]$Tmp) {
   $GitHubLarge = Invoke-ProbeDownload $GitHubBase $Manifest.LargeProbe $Tmp "github-large" $Deadline
   $Choice = Select-FastBenchmarkSource $OssLarge $GitHubLarge $Manifest.LargeProbe.Size $Manifest.AssetSize
   if ($Choice -eq "github") {
-    Write-Host "Selected GitHub (faster probe result)."
+    Write-Host "Selected GitHub (shorter estimated download time)."
     return [PSCustomObject]@{ BaseUrl = $GitHubBase; FallbackBaseUrl = $OssBase }
   }
   if ($Choice -eq "oss") {
-    Write-Host "Selected OSS mirror (default or faster probe result)."
+    Write-Host "Selected OSS mirror (shorter or equal estimated download time)."
     return [PSCustomObject]@{ BaseUrl = $OssBase; FallbackBaseUrl = $GitHubBase }
   }
   return $null

--- a/install.ps1
+++ b/install.ps1
@@ -43,6 +43,7 @@ $OssReleaseRoot = "$OssOrigin/releases"
 $GitHubReleaseRoot = "$Repo/releases/download"
 $GitHubLatestBase = "$Repo/releases/latest/download"
 $Asset = "penguin-win32-x64.zip"
+$BenchmarkTotalTimeoutSeconds = 5
 $PayloadName = "payload.zip"
 # The release workflow replaces this token with the immutable tag before publishing both the
 # standalone installer and the copy sealed inside the Windows bundle.
@@ -100,6 +101,12 @@ function Try-DownloadFile([string]$Uri, [string]$OutFile, [int]$TimeoutSec) {
   }
 }
 
+function Get-BenchmarkTimeoutSec([DateTime]$Deadline, [int]$MaxSec) {
+  $Remaining = [int][Math]::Ceiling(($Deadline - [DateTime]::UtcNow).TotalSeconds)
+  if ($Remaining -le 0) { return 0 }
+  return [Math]::Min($MaxSec, $Remaining)
+}
+
 function Get-OssLatestTag([string]$ManifestPath) {
   Remove-Item -LiteralPath $ManifestPath -Force -ErrorAction SilentlyContinue
   try {
@@ -151,10 +158,12 @@ function Test-SafeReleaseAssetName([string]$Value) {
   return $Value -match '^[A-Za-z0-9._+-]+$' -and -not $Value.Contains('..')
 }
 
-function Read-ReleaseDownloadManifest([string]$Tag, [string]$ManifestPath) {
+function Read-ReleaseDownloadManifest([string]$Tag, [string]$ManifestPath, [DateTime]$Deadline) {
   Remove-Item -LiteralPath $ManifestPath -Force -ErrorAction SilentlyContinue
-  if (-not (Try-DownloadFile "$OssReleaseRoot/$Tag/release-download-manifest.tsv" $ManifestPath 4)) {
-    if (-not (Try-DownloadFile "$GitHubReleaseRoot/$Tag/release-download-manifest.tsv" $ManifestPath 4)) {
+  $TimeoutSec = Get-BenchmarkTimeoutSec $Deadline 2
+  if ($TimeoutSec -le 0 -or -not (Try-DownloadFile "$OssReleaseRoot/$Tag/release-download-manifest.tsv" $ManifestPath $TimeoutSec)) {
+    $TimeoutSec = Get-BenchmarkTimeoutSec $Deadline 2
+    if ($TimeoutSec -le 0 -or -not (Try-DownloadFile "$GitHubReleaseRoot/$Tag/release-download-manifest.tsv" $ManifestPath $TimeoutSec)) {
       return $null
     }
   }
@@ -200,13 +209,18 @@ function Invoke-ProbeDownload(
   [string]$BaseUrl,
   [object]$Probe,
   [string]$Tmp,
-  [string]$Label
+  [string]$Label,
+  [DateTime]$Deadline
 ) {
   $ProbePath = Join-Path $Tmp "probe-$Label-$($Probe.Name)"
   Remove-Item -LiteralPath $ProbePath -Force -ErrorAction SilentlyContinue
+  $TimeoutSec = Get-BenchmarkTimeoutSec $Deadline 2
+  if ($TimeoutSec -le 0) {
+    return [PSCustomObject]@{ Ok = $false; Seconds = 0.0 }
+  }
   $Succeeded = $false
   $Elapsed = Measure-Command {
-    $Succeeded = Try-DownloadFile "$BaseUrl/$($Probe.Name)" $ProbePath 5
+    $Succeeded = Try-DownloadFile "$BaseUrl/$($Probe.Name)" $ProbePath $TimeoutSec
   }
   if (-not $Succeeded) {
     return [PSCustomObject]@{ Ok = $false; Seconds = 0.0 }
@@ -246,14 +260,15 @@ function Select-FastBenchmarkSource(
 }
 
 function Select-BenchmarkDownloadSources([string]$Tag, [string]$Tmp) {
-  $Manifest = Read-ReleaseDownloadManifest $Tag (Join-Path $Tmp "release-download-manifest.tsv")
+  $Deadline = [DateTime]::UtcNow.AddSeconds($BenchmarkTotalTimeoutSeconds)
+  $Manifest = Read-ReleaseDownloadManifest $Tag (Join-Path $Tmp "release-download-manifest.tsv") $Deadline
   if (-not $Manifest) { return $null }
 
   Write-Host "Testing OSS mirror and GitHub download sources ..."
   $OssBase = "$OssReleaseRoot/$Tag"
   $GitHubBase = "$GitHubReleaseRoot/$Tag"
-  $OssSmall = Invoke-ProbeDownload $OssBase $Manifest.SmallProbe $Tmp "oss-small"
-  $GitHubSmall = Invoke-ProbeDownload $GitHubBase $Manifest.SmallProbe $Tmp "github-small"
+  $OssSmall = Invoke-ProbeDownload $OssBase $Manifest.SmallProbe $Tmp "oss-small" $Deadline
+  $GitHubSmall = Invoke-ProbeDownload $GitHubBase $Manifest.SmallProbe $Tmp "github-small" $Deadline
 
   if ($GitHubSmall.Ok -and -not $OssSmall.Ok) {
     Write-Host "Selected GitHub (OSS mirror probe unavailable)."
@@ -270,8 +285,8 @@ function Select-BenchmarkDownloadSources([string]$Tag, [string]$Tmp) {
     return [PSCustomObject]@{ BaseUrl = $OssBase; FallbackBaseUrl = $GitHubBase }
   }
 
-  $OssLarge = Invoke-ProbeDownload $OssBase $Manifest.LargeProbe $Tmp "oss-large"
-  $GitHubLarge = Invoke-ProbeDownload $GitHubBase $Manifest.LargeProbe $Tmp "github-large"
+  $OssLarge = Invoke-ProbeDownload $OssBase $Manifest.LargeProbe $Tmp "oss-large" $Deadline
+  $GitHubLarge = Invoke-ProbeDownload $GitHubBase $Manifest.LargeProbe $Tmp "github-large" $Deadline
   $Choice = Select-FastBenchmarkSource $OssLarge $GitHubLarge $Manifest.LargeProbe.Size $Manifest.AssetSize
   if ($Choice -eq "github") {
     Write-Host "Selected GitHub (faster probe result)."

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@
 #   PENGUIN_INSTALL_DIR=<dir> install dir; default ~/.penguin
 #   PENGUIN_ARCHIVE=<file>    install a local Release archive without network access (same as --archive <file>)
 #   PENGUIN_DOWNLOAD_SOURCE=auto|oss|github choose the online source; default auto (OSS, then same-version GitHub)
-#   PENGUIN_DOWNLOAD_BENCHMARK=1 enable same-version OSS/GitHub probe timing in auto mode
+#   PENGUIN_DOWNLOAD_SPEED_PROBE=1 enable same-version OSS/GitHub probe timing in auto mode
 #   PENGUIN_DOWNLOAD_BASE_URL=<url> exact online asset directory selected by the stable forwarder
 #   PENGUIN_DOWNLOAD_FALLBACK_BASE_URL=<url> fallback for PENGUIN_DOWNLOAD_BASE_URL
 #   --universal               install the universal package (no bundled Node runtime; needs system Node >= 24)
@@ -41,9 +41,10 @@ ARCHIVE="${PENGUIN_ARCHIVE:-}"
 SOURCE_MODE="${PENGUIN_DOWNLOAD_SOURCE:-auto}"
 DOWNLOAD_BASE_URL="${PENGUIN_DOWNLOAD_BASE_URL:-}"
 DOWNLOAD_FALLBACK_BASE_URL="${PENGUIN_DOWNLOAD_FALLBACK_BASE_URL:-}"
-DOWNLOAD_BENCHMARK="${PENGUIN_DOWNLOAD_BENCHMARK:-0}"
-BENCHMARK_TOTAL_TIMEOUT_SECONDS=5
-BENCHMARK_STARTED_AT=0
+DOWNLOAD_SPEED_PROBE="${PENGUIN_DOWNLOAD_SPEED_PROBE:-0}"
+SPEED_PROBE_TOTAL_TIMEOUT_SECONDS=8
+SPEED_PROBE_GITHUB_MIN_BYTES_PER_SECOND=262144
+SPEED_PROBE_STARTED_AT=0
 PAYLOAD_NAME="payload.tar.gz"
 # The release workflow replaces this token with the immutable tag before publishing both the
 # standalone installer and the copies sealed inside the Linux, macOS and universal bundles.
@@ -134,9 +135,9 @@ case "$SOURCE_MODE" in
   auto | oss | github) ;;
   *) fail "PENGUIN_DOWNLOAD_SOURCE must be auto, oss, or github" ;;
 esac
-case "$DOWNLOAD_BENCHMARK" in
+case "$DOWNLOAD_SPEED_PROBE" in
   0 | 1) ;;
-  *) fail "PENGUIN_DOWNLOAD_BENCHMARK must be 0 or 1" ;;
+  *) fail "PENGUIN_DOWNLOAD_SPEED_PROBE must be 0 or 1" ;;
 esac
 RESOLVED_RELEASE_VERSION="$VERSION"
 if [ -z "$RESOLVED_RELEASE_VERSION" ] && is_release_tag "$EMBEDDED_RELEASE_VERSION"; then
@@ -275,17 +276,17 @@ is_positive_integer() {
   esac
 }
 
-benchmark_now_seconds() {
+speed_probe_now_seconds() {
   date +%s 2>/dev/null || printf '%s\n' 0
 }
 
-benchmark_remaining_seconds() {
-  brs_now="$(benchmark_now_seconds)"
-  case "$brs_now:$BENCHMARK_STARTED_AT" in
-    *[!0-9:]* | :* | *:) printf '%s\n' "$BENCHMARK_TOTAL_TIMEOUT_SECONDS"; return 0 ;;
+speed_probe_remaining_seconds() {
+  brs_now="$(speed_probe_now_seconds)"
+  case "$brs_now:$SPEED_PROBE_STARTED_AT" in
+    *[!0-9:]* | :* | *:) printf '%s\n' "$SPEED_PROBE_TOTAL_TIMEOUT_SECONDS"; return 0 ;;
   esac
-  brs_elapsed=$((brs_now - BENCHMARK_STARTED_AT))
-  brs_remaining=$((BENCHMARK_TOTAL_TIMEOUT_SECONDS - brs_elapsed))
+  brs_elapsed=$((brs_now - SPEED_PROBE_STARTED_AT))
+  brs_remaining=$((SPEED_PROBE_TOTAL_TIMEOUT_SECONDS - brs_elapsed))
   if [ "$brs_remaining" -gt 0 ]; then
     printf '%s\n' "$brs_remaining"
   else
@@ -293,9 +294,9 @@ benchmark_remaining_seconds() {
   fi
 }
 
-benchmark_curl_timeout() {
+speed_probe_curl_timeout() {
   bct_cap="$1"
-  bct_remaining="$(benchmark_remaining_seconds)"
+  bct_remaining="$(speed_probe_remaining_seconds)"
   [ "$bct_remaining" -gt 0 ] || return 1
   if [ "$bct_remaining" -lt "$bct_cap" ]; then
     printf '%s\n' "$bct_remaining"
@@ -308,10 +309,10 @@ load_release_download_manifest() {
   lrdm_tag="$1"
   lrdm_manifest="$TMP/release-download-manifest.tsv"
   rm -f "$lrdm_manifest"
-  if lrdm_timeout="$(benchmark_curl_timeout 2)" \
+  if lrdm_timeout="$(speed_probe_curl_timeout 2)" \
     && curl -fsSL --connect-timeout "$lrdm_timeout" --max-time "$lrdm_timeout" "$OSS_RELEASE_ROOT/$lrdm_tag/release-download-manifest.tsv" -o "$lrdm_manifest" 2>/dev/null; then
     :
-  elif lrdm_timeout="$(benchmark_curl_timeout 2)" \
+  elif lrdm_timeout="$(speed_probe_curl_timeout 2)" \
     && curl -fsSL --connect-timeout "$lrdm_timeout" --max-time "$lrdm_timeout" "$GITHUB_RELEASE_ROOT/$lrdm_tag/release-download-manifest.tsv" -o "$lrdm_manifest" 2>/dev/null; then
     :
   else
@@ -321,27 +322,27 @@ load_release_download_manifest() {
   lrdm_expected_header="$(printf 'penguin-release-download-manifest\t1\t%s' "$lrdm_tag")"
   [ "$(sed -n '1p' "$lrdm_manifest")" = "$lrdm_expected_header" ] || return 1
 
-  BENCHMARK_SMALL_PROBE="$(awk -F '\t' '$1 == "probe" && $2 == "small" { print $3; exit }' "$lrdm_manifest")"
-  BENCHMARK_SMALL_SIZE="$(awk -F '\t' '$1 == "probe" && $2 == "small" { print $4; exit }' "$lrdm_manifest")"
-  BENCHMARK_SMALL_HASH="$(awk -F '\t' '$1 == "probe" && $2 == "small" { print $5; exit }' "$lrdm_manifest")"
-  BENCHMARK_LARGE_PROBE="$(awk -F '\t' '$1 == "probe" && $2 == "large" { print $3; exit }' "$lrdm_manifest")"
-  BENCHMARK_LARGE_SIZE="$(awk -F '\t' '$1 == "probe" && $2 == "large" { print $4; exit }' "$lrdm_manifest")"
-  BENCHMARK_LARGE_HASH="$(awk -F '\t' '$1 == "probe" && $2 == "large" { print $5; exit }' "$lrdm_manifest")"
-  BENCHMARK_ASSET_SIZE="$(awk -F '\t' -v asset="$ASSET" '$1 == "asset" && $2 == asset { print $3; exit }' "$lrdm_manifest")"
+  SPEED_PROBE_SMALL_PROBE="$(awk -F '\t' '$1 == "probe" && $2 == "small" { print $3; exit }' "$lrdm_manifest")"
+  SPEED_PROBE_SMALL_SIZE="$(awk -F '\t' '$1 == "probe" && $2 == "small" { print $4; exit }' "$lrdm_manifest")"
+  SPEED_PROBE_SMALL_HASH="$(awk -F '\t' '$1 == "probe" && $2 == "small" { print $5; exit }' "$lrdm_manifest")"
+  SPEED_PROBE_LARGE_PROBE="$(awk -F '\t' '$1 == "probe" && $2 == "large" { print $3; exit }' "$lrdm_manifest")"
+  SPEED_PROBE_LARGE_SIZE="$(awk -F '\t' '$1 == "probe" && $2 == "large" { print $4; exit }' "$lrdm_manifest")"
+  SPEED_PROBE_LARGE_HASH="$(awk -F '\t' '$1 == "probe" && $2 == "large" { print $5; exit }' "$lrdm_manifest")"
+  SPEED_PROBE_ASSET_SIZE="$(awk -F '\t' -v asset="$ASSET" '$1 == "asset" && $2 == asset { print $3; exit }' "$lrdm_manifest")"
 
-  for lrdm_file in "$BENCHMARK_SMALL_PROBE" "$BENCHMARK_LARGE_PROBE"; do
+  for lrdm_file in "$SPEED_PROBE_SMALL_PROBE" "$SPEED_PROBE_LARGE_PROBE"; do
     case "$lrdm_file" in
       *[!A-Za-z0-9._+-]* | *..* | '') return 1 ;;
     esac
   done
-  is_positive_integer "$BENCHMARK_SMALL_SIZE" || return 1
-  is_positive_integer "$BENCHMARK_LARGE_SIZE" || return 1
-  is_positive_integer "$BENCHMARK_ASSET_SIZE" || return 1
-  case "$BENCHMARK_SMALL_HASH:$BENCHMARK_LARGE_HASH" in
+  is_positive_integer "$SPEED_PROBE_SMALL_SIZE" || return 1
+  is_positive_integer "$SPEED_PROBE_LARGE_SIZE" || return 1
+  is_positive_integer "$SPEED_PROBE_ASSET_SIZE" || return 1
+  case "$SPEED_PROBE_SMALL_HASH:$SPEED_PROBE_LARGE_HASH" in
     *[!0-9a-f:]* | *::* | :* | *:) return 1 ;;
   esac
-  [ "${#BENCHMARK_SMALL_HASH}" -eq 64 ] || return 1
-  [ "${#BENCHMARK_LARGE_HASH}" -eq 64 ] || return 1
+  [ "${#SPEED_PROBE_SMALL_HASH}" -eq 64 ] || return 1
+  [ "${#SPEED_PROBE_LARGE_HASH}" -eq 64 ] || return 1
   return 0
 }
 
@@ -352,10 +353,11 @@ probe_download_source() {
   pds_size="$4"
   pds_hash="$5"
   pds_metrics="$6"
+  pds_timeout_cap="${7:-2}"
   pds_body="$TMP/probe-$pds_label-$pds_file"
   pds_write="$pds_metrics.tmp"
   rm -f "$pds_body" "$pds_metrics" "$pds_write"
-  pds_timeout="$(benchmark_curl_timeout 2)" || {
+  pds_timeout="$(speed_probe_curl_timeout "$pds_timeout_cap")" || {
     printf '%s\n' "fail" > "$pds_metrics"
     return 0
   }
@@ -384,9 +386,9 @@ run_probe_pair() {
   rpp_hash="$3"
   OSS_PROBE_METRICS="$TMP/probe-oss-$rpp_file.metrics"
   GITHUB_PROBE_METRICS="$TMP/probe-github-$rpp_file.metrics"
-  probe_download_source oss "$OSS_BENCHMARK_BASE_URL" "$rpp_file" "$rpp_size" "$rpp_hash" "$OSS_PROBE_METRICS" &
+  probe_download_source oss "$OSS_SPEED_PROBE_BASE_URL" "$rpp_file" "$rpp_size" "$rpp_hash" "$OSS_PROBE_METRICS" &
   rpp_oss_pid=$!
-  probe_download_source github "$GITHUB_BENCHMARK_BASE_URL" "$rpp_file" "$rpp_size" "$rpp_hash" "$GITHUB_PROBE_METRICS" &
+  probe_download_source github "$GITHUB_SPEED_PROBE_BASE_URL" "$rpp_file" "$rpp_size" "$rpp_hash" "$GITHUB_PROBE_METRICS" &
   rpp_github_pid=$!
   wait "$rpp_oss_pid" 2>/dev/null || :
   wait "$rpp_github_pid" 2>/dev/null || :
@@ -401,12 +403,9 @@ probe_status() {
   fi
 }
 
-select_fast_source_from_metrics() {
-  sfm_oss_metrics="$1"
-  sfm_github_metrics="$2"
-  sfm_probe_size="$3"
-  sfm_asset_size="$4"
-  awk -v probe="$sfm_probe_size" -v asset="$sfm_asset_size" '
+select_speed_probe_source_from_metrics() {
+  sfm_github_metrics="$1"
+  awk -v github_min="$SPEED_PROBE_GITHUB_MIN_BYTES_PER_SECOND" '
     function read_metrics(path, out, line, fields) {
       if ((getline line < path) <= 0) return 0
       close(path)
@@ -414,51 +413,42 @@ select_fast_source_from_metrics() {
       if (fields[1] != "ok") return 0
       out["start"] = fields[2] + 0
       out["total"] = fields[3] + 0
+      out["speed"] = fields[4] + 0
       return 1
     }
     BEGIN {
-      oss_ok = read_metrics(ARGV[1], oss)
-      github_ok = read_metrics(ARGV[2], github)
-      ARGV[1] = ""; ARGV[2] = ""
-      if (github_ok && !oss_ok) { print "github"; exit }
-      if (oss_ok && !github_ok) { print "oss"; exit }
-      if (!oss_ok && !github_ok) { print "oss"; exit }
-      oss_body = oss["total"] - oss["start"]
-      github_body = github["total"] - github["start"]
-      if (oss_body < 0.001) oss_body = 0.001
-      if (github_body < 0.001) github_body = 0.001
-      oss_est = oss["start"] + asset / (probe / oss_body)
-      github_est = github["start"] + asset / (probe / github_body)
-      if (github_est < oss_est) print "github"
-      else print "oss"
+      github_ok = read_metrics(ARGV[1], github)
+      ARGV[1] = ""
+      if (github_ok && github["speed"] >= github_min) { print "github"; exit }
+      print "oss"
     }
-  ' "$sfm_oss_metrics" "$sfm_github_metrics"
+  ' "$sfm_github_metrics"
 }
 
-benchmark_release_sources() {
+speed_probe_release_sources() {
   brs_tag="$1"
-  BENCHMARK_BASE_URL=""
-  BENCHMARK_FALLBACK_BASE_URL=""
-  OSS_BENCHMARK_BASE_URL="$OSS_RELEASE_ROOT/$brs_tag"
-  GITHUB_BENCHMARK_BASE_URL="$GITHUB_RELEASE_ROOT/$brs_tag"
-  BENCHMARK_STARTED_AT="$(benchmark_now_seconds)"
+  SPEED_PROBE_BASE_URL=""
+  SPEED_PROBE_FALLBACK_BASE_URL=""
+  OSS_SPEED_PROBE_BASE_URL="$OSS_RELEASE_ROOT/$brs_tag"
+  GITHUB_SPEED_PROBE_BASE_URL="$GITHUB_RELEASE_ROOT/$brs_tag"
+  SPEED_PROBE_STARTED_AT="$(speed_probe_now_seconds)"
 
   load_release_download_manifest "$brs_tag" || return 1
   echo "Testing OSS mirror and GitHub download sources ..."
 
-  run_probe_pair "$BENCHMARK_SMALL_PROBE" "$BENCHMARK_SMALL_SIZE" "$BENCHMARK_SMALL_HASH"
+  run_probe_pair "$SPEED_PROBE_SMALL_PROBE" "$SPEED_PROBE_SMALL_SIZE" "$SPEED_PROBE_SMALL_HASH"
   brs_oss_small="$(probe_status "$OSS_PROBE_METRICS")"
   brs_github_small="$(probe_status "$GITHUB_PROBE_METRICS")"
 
   if [ "$brs_oss_small" != "ok" ] && [ "$brs_github_small" = "ok" ]; then
-    BENCHMARK_BASE_URL="$GITHUB_BENCHMARK_BASE_URL"
-    BENCHMARK_FALLBACK_BASE_URL="$OSS_BENCHMARK_BASE_URL"
+    SPEED_PROBE_BASE_URL="$GITHUB_SPEED_PROBE_BASE_URL"
+    SPEED_PROBE_FALLBACK_BASE_URL="$OSS_SPEED_PROBE_BASE_URL"
     echo "Selected GitHub (OSS mirror probe unavailable)."
     return 0
   fi
   if [ "$brs_oss_small" = "ok" ] && [ "$brs_github_small" != "ok" ]; then
-    BENCHMARK_BASE_URL="$OSS_BENCHMARK_BASE_URL"
-    BENCHMARK_FALLBACK_BASE_URL="$GITHUB_BENCHMARK_BASE_URL"
+    SPEED_PROBE_BASE_URL="$OSS_SPEED_PROBE_BASE_URL"
+    SPEED_PROBE_FALLBACK_BASE_URL="$GITHUB_SPEED_PROBE_BASE_URL"
     echo "Selected OSS mirror (GitHub probe unavailable)."
     return 0
   fi
@@ -466,23 +456,26 @@ benchmark_release_sources() {
     return 1
   fi
 
-  if [ "$BENCHMARK_ASSET_SIZE" -lt 33554432 ]; then
-    BENCHMARK_BASE_URL="$OSS_BENCHMARK_BASE_URL"
-    BENCHMARK_FALLBACK_BASE_URL="$GITHUB_BENCHMARK_BASE_URL"
+  if [ "$SPEED_PROBE_ASSET_SIZE" -lt 33554432 ]; then
+    SPEED_PROBE_BASE_URL="$OSS_SPEED_PROBE_BASE_URL"
+    SPEED_PROBE_FALLBACK_BASE_URL="$GITHUB_SPEED_PROBE_BASE_URL"
     echo "Selected OSS mirror (download source test did not need throughput probing)."
     return 0
   fi
 
-  run_probe_pair "$BENCHMARK_LARGE_PROBE" "$BENCHMARK_LARGE_SIZE" "$BENCHMARK_LARGE_HASH"
-  brs_choice="$(select_fast_source_from_metrics "$OSS_PROBE_METRICS" "$GITHUB_PROBE_METRICS" "$BENCHMARK_LARGE_SIZE" "$BENCHMARK_ASSET_SIZE")"
+  GITHUB_PROBE_METRICS="$TMP/probe-github-$SPEED_PROBE_LARGE_PROBE.metrics"
+  probe_download_source github "$GITHUB_SPEED_PROBE_BASE_URL" "$SPEED_PROBE_LARGE_PROBE" "$SPEED_PROBE_LARGE_SIZE" "$SPEED_PROBE_LARGE_HASH" "$GITHUB_PROBE_METRICS" 5
+  brs_choice="$(select_speed_probe_source_from_metrics "$GITHUB_PROBE_METRICS")"
   if [ "$brs_choice" = "github" ]; then
-    BENCHMARK_BASE_URL="$GITHUB_BENCHMARK_BASE_URL"
-    BENCHMARK_FALLBACK_BASE_URL="$OSS_BENCHMARK_BASE_URL"
-    echo "Selected GitHub (shorter estimated download time)."
+    SPEED_PROBE_BASE_URL="$GITHUB_SPEED_PROBE_BASE_URL"
+    SPEED_PROBE_FALLBACK_BASE_URL="$OSS_SPEED_PROBE_BASE_URL"
+    echo "Selected GitHub (meets minimum download speed)."
+  elif [ "$brs_choice" = "oss" ]; then
+    SPEED_PROBE_BASE_URL="$OSS_SPEED_PROBE_BASE_URL"
+    SPEED_PROBE_FALLBACK_BASE_URL="$GITHUB_SPEED_PROBE_BASE_URL"
+    echo "Selected OSS mirror (GitHub did not meet minimum download speed)."
   else
-    BENCHMARK_BASE_URL="$OSS_BENCHMARK_BASE_URL"
-    BENCHMARK_FALLBACK_BASE_URL="$GITHUB_BENCHMARK_BASE_URL"
-    echo "Selected OSS mirror (shorter or equal estimated download time)."
+    return 1
   fi
   return 0
 }
@@ -588,10 +581,10 @@ else
       if [ "$SOURCE_MODE" = "auto" ] && [ -z "$FALLBACK_BASE_URL" ]; then
         FALLBACK_BASE_URL="$GITHUB_RELEASE_ROOT/$SELECTED_TAG"
       fi
-      if [ "$SOURCE_MODE" = "auto" ] && [ "$DOWNLOAD_BENCHMARK" = "1" ] && [ -z "$DOWNLOAD_BASE_URL" ]; then
-        if benchmark_release_sources "$SELECTED_TAG"; then
-          BASE_URL="$BENCHMARK_BASE_URL"
-          FALLBACK_BASE_URL="$BENCHMARK_FALLBACK_BASE_URL"
+      if [ "$SOURCE_MODE" = "auto" ] && [ "$DOWNLOAD_SPEED_PROBE" = "1" ] && [ -z "$DOWNLOAD_BASE_URL" ]; then
+        if speed_probe_release_sources "$SELECTED_TAG"; then
+          BASE_URL="$SPEED_PROBE_BASE_URL"
+          FALLBACK_BASE_URL="$SPEED_PROBE_FALLBACK_BASE_URL"
         else
           echo "Download source test was inconclusive; using OSS with same-version GitHub fallback."
         fi

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@
 #   PENGUIN_DOWNLOAD_SOURCE=auto|oss|github choose the online source; default auto (OSS, then same-version GitHub)
 #   PENGUIN_DOWNLOAD_BENCHMARK=1 enable same-version OSS/GitHub probe timing in auto mode
 #   PENGUIN_DOWNLOAD_BASE_URL=<url> exact online asset directory selected by the stable forwarder
-#   PENGUIN_DOWNLOAD_FALLBACK_BASE_URL=<url> same-version fallback asset directory
+#   PENGUIN_DOWNLOAD_FALLBACK_BASE_URL=<url> fallback for PENGUIN_DOWNLOAD_BASE_URL
 #   --universal               install the universal package (no bundled Node runtime; needs system Node >= 24)
 #
 # Each Release attaches exactly one artifact per target: penguin-<target>.tar.gz, a shallow
@@ -145,10 +145,12 @@ fi
 if [ -n "$DOWNLOAD_BASE_URL" ]; then
   DOWNLOAD_BASE_URL="${DOWNLOAD_BASE_URL%/}"
   validate_https_url PENGUIN_DOWNLOAD_BASE_URL "$DOWNLOAD_BASE_URL"
-fi
-if [ -n "$DOWNLOAD_FALLBACK_BASE_URL" ]; then
-  DOWNLOAD_FALLBACK_BASE_URL="${DOWNLOAD_FALLBACK_BASE_URL%/}"
-  validate_https_url PENGUIN_DOWNLOAD_FALLBACK_BASE_URL "$DOWNLOAD_FALLBACK_BASE_URL"
+  if [ -n "$DOWNLOAD_FALLBACK_BASE_URL" ]; then
+    DOWNLOAD_FALLBACK_BASE_URL="${DOWNLOAD_FALLBACK_BASE_URL%/}"
+    validate_https_url PENGUIN_DOWNLOAD_FALLBACK_BASE_URL "$DOWNLOAD_FALLBACK_BASE_URL"
+  fi
+else
+  DOWNLOAD_FALLBACK_BASE_URL=""
 fi
 
 # --- Universal package precheck: system Node >= 24 (platform packages bundle the runtime, so exempt) ---

--- a/install.sh
+++ b/install.sh
@@ -9,6 +9,7 @@
 #   PENGUIN_INSTALL_DIR=<dir> install dir; default ~/.penguin
 #   PENGUIN_ARCHIVE=<file>    install a local Release archive without network access (same as --archive <file>)
 #   PENGUIN_DOWNLOAD_SOURCE=auto|oss|github choose the online source; default auto (OSS, then same-version GitHub)
+#   PENGUIN_DOWNLOAD_BENCHMARK=1 enable same-version OSS/GitHub probe timing in auto mode
 #   PENGUIN_DOWNLOAD_BASE_URL=<url> exact online asset directory selected by the stable forwarder
 #   PENGUIN_DOWNLOAD_FALLBACK_BASE_URL=<url> same-version fallback asset directory
 #   --universal               install the universal package (no bundled Node runtime; needs system Node >= 24)
@@ -40,6 +41,7 @@ ARCHIVE="${PENGUIN_ARCHIVE:-}"
 SOURCE_MODE="${PENGUIN_DOWNLOAD_SOURCE:-auto}"
 DOWNLOAD_BASE_URL="${PENGUIN_DOWNLOAD_BASE_URL:-}"
 DOWNLOAD_FALLBACK_BASE_URL="${PENGUIN_DOWNLOAD_FALLBACK_BASE_URL:-}"
+DOWNLOAD_BENCHMARK="${PENGUIN_DOWNLOAD_BENCHMARK:-0}"
 PAYLOAD_NAME="payload.tar.gz"
 # The release workflow replaces this token with the immutable tag before publishing both the
 # standalone installer and the copies sealed inside the Linux, macOS and universal bundles.
@@ -129,6 +131,10 @@ fi
 case "$SOURCE_MODE" in
   auto | oss | github) ;;
   *) fail "PENGUIN_DOWNLOAD_SOURCE must be auto, oss, or github" ;;
+esac
+case "$DOWNLOAD_BENCHMARK" in
+  0 | 1) ;;
+  *) fail "PENGUIN_DOWNLOAD_BENCHMARK must be 0 or 1" ;;
 esac
 RESOLVED_RELEASE_VERSION="$VERSION"
 if [ -z "$RESOLVED_RELEASE_VERSION" ] && is_release_tag "$EMBEDDED_RELEASE_VERSION"; then
@@ -247,6 +253,196 @@ verify_sha256() {
   echo "$3 checksum OK."
 }
 
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{ print $1 }'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{ print $1 }'
+  else
+    fail "sha256sum or shasum is required for checksum verification"
+  fi
+}
+
+is_positive_integer() {
+  case "$1" in
+    '' | *[!0-9]*) return 1 ;;
+    0) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+load_release_download_manifest() {
+  lrdm_tag="$1"
+  lrdm_manifest="$TMP/release-download-manifest.tsv"
+  rm -f "$lrdm_manifest"
+  curl -fsSL --connect-timeout 2 --max-time 4 "$OSS_RELEASE_ROOT/$lrdm_tag/release-download-manifest.tsv" -o "$lrdm_manifest" 2>/dev/null \
+    || curl -fsSL --connect-timeout 2 --max-time 4 "$GITHUB_RELEASE_ROOT/$lrdm_tag/release-download-manifest.tsv" -o "$lrdm_manifest" 2>/dev/null \
+    || return 1
+
+  lrdm_expected_header="$(printf 'penguin-release-download-manifest\t1\t%s' "$lrdm_tag")"
+  [ "$(sed -n '1p' "$lrdm_manifest")" = "$lrdm_expected_header" ] || return 1
+
+  BENCHMARK_SMALL_PROBE="$(awk -F '\t' '$1 == "probe" && $2 == "small" { print $3; exit }' "$lrdm_manifest")"
+  BENCHMARK_SMALL_SIZE="$(awk -F '\t' '$1 == "probe" && $2 == "small" { print $4; exit }' "$lrdm_manifest")"
+  BENCHMARK_SMALL_HASH="$(awk -F '\t' '$1 == "probe" && $2 == "small" { print $5; exit }' "$lrdm_manifest")"
+  BENCHMARK_LARGE_PROBE="$(awk -F '\t' '$1 == "probe" && $2 == "large" { print $3; exit }' "$lrdm_manifest")"
+  BENCHMARK_LARGE_SIZE="$(awk -F '\t' '$1 == "probe" && $2 == "large" { print $4; exit }' "$lrdm_manifest")"
+  BENCHMARK_LARGE_HASH="$(awk -F '\t' '$1 == "probe" && $2 == "large" { print $5; exit }' "$lrdm_manifest")"
+  BENCHMARK_ASSET_SIZE="$(awk -F '\t' -v asset="$ASSET" '$1 == "asset" && $2 == asset { print $3; exit }' "$lrdm_manifest")"
+
+  for lrdm_file in "$BENCHMARK_SMALL_PROBE" "$BENCHMARK_LARGE_PROBE"; do
+    case "$lrdm_file" in
+      *[!A-Za-z0-9._+-]* | *..* | '') return 1 ;;
+    esac
+  done
+  is_positive_integer "$BENCHMARK_SMALL_SIZE" || return 1
+  is_positive_integer "$BENCHMARK_LARGE_SIZE" || return 1
+  is_positive_integer "$BENCHMARK_ASSET_SIZE" || return 1
+  case "$BENCHMARK_SMALL_HASH:$BENCHMARK_LARGE_HASH" in
+    *[!0-9a-f:]* | *::* | :* | *:) return 1 ;;
+  esac
+  [ "${#BENCHMARK_SMALL_HASH}" -eq 64 ] || return 1
+  [ "${#BENCHMARK_LARGE_HASH}" -eq 64 ] || return 1
+  return 0
+}
+
+probe_download_source() {
+  pds_label="$1"
+  pds_base="$2"
+  pds_file="$3"
+  pds_size="$4"
+  pds_hash="$5"
+  pds_metrics="$6"
+  pds_body="$TMP/probe-$pds_label-$pds_file"
+  pds_write="$pds_metrics.tmp"
+  rm -f "$pds_body" "$pds_metrics" "$pds_write"
+  if curl -fsSL --connect-timeout 2 --max-time 5 -H "Accept-Encoding: identity" \
+      -w '%{time_starttransfer} %{time_total} %{speed_download}' \
+      "$pds_base/$pds_file" -o "$pds_body" > "$pds_write" 2>/dev/null; then
+    pds_actual_size="$(wc -c < "$pds_body" | tr -d ' ')"
+    pds_actual_hash="$(sha256_file "$pds_body" | tr 'A-F' 'a-f')"
+    if [ "$pds_actual_size" = "$pds_size" ] && [ "$pds_actual_hash" = "$pds_hash" ]; then
+      read pds_start pds_total pds_speed < "$pds_write" || :
+      case "$pds_start:$pds_total" in
+        *[!0-9.:]* | :* | *:) printf '%s\n' "fail" > "$pds_metrics" ;;
+        *) printf '%s %s %s %s\n' "ok" "$pds_start" "$pds_total" "${pds_speed:-0}" > "$pds_metrics" ;;
+      esac
+    else
+      printf '%s\n' "fail" > "$pds_metrics"
+    fi
+  else
+    printf '%s\n' "fail" > "$pds_metrics"
+  fi
+}
+
+run_probe_pair() {
+  rpp_file="$1"
+  rpp_size="$2"
+  rpp_hash="$3"
+  OSS_PROBE_METRICS="$TMP/probe-oss-$rpp_file.metrics"
+  GITHUB_PROBE_METRICS="$TMP/probe-github-$rpp_file.metrics"
+  probe_download_source oss "$OSS_BENCHMARK_BASE_URL" "$rpp_file" "$rpp_size" "$rpp_hash" "$OSS_PROBE_METRICS" &
+  rpp_oss_pid=$!
+  probe_download_source github "$GITHUB_BENCHMARK_BASE_URL" "$rpp_file" "$rpp_size" "$rpp_hash" "$GITHUB_PROBE_METRICS" &
+  rpp_github_pid=$!
+  wait "$rpp_oss_pid" 2>/dev/null || :
+  wait "$rpp_github_pid" 2>/dev/null || :
+}
+
+probe_status() {
+  ps_file="$1"
+  if [ -f "$ps_file" ]; then
+    awk 'NR == 1 { print $1 }' "$ps_file"
+  else
+    printf '%s\n' "fail"
+  fi
+}
+
+select_fast_source_from_metrics() {
+  sfm_oss_metrics="$1"
+  sfm_github_metrics="$2"
+  sfm_probe_size="$3"
+  sfm_asset_size="$4"
+  awk -v probe="$sfm_probe_size" -v asset="$sfm_asset_size" '
+    function read_metrics(path, out, line, fields) {
+      if ((getline line < path) <= 0) return 0
+      close(path)
+      split(line, fields, " ")
+      if (fields[1] != "ok") return 0
+      out["start"] = fields[2] + 0
+      out["total"] = fields[3] + 0
+      return 1
+    }
+    BEGIN {
+      oss_ok = read_metrics(ARGV[1], oss)
+      github_ok = read_metrics(ARGV[2], github)
+      ARGV[1] = ""; ARGV[2] = ""
+      if (github_ok && !oss_ok) { print "github"; exit }
+      if (oss_ok && !github_ok) { print "oss"; exit }
+      if (!oss_ok && !github_ok) { print "oss"; exit }
+      oss_body = oss["total"] - oss["start"]
+      github_body = github["total"] - github["start"]
+      if (oss_body < 0.001) oss_body = 0.001
+      if (github_body < 0.001) github_body = 0.001
+      oss_est = oss["start"] + asset / (probe / oss_body)
+      github_est = github["start"] + asset / (probe / github_body)
+      if (github_est <= oss_est * 0.80 && oss_est - github_est >= 2) print "github"
+      else print "oss"
+    }
+  ' "$sfm_oss_metrics" "$sfm_github_metrics"
+}
+
+benchmark_release_sources() {
+  brs_tag="$1"
+  BENCHMARK_BASE_URL=""
+  BENCHMARK_FALLBACK_BASE_URL=""
+  OSS_BENCHMARK_BASE_URL="$OSS_RELEASE_ROOT/$brs_tag"
+  GITHUB_BENCHMARK_BASE_URL="$GITHUB_RELEASE_ROOT/$brs_tag"
+
+  load_release_download_manifest "$brs_tag" || return 1
+  echo "Testing OSS mirror and GitHub download sources ..."
+
+  run_probe_pair "$BENCHMARK_SMALL_PROBE" "$BENCHMARK_SMALL_SIZE" "$BENCHMARK_SMALL_HASH"
+  brs_oss_small="$(probe_status "$OSS_PROBE_METRICS")"
+  brs_github_small="$(probe_status "$GITHUB_PROBE_METRICS")"
+
+  if [ "$brs_oss_small" != "ok" ] && [ "$brs_github_small" = "ok" ]; then
+    BENCHMARK_BASE_URL="$GITHUB_BENCHMARK_BASE_URL"
+    BENCHMARK_FALLBACK_BASE_URL="$OSS_BENCHMARK_BASE_URL"
+    echo "Selected GitHub (OSS mirror probe unavailable)."
+    return 0
+  fi
+  if [ "$brs_oss_small" = "ok" ] && [ "$brs_github_small" != "ok" ]; then
+    BENCHMARK_BASE_URL="$OSS_BENCHMARK_BASE_URL"
+    BENCHMARK_FALLBACK_BASE_URL="$GITHUB_BENCHMARK_BASE_URL"
+    echo "Selected OSS mirror (GitHub probe unavailable)."
+    return 0
+  fi
+  if [ "$brs_oss_small" != "ok" ] && [ "$brs_github_small" != "ok" ]; then
+    return 1
+  fi
+
+  if [ "$BENCHMARK_ASSET_SIZE" -lt 33554432 ]; then
+    BENCHMARK_BASE_URL="$OSS_BENCHMARK_BASE_URL"
+    BENCHMARK_FALLBACK_BASE_URL="$GITHUB_BENCHMARK_BASE_URL"
+    echo "Selected OSS mirror (download source test did not need throughput probing)."
+    return 0
+  fi
+
+  run_probe_pair "$BENCHMARK_LARGE_PROBE" "$BENCHMARK_LARGE_SIZE" "$BENCHMARK_LARGE_HASH"
+  brs_choice="$(select_fast_source_from_metrics "$OSS_PROBE_METRICS" "$GITHUB_PROBE_METRICS" "$BENCHMARK_LARGE_SIZE" "$BENCHMARK_ASSET_SIZE")"
+  if [ "$brs_choice" = "github" ]; then
+    BENCHMARK_BASE_URL="$GITHUB_BENCHMARK_BASE_URL"
+    BENCHMARK_FALLBACK_BASE_URL="$OSS_BENCHMARK_BASE_URL"
+    echo "Selected GitHub (faster probe result)."
+  else
+    BENCHMARK_BASE_URL="$OSS_BENCHMARK_BASE_URL"
+    BENCHMARK_FALLBACK_BASE_URL="$GITHUB_BENCHMARK_BASE_URL"
+    echo "Selected OSS mirror (default or faster probe result)."
+  fi
+  return 0
+}
+
 # Downloads the bundle and its checksum as a pair. Transport failures may try a same-version
 # fallback; checksum failures are handled afterwards and always abort rather than being hidden
 # by a different source.
@@ -255,9 +451,9 @@ download_release_pair() {
   drp_label="$(download_source_label "$drp_base")"
   echo "Downloading $ASSET from $drp_label ..."
   rm -f "$ARCHIVE_PATH" "$TMP/$ASSET.sha256"
-  curl -fSL --progress-bar "$drp_base/$ASSET" -o "$ARCHIVE_PATH" \
+  curl -fSL --progress-bar --connect-timeout 5 --speed-limit 65536 --speed-time 20 "$drp_base/$ASSET" -o "$ARCHIVE_PATH" \
     || return 1
-  curl -fsSL "$drp_base/$ASSET.sha256" -o "$TMP/$ASSET.sha256" \
+  curl -fsSL --connect-timeout 5 --speed-limit 1024 --speed-time 20 "$drp_base/$ASSET.sha256" -o "$TMP/$ASSET.sha256" \
     || return 1
   return 0
 }
@@ -347,6 +543,14 @@ else
       BASE_URL="$OSS_RELEASE_ROOT/$SELECTED_TAG"
       if [ "$SOURCE_MODE" = "auto" ] && [ -z "$FALLBACK_BASE_URL" ]; then
         FALLBACK_BASE_URL="$GITHUB_RELEASE_ROOT/$SELECTED_TAG"
+      fi
+      if [ "$SOURCE_MODE" = "auto" ] && [ "$DOWNLOAD_BENCHMARK" = "1" ] && [ -z "$DOWNLOAD_BASE_URL" ]; then
+        if benchmark_release_sources "$SELECTED_TAG"; then
+          BASE_URL="$BENCHMARK_BASE_URL"
+          FALLBACK_BASE_URL="$BENCHMARK_FALLBACK_BASE_URL"
+        else
+          echo "Download source test was inconclusive; using OSS with same-version GitHub fallback."
+        fi
       fi
     elif [ "$SOURCE_MODE" = "oss" ]; then
       fail "the OSS mirror is unavailable or its release metadata is invalid."

--- a/install.sh
+++ b/install.sh
@@ -42,6 +42,8 @@ SOURCE_MODE="${PENGUIN_DOWNLOAD_SOURCE:-auto}"
 DOWNLOAD_BASE_URL="${PENGUIN_DOWNLOAD_BASE_URL:-}"
 DOWNLOAD_FALLBACK_BASE_URL="${PENGUIN_DOWNLOAD_FALLBACK_BASE_URL:-}"
 DOWNLOAD_BENCHMARK="${PENGUIN_DOWNLOAD_BENCHMARK:-0}"
+BENCHMARK_TOTAL_TIMEOUT_SECONDS=5
+BENCHMARK_STARTED_AT=0
 PAYLOAD_NAME="payload.tar.gz"
 # The release workflow replaces this token with the immutable tag before publishing both the
 # standalone installer and the copies sealed inside the Linux, macOS and universal bundles.
@@ -271,13 +273,48 @@ is_positive_integer() {
   esac
 }
 
+benchmark_now_seconds() {
+  date +%s 2>/dev/null || printf '%s\n' 0
+}
+
+benchmark_remaining_seconds() {
+  brs_now="$(benchmark_now_seconds)"
+  case "$brs_now:$BENCHMARK_STARTED_AT" in
+    *[!0-9:]* | :* | *:) printf '%s\n' "$BENCHMARK_TOTAL_TIMEOUT_SECONDS"; return 0 ;;
+  esac
+  brs_elapsed=$((brs_now - BENCHMARK_STARTED_AT))
+  brs_remaining=$((BENCHMARK_TOTAL_TIMEOUT_SECONDS - brs_elapsed))
+  if [ "$brs_remaining" -gt 0 ]; then
+    printf '%s\n' "$brs_remaining"
+  else
+    printf '%s\n' 0
+  fi
+}
+
+benchmark_curl_timeout() {
+  bct_cap="$1"
+  bct_remaining="$(benchmark_remaining_seconds)"
+  [ "$bct_remaining" -gt 0 ] || return 1
+  if [ "$bct_remaining" -lt "$bct_cap" ]; then
+    printf '%s\n' "$bct_remaining"
+  else
+    printf '%s\n' "$bct_cap"
+  fi
+}
+
 load_release_download_manifest() {
   lrdm_tag="$1"
   lrdm_manifest="$TMP/release-download-manifest.tsv"
   rm -f "$lrdm_manifest"
-  curl -fsSL --connect-timeout 2 --max-time 4 "$OSS_RELEASE_ROOT/$lrdm_tag/release-download-manifest.tsv" -o "$lrdm_manifest" 2>/dev/null \
-    || curl -fsSL --connect-timeout 2 --max-time 4 "$GITHUB_RELEASE_ROOT/$lrdm_tag/release-download-manifest.tsv" -o "$lrdm_manifest" 2>/dev/null \
-    || return 1
+  if lrdm_timeout="$(benchmark_curl_timeout 2)" \
+    && curl -fsSL --connect-timeout "$lrdm_timeout" --max-time "$lrdm_timeout" "$OSS_RELEASE_ROOT/$lrdm_tag/release-download-manifest.tsv" -o "$lrdm_manifest" 2>/dev/null; then
+    :
+  elif lrdm_timeout="$(benchmark_curl_timeout 2)" \
+    && curl -fsSL --connect-timeout "$lrdm_timeout" --max-time "$lrdm_timeout" "$GITHUB_RELEASE_ROOT/$lrdm_tag/release-download-manifest.tsv" -o "$lrdm_manifest" 2>/dev/null; then
+    :
+  else
+    return 1
+  fi
 
   lrdm_expected_header="$(printf 'penguin-release-download-manifest\t1\t%s' "$lrdm_tag")"
   [ "$(sed -n '1p' "$lrdm_manifest")" = "$lrdm_expected_header" ] || return 1
@@ -316,7 +353,11 @@ probe_download_source() {
   pds_body="$TMP/probe-$pds_label-$pds_file"
   pds_write="$pds_metrics.tmp"
   rm -f "$pds_body" "$pds_metrics" "$pds_write"
-  if curl -fsSL --connect-timeout 2 --max-time 5 -H "Accept-Encoding: identity" \
+  pds_timeout="$(benchmark_curl_timeout 2)" || {
+    printf '%s\n' "fail" > "$pds_metrics"
+    return 0
+  }
+  if curl -fsSL --connect-timeout "$pds_timeout" --max-time "$pds_timeout" -H "Accept-Encoding: identity" \
       -w '%{time_starttransfer} %{time_total} %{speed_download}' \
       "$pds_base/$pds_file" -o "$pds_body" > "$pds_write" 2>/dev/null; then
     pds_actual_size="$(wc -c < "$pds_body" | tr -d ' ')"
@@ -398,6 +439,7 @@ benchmark_release_sources() {
   BENCHMARK_FALLBACK_BASE_URL=""
   OSS_BENCHMARK_BASE_URL="$OSS_RELEASE_ROOT/$brs_tag"
   GITHUB_BENCHMARK_BASE_URL="$GITHUB_RELEASE_ROOT/$brs_tag"
+  BENCHMARK_STARTED_AT="$(benchmark_now_seconds)"
 
   load_release_download_manifest "$brs_tag" || return 1
   echo "Testing OSS mirror and GitHub download sources ..."

--- a/install.sh
+++ b/install.sh
@@ -429,7 +429,7 @@ select_fast_source_from_metrics() {
       if (github_body < 0.001) github_body = 0.001
       oss_est = oss["start"] + asset / (probe / oss_body)
       github_est = github["start"] + asset / (probe / github_body)
-      if (github_est <= oss_est * 0.80 && oss_est - github_est >= 2) print "github"
+      if (github_est < oss_est) print "github"
       else print "oss"
     }
   ' "$sfm_oss_metrics" "$sfm_github_metrics"
@@ -478,11 +478,11 @@ benchmark_release_sources() {
   if [ "$brs_choice" = "github" ]; then
     BENCHMARK_BASE_URL="$GITHUB_BENCHMARK_BASE_URL"
     BENCHMARK_FALLBACK_BASE_URL="$OSS_BENCHMARK_BASE_URL"
-    echo "Selected GitHub (faster probe result)."
+    echo "Selected GitHub (shorter estimated download time)."
   else
     BENCHMARK_BASE_URL="$OSS_BENCHMARK_BASE_URL"
     BENCHMARK_FALLBACK_BASE_URL="$GITHUB_BENCHMARK_BASE_URL"
-    echo "Selected OSS mirror (default or faster probe result)."
+    echo "Selected OSS mirror (shorter or equal estimated download time)."
   fi
   return 0
 }

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -13,8 +13,9 @@
  *
  * Release discovery and installer download use the same environment contract as the public
  * installer entry point: an explicit PENGUIN_DOWNLOAD_BASE_URL has highest download priority;
- * otherwise auto prefers the OSS latest pointer and immutable release, then falls back to the same
- * GitHub tag, while oss and github are strict. The target-a-specific-release flag is spelled
+ * otherwise auto prefers the OSS latest pointer and immutable release when fetching the versioned
+ * installer, then lets that installer choose the large payload source for the same tag. The
+ * target-a-specific-release flag is spelled
  * `--release <tag>` rather than `--version <tag>`: commander's program-level
  * `-v, --version` intercepts a subcommand's own `--version` when it is written with a space, so
  * `penguin update --version 0.1.2` would silently print the CLI version and do nothing. A flag that
@@ -91,7 +92,7 @@ export interface InstallerCandidate {
   source: InstallerSource;
   baseUrl: string;
   url: string;
-  /** Same-tag payload fallback passed to install.sh after this candidate is selected. */
+  /** Same-tag payload fallback for an explicit configured mirror. */
   fallbackBaseUrl?: string;
 }
 
@@ -203,7 +204,9 @@ export function globalInstallCommand(
  *   the upgrade would silently relocate it;
  * - `--universal` is passed when the current install has no bundled `node/` directory, or the user
  *   would silently gain a runtime they deliberately did not install (and lose it in reverse);
- * - `PENGUIN_VERSION` pins the target when `--release` was given.
+ * - `PENGUIN_VERSION` pins the target when `--release` was given;
+ * - download base values are passed only when the caller deliberately sets them; empty strings
+ *   explicitly clear inherited values so install.sh can choose the large payload source itself.
  *
  * Pure so every combination is unit-testable; the caller supplies the two facts that need the
  * filesystem (`installDir`, `hasBundledNode`).
@@ -228,6 +231,22 @@ export function buildInstallerInvocation(opts: {
   if (opts.downloadFallbackBaseUrl !== undefined)
     env.PENGUIN_DOWNLOAD_FALLBACK_BASE_URL = opts.downloadFallbackBaseUrl;
   return { args, env };
+}
+
+export function payloadSourceEnv(
+  candidate: InstallerCandidate,
+  explicitBase: boolean,
+): Pick<
+  Parameters<typeof buildInstallerInvocation>[0],
+  "downloadBaseUrl" | "downloadFallbackBaseUrl"
+> {
+  if (explicitBase) {
+    return {
+      downloadBaseUrl: candidate.baseUrl,
+      downloadFallbackBaseUrl: candidate.fallbackBaseUrl ?? "",
+    };
+  }
+  return { downloadBaseUrl: "", downloadFallbackBaseUrl: "" };
 }
 
 /** GitHub download URL for the installer of a given release (latest when no version is pinned). */
@@ -382,7 +401,6 @@ export function installerCandidates(
     source: "oss",
     baseUrl: ossBase,
     url: `${ossBase}/install.sh`,
-    ...(source === "auto" ? { fallbackBaseUrl: githubBase } : {}),
   };
   return source === "auto" ? [oss, github] : [oss];
 }
@@ -631,9 +649,7 @@ export function registerUpdateCommand(program: Command, t: Messages): void {
         hasBundledNode,
         defaultInstallDir,
         version: target,
-        downloadBaseUrl: downloaded.candidate.baseUrl,
-        // Always override the inherited environment: an absent fallback must clear a stale one.
-        downloadFallbackBaseUrl: downloaded.candidate.fallbackBaseUrl ?? "",
+        ...payloadSourceEnv(downloaded.candidate, Boolean(explicitBaseValue)),
       });
       // Past this point the installer may delete the tree this process runs from. Everything below
       // is already-loaded code and already-resolved strings: no import, no file read, no re-entry.

--- a/packages/cli/test/update.test.ts
+++ b/packages/cli/test/update.test.ts
@@ -23,6 +23,7 @@ import {
   normalizeHttpsBaseUrl,
   parseDownloadSource,
   parseOssLatestManifest,
+  payloadSourceEnv,
   planUpdate,
   registerUpdateCommand,
   resolveRelease,
@@ -302,7 +303,6 @@ describe("release source selection", () => {
         source: "oss",
         baseUrl: `${ossOrigin}/releases/v0.2.0`,
         url: `${ossOrigin}/releases/v0.2.0/install.sh`,
-        fallbackBaseUrl: "https://github.com/Prism-Shadow/penguin-harness/releases/download/v0.2.0",
       },
       {
         source: "github",
@@ -419,7 +419,7 @@ describe("buildInstallerInvocation (preserves the shape of the install being upg
     });
   });
 
-  it("pins the selected payload source and same-version fallback for the child installer", () => {
+  it("passes an explicit mirror and same-version fallback through to the child installer", () => {
     expect(
       buildInstallerInvocation({
         ...base,
@@ -440,21 +440,39 @@ describe("buildInstallerInvocation (preserves the shape of the install being upg
     });
   });
 
-  it("explicitly clears an inherited fallback when the selected source has none", () => {
+  it("explicitly clears inherited payload source locks for delegated auto selection", () => {
     expect(
       buildInstallerInvocation({
         ...base,
         installDir: "/home/me/.penguin",
         hasBundledNode: true,
         version: "0.2.0",
-        downloadBaseUrl: "https://github.com/Prism-Shadow/penguin-harness/releases/download/v0.2.0",
+        downloadBaseUrl: "",
         downloadFallbackBaseUrl: "",
       }).env,
     ).toEqual({
       PENGUIN_VERSION: "v0.2.0",
-      PENGUIN_DOWNLOAD_BASE_URL:
-        "https://github.com/Prism-Shadow/penguin-harness/releases/download/v0.2.0",
+      PENGUIN_DOWNLOAD_BASE_URL: "",
       PENGUIN_DOWNLOAD_FALLBACK_BASE_URL: "",
+    });
+  });
+
+  it("keeps explicit mirrors strict but delegates non-explicit payload source selection", () => {
+    const candidate = {
+      source: "oss" as const,
+      baseUrl: "https://penguin-harness-releases.oss-cn-beijing.aliyuncs.com/releases/v0.2.0",
+      url: "https://penguin-harness-releases.oss-cn-beijing.aliyuncs.com/releases/v0.2.0/install.sh",
+      fallbackBaseUrl: "https://github.com/Prism-Shadow/penguin-harness/releases/download/v0.2.0",
+    };
+    expect(payloadSourceEnv(candidate, true)).toEqual({
+      downloadBaseUrl:
+        "https://penguin-harness-releases.oss-cn-beijing.aliyuncs.com/releases/v0.2.0",
+      downloadFallbackBaseUrl:
+        "https://github.com/Prism-Shadow/penguin-harness/releases/download/v0.2.0",
+    });
+    expect(payloadSourceEnv(candidate, false)).toEqual({
+      downloadBaseUrl: "",
+      downloadFallbackBaseUrl: "",
     });
   });
 

--- a/packages/landing/public/install.ps1
+++ b/packages/landing/public/install.ps1
@@ -2,8 +2,10 @@
 #
 # GitHub Pages cannot serve HTTP redirects, so this thin forwarder IS the
 # stable install URL. It selects an immutable OSS release when that mirror is
-# available, otherwise it falls back to the matching GitHub Release, then runs
-# the real installer while forwarding every argument it was given. Usage:
+# available, otherwise it falls back to GitHub, then runs the real installer
+# while forwarding every argument it was given. In auto mode the script source
+# does not lock the large payload source; the real versioned installer decides
+# that for its own release. Usage:
 #
 #   irm https://penguin.ooo/install.ps1 | iex
 #   & ([scriptblock]::Create((irm https://penguin.ooo/install.ps1))) -Version v0.2.0
@@ -136,10 +138,15 @@
       }
     }
 
-    $env:PENGUIN_DOWNLOAD_BASE_URL = $SelectedBase
-    if ($FallbackBase) {
-      $env:PENGUIN_DOWNLOAD_FALLBACK_BASE_URL = $FallbackBase
+    if ($OriginalBase) {
+      $env:PENGUIN_DOWNLOAD_BASE_URL = $SelectedBase
+      if ($FallbackBase) {
+        $env:PENGUIN_DOWNLOAD_FALLBACK_BASE_URL = $FallbackBase
+      } else {
+        Remove-Item Env:\PENGUIN_DOWNLOAD_FALLBACK_BASE_URL -ErrorAction SilentlyContinue
+      }
     } else {
+      Remove-Item Env:\PENGUIN_DOWNLOAD_BASE_URL -ErrorAction SilentlyContinue
       Remove-Item Env:\PENGUIN_DOWNLOAD_FALLBACK_BASE_URL -ErrorAction SilentlyContinue
     }
     $InstallerText = [IO.File]::ReadAllText($InstallerPath, [Text.UTF8Encoding]::new($false))

--- a/packages/landing/public/install.sh
+++ b/packages/landing/public/install.sh
@@ -3,8 +3,10 @@
 #
 # GitHub Pages cannot serve HTTP redirects, so this thin forwarder IS the
 # stable install URL. It selects an immutable OSS release when that mirror is
-# available, otherwise it falls back to the matching GitHub Release, then runs
-# the real installer while forwarding every argument it was given. Usage:
+# available, otherwise it falls back to GitHub, then runs the real installer
+# while forwarding every argument it was given. In auto mode the script source
+# does not lock the large payload source; the real versioned installer decides
+# that for its own release. Usage:
 #
 #   curl -fsSL https://penguin.ooo/install.sh | sh
 #   curl -fsSL https://penguin.ooo/install.sh | sh -s -- --universal
@@ -130,10 +132,15 @@ fi
 
 rc=0
 (
-  export PENGUIN_DOWNLOAD_BASE_URL="$SELECTED_BASE"
-  if [ -n "$FALLBACK_BASE" ]; then
-    export PENGUIN_DOWNLOAD_FALLBACK_BASE_URL="$FALLBACK_BASE"
+  if [ -n "$EXPLICIT_BASE" ]; then
+    export PENGUIN_DOWNLOAD_BASE_URL="$SELECTED_BASE"
+    if [ -n "$FALLBACK_BASE" ]; then
+      export PENGUIN_DOWNLOAD_FALLBACK_BASE_URL="$FALLBACK_BASE"
+    else
+      unset PENGUIN_DOWNLOAD_FALLBACK_BASE_URL
+    fi
   else
+    unset PENGUIN_DOWNLOAD_BASE_URL
     unset PENGUIN_DOWNLOAD_FALLBACK_BASE_URL
   fi
   sh "$INSTALLER" "$@"

--- a/scripts/generate-release-download-manifest.mjs
+++ b/scripts/generate-release-download-manifest.mjs
@@ -119,13 +119,7 @@ async function main() {
   const rows = [["penguin-release-download-manifest", "1", tag]];
   for (const probe of PROBES) {
     const info = filePath(outputDir, probe.file);
-    rows.push([
-      "probe",
-      probe.label,
-      probe.file,
-      String(info.size),
-      await sha256File(info.path),
-    ]);
+    rows.push(["probe", probe.label, probe.file, String(info.size), await sha256File(info.path)]);
   }
 
   for (const file of CLI_BUNDLES) await addRecord(rows, "asset", cliDir, file);

--- a/scripts/generate-release-download-manifest.mjs
+++ b/scripts/generate-release-download-manifest.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { createReadStream, mkdirSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const USAGE =
+  "usage: generate-release-download-manifest.mjs <tag> <output-dir> <cli-artifacts-dir> <desktop-artifacts-dir> [extra-release-file...]";
+
+const CLI_BUNDLES = [
+  "penguin-linux-x64.tar.gz",
+  "penguin-linux-arm64.tar.gz",
+  "penguin-darwin-x64.tar.gz",
+  "penguin-darwin-arm64.tar.gz",
+  "penguin-universal.tar.gz",
+  "penguin-win32-x64.zip",
+];
+
+const DESKTOP_INSTALLERS = [
+  "penguin-desktop-darwin-arm64.dmg",
+  "penguin-desktop-darwin-arm64.zip",
+  "penguin-desktop-darwin-x64.dmg",
+  "penguin-desktop-darwin-x64.zip",
+  "penguin-desktop-linux-x86_64.AppImage",
+  "penguin-desktop-linux-amd64.deb",
+  "penguin-desktop-win32-x64.exe",
+];
+
+const DESKTOP_UPDATE_METADATA = ["latest.yml", "latest-mac.yml", "latest-linux.yml"];
+
+const DESKTOP_UPDATE_BLOCKMAPS = [
+  "penguin-desktop-darwin-arm64.zip.blockmap",
+  "penguin-desktop-darwin-x64.zip.blockmap",
+  "penguin-desktop-win32-x64.exe.blockmap",
+];
+
+const PROBES = [
+  { label: "small", file: "probe-64k.bin", size: 64 * 1024 },
+  { label: "large", file: "probe-1m.bin", size: 1024 * 1024 },
+];
+
+function fail(message) {
+  console.error(`error: ${message}`);
+  console.error(USAGE);
+  process.exit(1);
+}
+
+function assertSafeTag(tag) {
+  if (!/^v[0-9A-Za-z][0-9A-Za-z._-]*$/.test(tag) || tag.includes("..")) {
+    fail(`release tag is not safe: ${tag}`);
+  }
+}
+
+function assertSafeFileName(file) {
+  if (!/^[A-Za-z0-9._+-]+$/.test(file) || file.includes("..")) {
+    fail(`release asset name is not safe: ${file}`);
+  }
+}
+
+function filePath(dir, file) {
+  assertSafeFileName(file);
+  const p = path.join(dir, file);
+  try {
+    const stat = statSync(p);
+    if (!stat.isFile()) fail(`release asset is not a file: ${p}`);
+    return { path: p, size: stat.size };
+  } catch {
+    fail(`missing release asset: ${p}`);
+  }
+}
+
+async function sha256File(file) {
+  const hash = createHash("sha256");
+  await new Promise((resolve, reject) => {
+    createReadStream(file)
+      .on("data", (chunk) => hash.update(chunk))
+      .on("error", reject)
+      .on("end", resolve);
+  });
+  return hash.digest("hex");
+}
+
+function makeProbe(size) {
+  const out = Buffer.allocUnsafe(size);
+  let offset = 0;
+  let counter = 0;
+  while (offset < size) {
+    const chunk = createHash("sha256")
+      .update("penguin-harness release probe v1\0")
+      .update(String(size))
+      .update("\0")
+      .update(String(counter))
+      .digest();
+    counter += 1;
+    const copied = chunk.copy(out, offset, 0, Math.min(chunk.length, size - offset));
+    offset += copied;
+  }
+  return out;
+}
+
+async function addRecord(rows, type, dir, file) {
+  const info = filePath(dir, file);
+  rows.push([type, file, String(info.size), await sha256File(info.path)]);
+}
+
+async function main() {
+  const [tag, outputDirArg, cliDirArg, desktopDirArg, ...extraFiles] = process.argv.slice(2);
+  if (!tag || !outputDirArg || !cliDirArg || !desktopDirArg) fail("missing required arguments");
+  assertSafeTag(tag);
+
+  const outputDir = path.resolve(outputDirArg);
+  const cliDir = path.resolve(cliDirArg);
+  const desktopDir = path.resolve(desktopDirArg);
+  mkdirSync(outputDir, { recursive: true });
+
+  for (const probe of PROBES) {
+    writeFileSync(path.join(outputDir, probe.file), makeProbe(probe.size));
+  }
+
+  const rows = [["penguin-release-download-manifest", "1", tag]];
+  for (const probe of PROBES) {
+    const info = filePath(outputDir, probe.file);
+    rows.push([
+      "probe",
+      probe.label,
+      probe.file,
+      String(info.size),
+      await sha256File(info.path),
+    ]);
+  }
+
+  for (const file of CLI_BUNDLES) await addRecord(rows, "asset", cliDir, file);
+  for (const file of CLI_BUNDLES.map((file) => `${file}.sha256`)) {
+    await addRecord(rows, "asset_checksum", cliDir, file);
+  }
+  await addRecord(rows, "asset_checksum", cliDir, "SHA256SUMS");
+
+  for (const file of DESKTOP_INSTALLERS) await addRecord(rows, "desktop_asset", desktopDir, file);
+  for (const file of DESKTOP_UPDATE_METADATA) {
+    await addRecord(rows, "desktop_update_metadata", desktopDir, file);
+  }
+
+  const availableBlockmaps = new Set(
+    readdirSync(desktopDir).filter((file) => file.endsWith(".blockmap")),
+  );
+  for (const file of DESKTOP_UPDATE_BLOCKMAPS) {
+    if (!availableBlockmaps.has(file)) fail(`missing desktop update blockmap: ${file}`);
+  }
+  const blockmaps = [...availableBlockmaps].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  for (const file of blockmaps) await addRecord(rows, "desktop_update_blockmap", desktopDir, file);
+  await addRecord(rows, "desktop_checksum", desktopDir, "SHA256SUMS.desktop");
+
+  for (const fileArg of extraFiles) {
+    const file = path.basename(fileArg);
+    if (file !== fileArg) fail(`extra release file must not contain a directory: ${fileArg}`);
+    await addRecord(rows, "installer_script", process.cwd(), file);
+  }
+
+  const manifest = rows.map((row) => row.join("\t")).join("\n") + "\n";
+  const manifestPath = path.join(outputDir, "release-download-manifest.tsv");
+  writeFileSync(manifestPath, manifest, "utf8");
+  console.log(`Generated ${manifestPath}`);
+}
+
+await main();

--- a/scripts/publish-release-to-oss.sh
+++ b/scripts/publish-release-to-oss.sh
@@ -82,6 +82,56 @@ penguin-desktop-linux-x86_64.AppImage
 penguin-desktop-linux-amd64.deb
 penguin-desktop-win32-x64.exe
 "
+DESKTOP_UPDATE_METADATA="
+latest.yml
+latest-mac.yml
+latest-linux.yml
+"
+EXPECTED_DESKTOP_UPDATE_BLOCKMAPS="
+penguin-desktop-darwin-arm64.zip.blockmap
+penguin-desktop-darwin-x64.zip.blockmap
+penguin-desktop-win32-x64.exe.blockmap
+"
+
+if [ -f "$RELEASE_DIR/release-download-manifest.tsv" ]; then
+  RELEASE_PROBES_AND_MANIFEST="
+probe-64k.bin
+probe-1m.bin
+release-download-manifest.tsv
+"
+else
+  if [ -f "$RELEASE_DIR/probe-64k.bin" ] || [ -f "$RELEASE_DIR/probe-1m.bin" ]; then
+    echo "error: release probes are present but release-download-manifest.tsv is missing" >&2
+    exit 1
+  fi
+  RELEASE_PROBES_AND_MANIFEST=""
+  echo "No release download manifest found; mirroring legacy release assets."
+fi
+
+PRESENT_DESKTOP_UPDATE_METADATA=""
+for file in $DESKTOP_UPDATE_METADATA; do
+  if [ -f "$RELEASE_DIR/$file" ]; then
+    PRESENT_DESKTOP_UPDATE_METADATA="$PRESENT_DESKTOP_UPDATE_METADATA
+$file"
+  elif [ -n "$RELEASE_PROBES_AND_MANIFEST" ]; then
+    echo "error: missing desktop update metadata for release manifest contract: $file" >&2
+    exit 1
+  fi
+done
+
+for file in $EXPECTED_DESKTOP_UPDATE_BLOCKMAPS; do
+  if [ ! -f "$RELEASE_DIR/$file" ] && [ -n "$RELEASE_PROBES_AND_MANIFEST" ]; then
+    echo "error: missing desktop update blockmap for release manifest contract: $file" >&2
+    exit 1
+  fi
+done
+PRESENT_DESKTOP_UPDATE_BLOCKMAPS="$(
+  for path in "$RELEASE_DIR"/*.blockmap; do
+    [ -f "$path" ] || continue
+    basename "$path"
+  done | LC_ALL=C sort
+)"
+
 FILES="$BUNDLES
 penguin-linux-x64.tar.gz.sha256
 penguin-linux-arm64.tar.gz.sha256
@@ -91,7 +141,10 @@ penguin-universal.tar.gz.sha256
 penguin-win32-x64.zip.sha256
 SHA256SUMS
 $DESKTOP_INSTALLERS
+$PRESENT_DESKTOP_UPDATE_METADATA
+$PRESENT_DESKTOP_UPDATE_BLOCKMAPS
 SHA256SUMS.desktop
+$RELEASE_PROBES_AND_MANIFEST
 install.sh
 install.ps1
 "
@@ -148,6 +201,107 @@ file_sha256() {
   sha256sum "$1" | awk '{print $1}'
 }
 
+validate_release_download_manifest() {
+  manifest="$RELEASE_DIR/release-download-manifest.tsv"
+  [ -f "$manifest" ] || return 0
+
+  expected_header="$(printf 'penguin-release-download-manifest\t1\t%s' "$TAG")"
+  tab="$(printf '\t')"
+  line_no=0
+  while IFS= read -r line || [ -n "$line" ]; do
+    line_no=$((line_no + 1))
+    if [ "$line_no" -eq 1 ]; then
+      [ "$line" = "$expected_header" ] || {
+        echo "error: release-download-manifest.tsv header does not match $TAG" >&2
+        exit 1
+      }
+      continue
+    fi
+    [ -n "$line" ] || {
+      echo "error: release-download-manifest.tsv has an empty row at line $line_no" >&2
+      exit 1
+    }
+
+    old_ifs="$IFS"
+    IFS="$tab"
+    set -- $line
+    IFS="$old_ifs"
+
+    case "${1:-}" in
+      probe)
+        [ "$#" -eq 5 ] || {
+          echo "error: probe row $line_no must have 5 fields" >&2
+          exit 1
+        }
+        file="$3"
+        size="$4"
+        hash="$5"
+        ;;
+      asset|asset_checksum|desktop_asset|desktop_update_metadata|desktop_update_blockmap|desktop_checksum|installer_script)
+        [ "$#" -eq 4 ] || {
+          echo "error: manifest row $line_no must have 4 fields" >&2
+          exit 1
+        }
+        file="$2"
+        size="$3"
+        hash="$4"
+        ;;
+      *)
+        echo "error: unknown manifest row type at line $line_no: ${1:-}" >&2
+        exit 1
+        ;;
+    esac
+
+    case "$file" in
+      ""|*[!A-Za-z0-9._+-]*|*..*)
+        echo "error: unsafe filename in release-download-manifest.tsv line $line_no: $file" >&2
+        exit 1
+        ;;
+    esac
+    case "$size" in
+      ""|*[!0-9]*)
+        echo "error: invalid size in release-download-manifest.tsv line $line_no: $size" >&2
+        exit 1
+        ;;
+    esac
+    if ! [ "$size" -gt 0 ] 2>/dev/null; then
+      echo "error: non-positive size in release-download-manifest.tsv line $line_no: $size" >&2
+      exit 1
+    fi
+    case "$hash" in
+      ""|*[!0-9a-f]*)
+        echo "error: invalid sha256 in release-download-manifest.tsv line $line_no: $hash" >&2
+        exit 1
+        ;;
+    esac
+    [ "${#hash}" -eq 64 ] || {
+      echo "error: sha256 has wrong length in release-download-manifest.tsv line $line_no" >&2
+      exit 1
+    }
+
+    local_file="$RELEASE_DIR/$file"
+    [ -f "$local_file" ] || {
+      echo "error: manifest references missing release asset: $file" >&2
+      exit 1
+    }
+    actual_size="$(wc -c < "$local_file" | tr -d ' ')"
+    [ "$actual_size" = "$size" ] || {
+      echo "error: manifest size mismatch for $file: expected $size, got $actual_size" >&2
+      exit 1
+    }
+    actual_hash="$(file_sha256 "$local_file")"
+    [ "$actual_hash" = "$hash" ] || {
+      echo "error: manifest sha256 mismatch for $file" >&2
+      exit 1
+    }
+  done < "$manifest"
+
+  [ "$line_no" -gt 1 ] || {
+    echo "error: release-download-manifest.tsv has no asset rows" >&2
+    exit 1
+  }
+}
+
 verify_remote_file() {
   local_file="$1"
   remote_uri="$2"
@@ -187,6 +341,8 @@ upload_immutable_file() {
   fi
   verify_remote_file "$local_file" "$remote_uri"
 }
+
+validate_release_download_manifest
 
 RELEASE_PREFIX="releases/$TAG"
 for file in $FILES; do

--- a/scripts/test-installer.ps1
+++ b/scripts/test-installer.ps1
@@ -14,6 +14,7 @@ $OriginalOs = $env:OS
 $OriginalDownloadBaseUrl = $env:PENGUIN_DOWNLOAD_BASE_URL
 $OriginalDownloadFallbackBaseUrl = $env:PENGUIN_DOWNLOAD_FALLBACK_BASE_URL
 $OriginalDownloadSource = $env:PENGUIN_DOWNLOAD_SOURCE
+$OriginalDownloadBenchmark = $env:PENGUIN_DOWNLOAD_BENCHMARK
 $OriginalArchive = $env:PENGUIN_ARCHIVE
 $OriginalInstallDir = $env:PENGUIN_INSTALL_DIR
 $OriginalVersion = $env:PENGUIN_VERSION
@@ -24,6 +25,10 @@ $Fixture = @{
   BadInnerBundle = $null
   LegacyArchive = $null
   Installer = $Installer
+  Probe64 = $null
+  Probe64Hash = $null
+  Probe1M = $null
+  Probe1MHash = $null
 }
 $global:PenguinInstallerFixture = $Fixture
 
@@ -77,6 +82,9 @@ function global:Invoke-WebRequest {
   if ($f.Mode -eq "forwarder-auto-github" -and $Uri -like "*/latest.json") {
     throw "fixture OSS metadata failure"
   }
+  if ($f.Mode -eq "benchmark-missing-manifest" -and $Uri -like "*/release-download-manifest.tsv") {
+    throw "fixture missing release download manifest"
+  }
   switch -Wildcard ($Uri) {
     "*/latest.json" {
       if ($f.Mode -eq "forwarder-invalid-metadata") {
@@ -89,6 +97,24 @@ function global:Invoke-WebRequest {
           releaseBaseUrl = "https://penguin-harness-releases.oss-cn-beijing.aliyuncs.com/releases/v0.0.0-test"
         } | ConvertTo-Json | Set-Content -LiteralPath $OutFile -Encoding ascii
       }
+    }
+    "*/release-download-manifest.tsv" {
+      if ($f.Mode -eq "benchmark-small") {
+        @(
+          "penguin-release-download-manifest`t1`tv0.0.0-test"
+          "probe`tsmall`tprobe-64k.bin`t65536`t$($f.Probe64Hash)"
+          "probe`tlarge`tprobe-1m.bin`t1048576`t$($f.Probe1MHash)"
+          "asset`tpenguin-win32-x64.zip`t16777216`t$((Get-FileHash -Algorithm SHA256 -LiteralPath $f.GoodBundle).Hash.ToLowerInvariant())"
+        ) | Set-Content -LiteralPath $OutFile -Encoding ascii
+      } else {
+        throw "unexpected manifest request: $Uri"
+      }
+    }
+    "*/probe-64k.bin" {
+      Copy-Item -LiteralPath $f.Probe64 -Destination $OutFile
+    }
+    "*/probe-1m.bin" {
+      Copy-Item -LiteralPath $f.Probe1M -Destination $OutFile
     }
     "*/install.ps1" {
       Copy-Item -LiteralPath $f.Installer -Destination $OutFile
@@ -120,7 +146,8 @@ function Invoke-OnlineCase(
   [string]$Version,
   [bool]$ShouldSucceed,
   [int]$ExpectedRequests,
-  [string]$InstallerPath = ""
+  [string]$InstallerPath = "",
+  [string]$Benchmark = "0"
 ) {
   $Fixture.Mode = $Mode
   $Fixture.Requests.Clear()
@@ -128,10 +155,11 @@ function Invoke-OnlineCase(
   $Arguments = @{ InstallDir = $InstallDir }
   if ($Version) { $Arguments.Version = $Version }
   if (-not $InstallerPath) { $InstallerPath = $Installer }
+  $env:PENGUIN_DOWNLOAD_BENCHMARK = $Benchmark
   $Succeeded = $true
   $Output = @()
-  try { $Output = @(& $InstallerPath @Arguments *>&1) } catch { $Succeeded = $false }
-  Assert-True ($Succeeded -eq $ShouldSucceed) "$Name returned an unexpected result"
+  try { $Output = @(& $InstallerPath @Arguments *>&1) } catch { $Succeeded = $false; $Output += $_ }
+  Assert-True ($Succeeded -eq $ShouldSucceed) "$Name returned an unexpected result: $(($Output | Out-String).Trim())"
   Assert-True ($Fixture.Requests.Count -eq $ExpectedRequests) `
     "$Name made $($Fixture.Requests.Count) requests, expected $ExpectedRequests"
   [PSCustomObject]@{ InstallDir = $InstallDir; Requests = @($Fixture.Requests); Output = @($Output) }
@@ -175,7 +203,7 @@ try {
   # Keep the fixture tests away from the runner's user registry Path.
   $env:OS = "PenguinInstallerFixtureTest"
   Remove-Item Env:\PENGUIN_DOWNLOAD_BASE_URL, Env:\PENGUIN_DOWNLOAD_FALLBACK_BASE_URL, `
-    Env:\PENGUIN_DOWNLOAD_SOURCE, Env:\PENGUIN_ARCHIVE, Env:\PENGUIN_INSTALL_DIR, `
+    Env:\PENGUIN_DOWNLOAD_SOURCE, Env:\PENGUIN_DOWNLOAD_BENCHMARK, Env:\PENGUIN_ARCHIVE, Env:\PENGUIN_INSTALL_DIR, `
     Env:\PENGUIN_VERSION -ErrorAction SilentlyContinue
 
   # --- Offline program archive: good install, then a failing upgrade must roll back. ---
@@ -219,6 +247,12 @@ try {
     Set-Content -LiteralPath "$($Fixture.BadInnerBundle).sha256" -Encoding ascii
 
   $Fixture.LegacyArchive = $GoodArchive
+  $Fixture.Probe64 = Join-Path $WorkDir "probe-64k.bin"
+  $Fixture.Probe1M = Join-Path $WorkDir "probe-1m.bin"
+  [IO.File]::WriteAllBytes($Fixture.Probe64, [byte[]]::new(65536))
+  [IO.File]::WriteAllBytes($Fixture.Probe1M, [byte[]]::new(1048576))
+  $Fixture.Probe64Hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $Fixture.Probe64).Hash.ToLowerInvariant()
+  $Fixture.Probe1MHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $Fixture.Probe1M).Hash.ToLowerInvariant()
 
   # Model the release workflow's installer stamping without changing the source installer.
   $StampedInstaller = Join-Path $WorkDir "install-v0.0.0-test.ps1"
@@ -265,6 +299,18 @@ try {
     "stamped installer did not try its own OSS release first"
   Assert-True ($stampedFallback.Requests[1] -like "https://github.com/*/releases/download/v0.0.0-test/penguin-win32-x64.zip") `
     "stamped installer did not fall back to the same GitHub version"
+
+  $benchmarkSmall = Invoke-OnlineCase "benchmark-small" "benchmark-small" "" $true 5 $StampedInstaller "1"
+  Assert-True (($benchmarkSmall.Requests | Out-String) -match 'release-download-manifest\.tsv') `
+    "benchmark did not request the release download manifest"
+  Assert-True (($benchmarkSmall.Requests | Out-String) -match 'probe-64k\.bin') `
+    "benchmark did not request the small probe"
+  Assert-True ($benchmarkSmall.Requests[-2] -like "https://penguin-harness-releases.oss-cn-beijing.aliyuncs.com/*/penguin-win32-x64.zip") `
+    "small benchmark path did not keep the default OSS source"
+
+  $benchmarkMissing = Invoke-OnlineCase "benchmark-missing-manifest" "benchmark-missing-manifest" "" $true 4 $StampedInstaller "1"
+  Assert-True (($benchmarkMissing.Output | Out-String) -match 'Download source test was inconclusive') `
+    "missing benchmark manifest did not fall back to the compatible source policy"
 
   $env:PENGUIN_DOWNLOAD_SOURCE = "github"
   $stampedGitHub = Invoke-OnlineCase "stamped-github" "canonical" "" $true 2 $StampedInstaller
@@ -320,7 +366,7 @@ try {
     "pinned forwarder did not request the versioned installer"
   Assert-True ($pinnedForwarder.Requests[1] -like "*/releases/v0.0.0-test/penguin-win32-x64.zip") `
     "pinned installer did not keep the selected release version"
-  Remove-Item Env:\PENGUIN_ARCHIVE, Env:\PENGUIN_INSTALL_DIR, Env:\PENGUIN_DOWNLOAD_SOURCE, Env:\PENGUIN_VERSION -ErrorAction SilentlyContinue
+  Remove-Item Env:\PENGUIN_ARCHIVE, Env:\PENGUIN_INSTALL_DIR, Env:\PENGUIN_DOWNLOAD_SOURCE, Env:\PENGUIN_DOWNLOAD_BENCHMARK, Env:\PENGUIN_VERSION -ErrorAction SilentlyContinue
 
   Invoke-OnlineCase "outer-mismatch" "outer-sha-mismatch" "" $false 3 | Out-Null
   Invoke-OnlineCase "inner-mismatch" "inner-sha-mismatch" "" $false 3 | Out-Null
@@ -348,6 +394,11 @@ try {
     Remove-Item Env:\PENGUIN_DOWNLOAD_SOURCE -ErrorAction SilentlyContinue
   } else {
     $env:PENGUIN_DOWNLOAD_SOURCE = $OriginalDownloadSource
+  }
+  if ($null -eq $OriginalDownloadBenchmark) {
+    Remove-Item Env:\PENGUIN_DOWNLOAD_BENCHMARK -ErrorAction SilentlyContinue
+  } else {
+    $env:PENGUIN_DOWNLOAD_BENCHMARK = $OriginalDownloadBenchmark
   }
   if ($null -eq $OriginalArchive) {
     Remove-Item Env:\PENGUIN_ARCHIVE -ErrorAction SilentlyContinue

--- a/scripts/test-installer.ps1
+++ b/scripts/test-installer.ps1
@@ -14,7 +14,7 @@ $OriginalOs = $env:OS
 $OriginalDownloadBaseUrl = $env:PENGUIN_DOWNLOAD_BASE_URL
 $OriginalDownloadFallbackBaseUrl = $env:PENGUIN_DOWNLOAD_FALLBACK_BASE_URL
 $OriginalDownloadSource = $env:PENGUIN_DOWNLOAD_SOURCE
-$OriginalDownloadBenchmark = $env:PENGUIN_DOWNLOAD_BENCHMARK
+$OriginalDownloadSpeedProbe = $env:PENGUIN_DOWNLOAD_SPEED_PROBE
 $OriginalArchive = $env:PENGUIN_ARCHIVE
 $OriginalInstallDir = $env:PENGUIN_INSTALL_DIR
 $OriginalVersion = $env:PENGUIN_VERSION
@@ -82,8 +82,11 @@ function global:Invoke-WebRequest {
   if ($f.Mode -eq "forwarder-auto-github" -and $Uri -like "*/latest.json") {
     throw "fixture OSS metadata failure"
   }
-  if ($f.Mode -eq "benchmark-missing-manifest" -and $Uri -like "*/release-download-manifest.tsv") {
+  if ($f.Mode -eq "speed-probe-missing-manifest" -and $Uri -like "*/release-download-manifest.tsv") {
     throw "fixture missing release download manifest"
+  }
+  if ($f.Mode -eq "speed-probe-github-below-threshold" -and $Uri -like "https://github.com/*/probe-1m.bin") {
+    Start-Sleep -Milliseconds 4300
   }
   switch -Wildcard ($Uri) {
     "*/latest.json" {
@@ -99,12 +102,13 @@ function global:Invoke-WebRequest {
       }
     }
     "*/release-download-manifest.tsv" {
-      if ($f.Mode -eq "benchmark-small") {
+      if ($f.Mode -in @("speed-probe-small", "speed-probe-github-fast", "speed-probe-github-below-threshold")) {
+        $AssetSize = if ($f.Mode -eq "speed-probe-small") { 16777216 } else { 104857600 }
         @(
           "penguin-release-download-manifest`t1`tv0.0.0-test"
           "probe`tsmall`tprobe-64k.bin`t65536`t$($f.Probe64Hash)"
           "probe`tlarge`tprobe-1m.bin`t1048576`t$($f.Probe1MHash)"
-          "asset`tpenguin-win32-x64.zip`t16777216`t$((Get-FileHash -Algorithm SHA256 -LiteralPath $f.GoodBundle).Hash.ToLowerInvariant())"
+          "asset`tpenguin-win32-x64.zip`t$AssetSize`t$((Get-FileHash -Algorithm SHA256 -LiteralPath $f.GoodBundle).Hash.ToLowerInvariant())"
         ) | Set-Content -LiteralPath $OutFile -Encoding ascii
       } else {
         throw "unexpected manifest request: $Uri"
@@ -147,7 +151,7 @@ function Invoke-OnlineCase(
   [bool]$ShouldSucceed,
   [int]$ExpectedRequests,
   [string]$InstallerPath = "",
-  [string]$Benchmark = "0"
+  [string]$SpeedProbe = "0"
 ) {
   $Fixture.Mode = $Mode
   $Fixture.Requests.Clear()
@@ -155,7 +159,7 @@ function Invoke-OnlineCase(
   $Arguments = @{ InstallDir = $InstallDir }
   if ($Version) { $Arguments.Version = $Version }
   if (-not $InstallerPath) { $InstallerPath = $Installer }
-  $env:PENGUIN_DOWNLOAD_BENCHMARK = $Benchmark
+  $env:PENGUIN_DOWNLOAD_SPEED_PROBE = $SpeedProbe
   $Succeeded = $true
   $Output = @()
   try { $Output = @(& $InstallerPath @Arguments *>&1) } catch { $Succeeded = $false; $Output += $_ }
@@ -171,7 +175,8 @@ function Invoke-ForwarderCase(
   [string]$Source,
   [int]$ExpectedRequests,
   [string]$Version = "",
-  [bool]$ShouldSucceed = $true
+  [bool]$ShouldSucceed = $true,
+  [string]$SpeedProbe = "0"
 ) {
   $Fixture.Mode = $Mode
   $Fixture.Requests.Clear()
@@ -185,6 +190,7 @@ function Invoke-ForwarderCase(
   }
   $env:PENGUIN_INSTALL_DIR = $InstallDir
   $env:PENGUIN_DOWNLOAD_SOURCE = $Source
+  $env:PENGUIN_DOWNLOAD_SPEED_PROBE = $SpeedProbe
   Remove-Item Env:\PENGUIN_DOWNLOAD_BASE_URL, Env:\PENGUIN_DOWNLOAD_FALLBACK_BASE_URL -ErrorAction SilentlyContinue
   $Forwarder = Join-Path $RepoRoot "packages\landing\public\install.ps1"
   $Output = @()
@@ -203,7 +209,7 @@ try {
   # Keep the fixture tests away from the runner's user registry Path.
   $env:OS = "PenguinInstallerFixtureTest"
   Remove-Item Env:\PENGUIN_DOWNLOAD_BASE_URL, Env:\PENGUIN_DOWNLOAD_FALLBACK_BASE_URL, `
-    Env:\PENGUIN_DOWNLOAD_SOURCE, Env:\PENGUIN_DOWNLOAD_BENCHMARK, Env:\PENGUIN_ARCHIVE, Env:\PENGUIN_INSTALL_DIR, `
+    Env:\PENGUIN_DOWNLOAD_SOURCE, Env:\PENGUIN_DOWNLOAD_SPEED_PROBE, Env:\PENGUIN_ARCHIVE, Env:\PENGUIN_INSTALL_DIR, `
     Env:\PENGUIN_VERSION -ErrorAction SilentlyContinue
 
   # --- Offline program archive: good install, then a failing upgrade must roll back. ---
@@ -300,17 +306,25 @@ try {
   Assert-True ($stampedFallback.Requests[1] -like "https://github.com/*/releases/download/v0.0.0-test/penguin-win32-x64.zip") `
     "stamped installer did not fall back to the same GitHub version"
 
-  $benchmarkSmall = Invoke-OnlineCase "benchmark-small" "benchmark-small" "" $true 5 $StampedInstaller "1"
-  Assert-True (($benchmarkSmall.Requests | Out-String) -match 'release-download-manifest\.tsv') `
-    "benchmark did not request the release download manifest"
-  Assert-True (($benchmarkSmall.Requests | Out-String) -match 'probe-64k\.bin') `
-    "benchmark did not request the small probe"
-  Assert-True ($benchmarkSmall.Requests[-2] -like "https://penguin-harness-releases.oss-cn-beijing.aliyuncs.com/*/penguin-win32-x64.zip") `
-    "small benchmark path did not keep the default OSS source"
+  $speedProbeSmall = Invoke-OnlineCase "speed-probe-small" "speed-probe-small" "" $true 5 $StampedInstaller "1"
+  Assert-True (($speedProbeSmall.Requests | Out-String) -match 'release-download-manifest\.tsv') `
+    "speed probe did not request the release download manifest"
+  Assert-True (($speedProbeSmall.Requests | Out-String) -match 'probe-64k\.bin') `
+    "speed probe did not request the small probe"
+  Assert-True ($speedProbeSmall.Requests[-2] -like "https://penguin-harness-releases.oss-cn-beijing.aliyuncs.com/*/penguin-win32-x64.zip") `
+    "small speed probe path did not keep the default OSS source"
 
-  $benchmarkMissing = Invoke-OnlineCase "benchmark-missing-manifest" "benchmark-missing-manifest" "" $true 4 $StampedInstaller "1"
-  Assert-True (($benchmarkMissing.Output | Out-String) -match 'Download source test was inconclusive') `
-    "missing benchmark manifest did not fall back to the compatible source policy"
+  $speedProbeGitHubFast = Invoke-OnlineCase "speed-probe-github-fast" "speed-probe-github-fast" "" $true 6 $StampedInstaller "1"
+  Assert-True ($speedProbeGitHubFast.Requests[-2] -like "https://github.com/*/releases/download/v0.0.0-test/penguin-win32-x64.zip") `
+    "speed probe did not select GitHub when it met the minimum speed"
+
+  $speedProbeGitHubBelowThreshold = Invoke-OnlineCase "speed-probe-github-below-threshold" "speed-probe-github-below-threshold" "" $true 6 $StampedInstaller "1"
+  Assert-True ($speedProbeGitHubBelowThreshold.Requests[-2] -like "https://penguin-harness-releases.oss-cn-beijing.aliyuncs.com/*/penguin-win32-x64.zip") `
+    "speed probe did not keep OSS when GitHub was below the minimum speed"
+
+  $speedProbeMissing = Invoke-OnlineCase "speed-probe-missing-manifest" "speed-probe-missing-manifest" "" $true 4 $StampedInstaller "1"
+  Assert-True (($speedProbeMissing.Output | Out-String) -match 'Download source test was inconclusive') `
+    "missing speed probe manifest did not fall back to the compatible source policy"
 
   $env:PENGUIN_DOWNLOAD_SOURCE = "github"
   $stampedGitHub = Invoke-OnlineCase "stamped-github" "canonical" "" $true 2 $StampedInstaller
@@ -374,7 +388,14 @@ try {
     "pinned forwarder did not request the versioned installer"
   Assert-True ($pinnedForwarder.Requests[1] -like "*/releases/v0.0.0-test/penguin-win32-x64.zip") `
     "pinned installer did not keep the selected release version"
-  Remove-Item Env:\PENGUIN_ARCHIVE, Env:\PENGUIN_INSTALL_DIR, Env:\PENGUIN_DOWNLOAD_SOURCE, Env:\PENGUIN_DOWNLOAD_BENCHMARK, Env:\PENGUIN_VERSION -ErrorAction SilentlyContinue
+
+  $speedProbeForwarder = Invoke-ForwarderCase "forwarder-speed-probe-handoff" "speed-probe-github-fast" "auto" 7 "v0.0.0-test" $true "1"
+  Assert-True ($speedProbeForwarder.Requests[0] -like "*/releases/v0.0.0-test/install.ps1") `
+    "speed probe handoff forwarder did not fetch the versioned installer"
+  Assert-True ($speedProbeForwarder.Requests[-2] -like "https://github.com/*/releases/download/v0.0.0-test/penguin-win32-x64.zip") `
+    "forwarder locked the payload source instead of letting the installer run speed probes"
+
+  Remove-Item Env:\PENGUIN_ARCHIVE, Env:\PENGUIN_INSTALL_DIR, Env:\PENGUIN_DOWNLOAD_SOURCE, Env:\PENGUIN_DOWNLOAD_SPEED_PROBE, Env:\PENGUIN_VERSION -ErrorAction SilentlyContinue
 
   Invoke-OnlineCase "outer-mismatch" "outer-sha-mismatch" "" $false 3 | Out-Null
   Invoke-OnlineCase "inner-mismatch" "inner-sha-mismatch" "" $false 3 | Out-Null
@@ -403,10 +424,10 @@ try {
   } else {
     $env:PENGUIN_DOWNLOAD_SOURCE = $OriginalDownloadSource
   }
-  if ($null -eq $OriginalDownloadBenchmark) {
-    Remove-Item Env:\PENGUIN_DOWNLOAD_BENCHMARK -ErrorAction SilentlyContinue
+  if ($null -eq $OriginalDownloadSpeedProbe) {
+    Remove-Item Env:\PENGUIN_DOWNLOAD_SPEED_PROBE -ErrorAction SilentlyContinue
   } else {
-    $env:PENGUIN_DOWNLOAD_BENCHMARK = $OriginalDownloadBenchmark
+    $env:PENGUIN_DOWNLOAD_SPEED_PROBE = $OriginalDownloadSpeedProbe
   }
   if ($null -eq $OriginalArchive) {
     Remove-Item Env:\PENGUIN_ARCHIVE -ErrorAction SilentlyContinue

--- a/scripts/test-installer.ps1
+++ b/scripts/test-installer.ps1
@@ -338,6 +338,14 @@ try {
   Remove-Item Env:\PENGUIN_DOWNLOAD_FALLBACK_BASE_URL
   Remove-Item Env:\PENGUIN_DOWNLOAD_BASE_URL
 
+  $env:PENGUIN_DOWNLOAD_FALLBACK_BASE_URL = "https://example.invalid/releases/v0.0.0-test"
+  $fallbackWithoutBase = Invoke-OnlineCase "fallback-without-base" "primary-network" "" $true 3 $StampedInstaller
+  Assert-True (-not (($fallbackWithoutBase.Requests | Out-String) -match 'example\.invalid')) `
+    "fallback without base should not override auto/source fallback"
+  Assert-True (($fallbackWithoutBase.Requests | Out-String) -match 'github\.com/.*/releases/download/v0\.0\.0-test/penguin-win32-x64\.zip') `
+    "fallback without base did not keep the internal same-version GitHub fallback"
+  Remove-Item Env:\PENGUIN_DOWNLOAD_FALLBACK_BASE_URL
+
   $forwarderOss = Invoke-ForwarderCase "forwarder-oss" "forwarder-oss" "auto" 2
   Assert-True ($forwarderOss.Requests[0] -like "*/latest.json") `
     "OSS forwarder did not request release metadata first"

--- a/scripts/test-installer.sh
+++ b/scripts/test-installer.sh
@@ -325,7 +325,7 @@ dd if=/dev/zero of="$PROBE1M" bs=1048576 count=1 2>/dev/null
 PROBE64_HASH="$(sha256sum "$PROBE64" | awk '{ print $1 }')"
 PROBE1M_HASH="$(sha256sum "$PROBE1M" | awk '{ print $1 }')"
 HOST_ASSET_HASH="$(sha256sum "$ARTIFACT_DIR/$HOST_ASSET" | awk '{ print $1 }')"
-BENCHMARK_ASSET_SIZE=104857600
+SPEED_PROBE_ASSET_SIZE=104857600
 
 cat > "$STUB_BIN/curl" <<'EOF'
 #!/bin/sh
@@ -356,26 +356,26 @@ case "$MODE:$base" in
   canonical:latest.json | outer-sha-mismatch:latest.json | inner-sha-mismatch:latest.json | forwarder-oss:latest.json | forced-oss-payload:latest.json)
     printf '%s\n' '{"schemaVersion":1,"tag":"v0.0.0-test","releaseBaseUrl":"https://penguin-harness-releases.oss-cn-beijing.aliyuncs.com/releases/v0.0.0-test"}' > "$output"
     ;;
-  benchmark-missing-manifest:release-download-manifest.tsv) exit 22 ;;
-  benchmark-github-fast:release-download-manifest.tsv | benchmark-github-slightly-fast:release-download-manifest.tsv | benchmark-missing-manifest-github:release-download-manifest.tsv)
+  speed-probe-missing-manifest:release-download-manifest.tsv) exit 22 ;;
+  speed-probe-github-fast:release-download-manifest.tsv | speed-probe-github-below-threshold:release-download-manifest.tsv | speed-probe-missing-manifest-github:release-download-manifest.tsv)
     {
       printf 'penguin-release-download-manifest\t1\tv0.0.0-test\n'
       printf 'probe\tsmall\tprobe-64k.bin\t65536\t%s\n' "$PROBE64_HASH"
       printf 'probe\tlarge\tprobe-1m.bin\t1048576\t%s\n' "$PROBE1M_HASH"
-      printf 'asset\t%s\t%s\t%s\n' "$HOST_ASSET" "$BENCHMARK_ASSET_SIZE" "$HOST_ASSET_HASH"
+      printf 'asset\t%s\t%s\t%s\n' "$HOST_ASSET" "$SPEED_PROBE_ASSET_SIZE" "$HOST_ASSET_HASH"
     } > "$output"
     ;;
-  benchmark-github-fast:probe-64k.bin | benchmark-github-slightly-fast:probe-64k.bin) cp "$PROBE64" "$output" ;;
-  benchmark-github-fast:probe-1m.bin | benchmark-github-slightly-fast:probe-1m.bin) cp "$PROBE1M" "$output" ;;
-  forwarder-oss:install.sh | forced-oss-payload:install.sh | forwarder-auto-github:install.sh | forwarder-invalid-metadata:install.sh | canonical:install.sh | benchmark-github-fast:install.sh | benchmark-github-slightly-fast:install.sh) cp "$ROOT_DIR/install.sh" "$output" ;;
+  speed-probe-github-fast:probe-64k.bin | speed-probe-github-below-threshold:probe-64k.bin) cp "$PROBE64" "$output" ;;
+  speed-probe-github-fast:probe-1m.bin | speed-probe-github-below-threshold:probe-1m.bin) cp "$PROBE1M" "$output" ;;
+  forwarder-oss:install.sh | forced-oss-payload:install.sh | forwarder-auto-github:install.sh | forwarder-invalid-metadata:install.sh | canonical:install.sh | speed-probe-github-fast:install.sh | speed-probe-github-below-threshold:install.sh) cp "$ROOT_DIR/install.sh" "$output" ;;
   404:penguin-*) exit 22 ;;
   network:penguin-*) exit 7 ;;
   outer-sha-mismatch:penguin-*.sha256) printf '%064d  %s\n' 0 "${base%.sha256}" > "$output" ;;
   outer-sha-mismatch:penguin-*) cp "$ARTIFACT_DIR/$base" "$output" ;;
   inner-sha-mismatch:penguin-*.sha256) cp "$BAD_BUNDLE.sha256" "$output" ;;
   inner-sha-mismatch:penguin-*) cp "$BAD_BUNDLE" "$output" ;;
-  benchmark-github-fast:penguin-*.sha256 | benchmark-github-slightly-fast:penguin-*.sha256 | benchmark-missing-manifest:penguin-*.sha256) cp "$ARTIFACT_DIR/$base" "$output" ;;
-  benchmark-github-fast:penguin-* | benchmark-github-slightly-fast:penguin-* | benchmark-missing-manifest:penguin-*) cp "$ARTIFACT_DIR/$base" "$output" ;;
+  speed-probe-github-fast:penguin-*.sha256 | speed-probe-github-below-threshold:penguin-*.sha256 | speed-probe-missing-manifest:penguin-*.sha256) cp "$ARTIFACT_DIR/$base" "$output" ;;
+  speed-probe-github-fast:penguin-* | speed-probe-github-below-threshold:penguin-* | speed-probe-missing-manifest:penguin-*) cp "$ARTIFACT_DIR/$base" "$output" ;;
   primary-network:penguin-*.sha256) cp "$ARTIFACT_DIR/$base" "$output" ;;
   primary-network:penguin-*) cp "$ARTIFACT_DIR/$base" "$output" ;;
   forced-oss-payload:penguin-*.sha256) cp "$ARTIFACT_DIR/$base" "$output" ;;
@@ -388,17 +388,17 @@ case "$MODE:$base" in
 esac
 if [ -n "$writeout" ]; then
   case "$MODE:$url" in
-    benchmark-github-fast:https://github.com/*/probe-1m.bin) printf '%s' '0.020 0.120 8738133' ;;
-    benchmark-github-fast:*aliyuncs.com*/probe-1m.bin) printf '%s' '0.100 2.100 499321' ;;
-    benchmark-github-slightly-fast:https://github.com/*/probe-1m.bin) printf '%s' '0.020 0.115 9118052' ;;
-    benchmark-github-slightly-fast:*aliyuncs.com*/probe-1m.bin) printf '%s' '0.020 0.120 8738133' ;;
-    benchmark-github-fast:*) printf '%s' '0.020 0.060 1092266' ;;
+    speed-probe-github-fast:https://github.com/*/probe-1m.bin) printf '%s' '0.020 0.120 8738133' ;;
+    speed-probe-github-fast:*aliyuncs.com*/probe-1m.bin) printf '%s' '0.100 2.100 499321' ;;
+    speed-probe-github-below-threshold:https://github.com/*/probe-1m.bin) printf '%s' '0.020 4.287 245760' ;;
+    speed-probe-github-below-threshold:*aliyuncs.com*/probe-1m.bin) printf '%s' '0.020 5.140 204800' ;;
+    speed-probe-github-fast:*) printf '%s' '0.020 0.060 1092266' ;;
     *) printf '%s' '0.010 0.020 3276800' ;;
   esac
 fi
 EOF
 chmod +x "$STUB_BIN/curl"
-export ARTIFACT_DIR BAD_BUNDLE LEGACY_ARCHIVE ROOT_DIR PROBE64 PROBE1M PROBE64_HASH PROBE1M_HASH HOST_ASSET HOST_ASSET_HASH BENCHMARK_ASSET_SIZE
+export ARTIFACT_DIR BAD_BUNDLE LEGACY_ARCHIVE ROOT_DIR PROBE64 PROBE1M PROBE64_HASH PROBE1M_HASH HOST_ASSET HOST_ASSET_HASH SPEED_PROBE_ASSET_SIZE
 
 run_online_case() {
   name="$1"
@@ -410,7 +410,7 @@ run_online_case() {
   download_fallback_base_url="${7:-}"
   installer_path="${8:-$ROOT_DIR/install.sh}"
   source_mode="${9:-auto}"
-  benchmark="${10:-0}"
+  speed_probe="${10:-0}"
   CASE_LOG="$WORK_DIR/$name.log"
   CASE_OUTPUT="$WORK_DIR/$name.output"
   CASE_INSTALL="$WORK_DIR/$name-install"
@@ -420,7 +420,7 @@ run_online_case() {
     HOME="$WORK_DIR/$name-home" PENGUIN_INSTALL_DIR="$CASE_INSTALL" \
     PENGUIN_VERSION="$version" PENGUIN_DOWNLOAD_BASE_URL="$download_base_url" \
     PENGUIN_DOWNLOAD_FALLBACK_BASE_URL="$download_fallback_base_url" \
-    PENGUIN_DOWNLOAD_SOURCE="$source_mode" PENGUIN_DOWNLOAD_BENCHMARK="$benchmark" \
+    PENGUIN_DOWNLOAD_SOURCE="$source_mode" PENGUIN_DOWNLOAD_SPEED_PROBE="$speed_probe" \
     sh "$installer_path" >"$CASE_OUTPUT" 2>&1
   status=$?
   set -e
@@ -455,18 +455,18 @@ run_online_case stamped-fallback primary-network "" success 3 "" "" "$STAMPED_IN
 grep -q "github.com/.*/releases/download/v0.0.0-test/$HOST_ASSET\$" "$WORK_DIR/stamped-fallback.log" \
   || fail_test "stamped installer did not fall back to the same GitHub version"
 
-run_online_case benchmark-github-fast benchmark-github-fast "" success 7 "" "" "$STAMPED_INSTALLER" auto 1
-[ "$(grep -c "/$HOST_ASSET\$" "$WORK_DIR/benchmark-github-fast.log" | tr -d ' ')" -eq 1 ] \
-  || fail_test "benchmark selected more than one primary bundle download"
-grep -q "github.com/.*/releases/download/v0.0.0-test/$HOST_ASSET\$" "$WORK_DIR/benchmark-github-fast.log" \
-  || fail_test "benchmark did not select the faster GitHub source"
-run_online_case benchmark-github-slightly-fast benchmark-github-slightly-fast "" success 7 "" "" "$STAMPED_INSTALLER" auto 1
-grep -q "github.com/.*/releases/download/v0.0.0-test/$HOST_ASSET\$" "$WORK_DIR/benchmark-github-slightly-fast.log" \
-  || fail_test "benchmark did not select the shorter estimated GitHub source"
+run_online_case speed-probe-github-fast speed-probe-github-fast "" success 6 "" "" "$STAMPED_INSTALLER" auto 1
+[ "$(grep -c "/$HOST_ASSET\$" "$WORK_DIR/speed-probe-github-fast.log" | tr -d ' ')" -eq 1 ] \
+  || fail_test "speed probe selected more than one primary bundle download"
+grep -q "github.com/.*/releases/download/v0.0.0-test/$HOST_ASSET\$" "$WORK_DIR/speed-probe-github-fast.log" \
+  || fail_test "speed probe did not select GitHub when it met the minimum speed"
+run_online_case speed-probe-github-below-threshold speed-probe-github-below-threshold "" success 6 "" "" "$STAMPED_INSTALLER" auto 1
+grep -q "penguin-harness-releases.oss-cn-beijing.aliyuncs.com/.*/$HOST_ASSET\$" "$WORK_DIR/speed-probe-github-below-threshold.log" \
+  || fail_test "speed probe did not keep OSS when GitHub was below the minimum speed"
 
-run_online_case benchmark-missing-manifest benchmark-missing-manifest "" success 4 "" "" "$STAMPED_INSTALLER" auto 1
-grep -q "Download source test was inconclusive" "$WORK_DIR/benchmark-missing-manifest.output" \
-  || fail_test "missing benchmark manifest did not fall back to the compatible source policy"
+run_online_case speed-probe-missing-manifest speed-probe-missing-manifest "" success 4 "" "" "$STAMPED_INSTALLER" auto 1
+grep -q "Download source test was inconclusive" "$WORK_DIR/speed-probe-missing-manifest.output" \
+  || fail_test "missing speed probe manifest did not fall back to the compatible source policy"
 
 run_online_case stamped-github canonical "" success 2 "" "" "$STAMPED_INSTALLER" github
 grep -q "github.com/.*/releases/download/v0.0.0-test/$HOST_ASSET\$" "$WORK_DIR/stamped-github.log" \
@@ -511,7 +511,7 @@ run_forwarder_case() {
   source="${4:-auto}"
   version="${5:-}"
   expected="${6:-success}"
-  benchmark="${7:-0}"
+  speed_probe="${7:-0}"
   CASE_LOG="$WORK_DIR/$name.log"
   CASE_OUTPUT="$WORK_DIR/$name.output"
   CASE_INSTALL="$WORK_DIR/$name-install"
@@ -526,7 +526,7 @@ run_forwarder_case() {
     HOME="$WORK_DIR/$name-home" PENGUIN_INSTALL_DIR="$CASE_INSTALL" \
     PENGUIN_ARCHIVE="$archive" PENGUIN_VERSION="$version" \
     PENGUIN_DOWNLOAD_SOURCE="$source" PENGUIN_DOWNLOAD_BASE_URL="" \
-    PENGUIN_DOWNLOAD_FALLBACK_BASE_URL="" PENGUIN_DOWNLOAD_BENCHMARK="$benchmark" \
+    PENGUIN_DOWNLOAD_FALLBACK_BASE_URL="" PENGUIN_DOWNLOAD_SPEED_PROBE="$speed_probe" \
     sh "$ROOT_DIR/packages/landing/public/install.sh" >"$CASE_OUTPUT" 2>&1
   status=$?
   set -e
@@ -571,11 +571,11 @@ run_forwarder_case forwarder-pinned canonical 3 auto v0.0.0-test
   "https://penguin-harness-releases.oss-cn-beijing.aliyuncs.com/releases/v0.0.0-test/$HOST_ASSET" ] \
   || fail_test "pinned installer did not keep the selected release version"
 
-run_forwarder_case forwarder-benchmark-handoff benchmark-github-fast 8 auto v0.0.0-test success 1
-[ "$(sed -n '1p' "$WORK_DIR/forwarder-benchmark-handoff.log")" = \
+run_forwarder_case forwarder-speed-probe-handoff speed-probe-github-fast 8 auto v0.0.0-test success 1
+[ "$(sed -n '1p' "$WORK_DIR/forwarder-speed-probe-handoff.log")" = \
   "https://penguin-harness-releases.oss-cn-beijing.aliyuncs.com/releases/v0.0.0-test/install.sh" ] \
-  || fail_test "benchmark handoff forwarder did not fetch the versioned OSS installer"
-grep -q "github.com/.*/releases/download/v0.0.0-test/$HOST_ASSET\$" "$WORK_DIR/forwarder-benchmark-handoff.log" \
-  || fail_test "forwarder locked the payload source instead of letting the installer benchmark"
+  || fail_test "speed probe handoff forwarder did not fetch the versioned OSS installer"
+grep -q "github.com/.*/releases/download/v0.0.0-test/$HOST_ASSET\$" "$WORK_DIR/forwarder-speed-probe-handoff.log" \
+  || fail_test "forwarder locked the payload source instead of letting the installer speed probe"
 
 echo "Installer bundle, offline, rollback and online tests passed."

--- a/scripts/test-installer.sh
+++ b/scripts/test-installer.sh
@@ -482,6 +482,12 @@ grep -q "github.com/.*/releases/download/v0.0.0-test/$HOST_ASSET\$" "$WORK_DIR/d
   || fail_test "download fallback did not use the same-version GitHub source"
 ! grep -q "aliyuncs.com" "$WORK_DIR/download-fallback.output" \
   || fail_test "download fallback exposed the OSS URL in normal output"
+run_online_case fallback-without-base primary-network "" success 3 "" \
+  "https://example.invalid/releases/v0.0.0-test" "$STAMPED_INSTALLER"
+! grep -q "example.invalid" "$WORK_DIR/fallback-without-base.log" \
+  || fail_test "fallback without base should not override auto/source fallback"
+grep -q "github.com/.*/releases/download/v0.0.0-test/$HOST_ASSET\$" "$WORK_DIR/fallback-without-base.log" \
+  || fail_test "fallback without base did not keep the internal same-version GitHub fallback"
 run_online_case outer-mismatch outer-sha-mismatch "" failure 3
 run_online_case inner-mismatch inner-sha-mismatch "" failure 3
 run_online_case latest-404 404 "" failure 2

--- a/scripts/test-installer.sh
+++ b/scripts/test-installer.sh
@@ -571,10 +571,12 @@ run_forwarder_case forwarder-pinned canonical 3 auto v0.0.0-test
   "https://penguin-harness-releases.oss-cn-beijing.aliyuncs.com/releases/v0.0.0-test/$HOST_ASSET" ] \
   || fail_test "pinned installer did not keep the selected release version"
 
-run_forwarder_case forwarder-speed-probe-handoff speed-probe-github-fast 8 auto v0.0.0-test success 1
+run_forwarder_case forwarder-speed-probe-handoff speed-probe-github-fast 7 auto v0.0.0-test success 1
 [ "$(sed -n '1p' "$WORK_DIR/forwarder-speed-probe-handoff.log")" = \
   "https://penguin-harness-releases.oss-cn-beijing.aliyuncs.com/releases/v0.0.0-test/install.sh" ] \
   || fail_test "speed probe handoff forwarder did not fetch the versioned OSS installer"
+! grep -q "penguin-harness-releases.oss-cn-beijing.aliyuncs.com/.*/$HOST_ASSET\$" "$WORK_DIR/forwarder-speed-probe-handoff.log" \
+  || fail_test "forwarder locked the payload source to OSS instead of letting the installer speed probe"
 grep -q "github.com/.*/releases/download/v0.0.0-test/$HOST_ASSET\$" "$WORK_DIR/forwarder-speed-probe-handoff.log" \
   || fail_test "forwarder locked the payload source instead of letting the installer speed probe"
 

--- a/scripts/test-installer.sh
+++ b/scripts/test-installer.sh
@@ -318,15 +318,26 @@ BAD_BUNDLE="$WORK_DIR/bad-bundle.tar.gz"
 tar -czf "$BAD_BUNDLE" -C "$BAD_DIR" .
 write_sha256 "$BAD_BUNDLE"
 
+PROBE64="$WORK_DIR/probe-64k.bin"
+PROBE1M="$WORK_DIR/probe-1m.bin"
+dd if=/dev/zero of="$PROBE64" bs=65536 count=1 2>/dev/null
+dd if=/dev/zero of="$PROBE1M" bs=1048576 count=1 2>/dev/null
+PROBE64_HASH="$(sha256sum "$PROBE64" | awk '{ print $1 }')"
+PROBE1M_HASH="$(sha256sum "$PROBE1M" | awk '{ print $1 }')"
+HOST_ASSET_HASH="$(sha256sum "$ARTIFACT_DIR/$HOST_ASSET" | awk '{ print $1 }')"
+BENCHMARK_ASSET_SIZE=104857600
+
 cat > "$STUB_BIN/curl" <<'EOF'
 #!/bin/sh
 set -eu
 output=""
 url=""
+writeout=""
 while [ $# -gt 0 ]; do
   case "$1" in
     -o) output="$2"; shift 2 ;;
-    --connect-timeout | --max-time) shift 2 ;;
+    -w | --write-out) writeout="$2"; shift 2 ;;
+    -H | --header | --connect-timeout | --max-time | --speed-limit | --speed-time) shift 2 ;;
     -*) shift ;;
     *) url="$1"; shift ;;
   esac
@@ -345,13 +356,26 @@ case "$MODE:$base" in
   canonical:latest.json | outer-sha-mismatch:latest.json | inner-sha-mismatch:latest.json | forwarder-oss:latest.json | forced-oss-payload:latest.json)
     printf '%s\n' '{"schemaVersion":1,"tag":"v0.0.0-test","releaseBaseUrl":"https://penguin-harness-releases.oss-cn-beijing.aliyuncs.com/releases/v0.0.0-test"}' > "$output"
     ;;
-  forwarder-oss:install.sh | forced-oss-payload:install.sh | forwarder-auto-github:install.sh | forwarder-invalid-metadata:install.sh | canonical:install.sh) cp "$ROOT_DIR/install.sh" "$output" ;;
+  benchmark-missing-manifest:release-download-manifest.tsv) exit 22 ;;
+  benchmark-github-fast:release-download-manifest.tsv | benchmark-missing-manifest-github:release-download-manifest.tsv)
+    {
+      printf 'penguin-release-download-manifest\t1\tv0.0.0-test\n'
+      printf 'probe\tsmall\tprobe-64k.bin\t65536\t%s\n' "$PROBE64_HASH"
+      printf 'probe\tlarge\tprobe-1m.bin\t1048576\t%s\n' "$PROBE1M_HASH"
+      printf 'asset\t%s\t%s\t%s\n' "$HOST_ASSET" "$BENCHMARK_ASSET_SIZE" "$HOST_ASSET_HASH"
+    } > "$output"
+    ;;
+  benchmark-github-fast:probe-64k.bin) cp "$PROBE64" "$output" ;;
+  benchmark-github-fast:probe-1m.bin) cp "$PROBE1M" "$output" ;;
+  forwarder-oss:install.sh | forced-oss-payload:install.sh | forwarder-auto-github:install.sh | forwarder-invalid-metadata:install.sh | canonical:install.sh | benchmark-github-fast:install.sh) cp "$ROOT_DIR/install.sh" "$output" ;;
   404:penguin-*) exit 22 ;;
   network:penguin-*) exit 7 ;;
   outer-sha-mismatch:penguin-*.sha256) printf '%064d  %s\n' 0 "${base%.sha256}" > "$output" ;;
   outer-sha-mismatch:penguin-*) cp "$ARTIFACT_DIR/$base" "$output" ;;
   inner-sha-mismatch:penguin-*.sha256) cp "$BAD_BUNDLE.sha256" "$output" ;;
   inner-sha-mismatch:penguin-*) cp "$BAD_BUNDLE" "$output" ;;
+  benchmark-github-fast:penguin-*.sha256 | benchmark-missing-manifest:penguin-*.sha256) cp "$ARTIFACT_DIR/$base" "$output" ;;
+  benchmark-github-fast:penguin-* | benchmark-missing-manifest:penguin-*) cp "$ARTIFACT_DIR/$base" "$output" ;;
   primary-network:penguin-*.sha256) cp "$ARTIFACT_DIR/$base" "$output" ;;
   primary-network:penguin-*) cp "$ARTIFACT_DIR/$base" "$output" ;;
   forced-oss-payload:penguin-*.sha256) cp "$ARTIFACT_DIR/$base" "$output" ;;
@@ -362,9 +386,17 @@ case "$MODE:$base" in
   canonical:penguin-*) cp "$ARTIFACT_DIR/$base" "$output" ;;
   *) echo "unexpected fixture request: $url" >&2; exit 2 ;;
 esac
+if [ -n "$writeout" ]; then
+  case "$MODE:$url" in
+    benchmark-github-fast:https://github.com/*/probe-1m.bin) printf '%s' '0.020 0.120 8738133' ;;
+    benchmark-github-fast:*aliyuncs.com*/probe-1m.bin) printf '%s' '0.100 2.100 499321' ;;
+    benchmark-github-fast:*) printf '%s' '0.020 0.060 1092266' ;;
+    *) printf '%s' '0.010 0.020 3276800' ;;
+  esac
+fi
 EOF
 chmod +x "$STUB_BIN/curl"
-export ARTIFACT_DIR BAD_BUNDLE LEGACY_ARCHIVE ROOT_DIR
+export ARTIFACT_DIR BAD_BUNDLE LEGACY_ARCHIVE ROOT_DIR PROBE64 PROBE1M PROBE64_HASH PROBE1M_HASH HOST_ASSET HOST_ASSET_HASH BENCHMARK_ASSET_SIZE
 
 run_online_case() {
   name="$1"
@@ -376,6 +408,7 @@ run_online_case() {
   download_fallback_base_url="${7:-}"
   installer_path="${8:-$ROOT_DIR/install.sh}"
   source_mode="${9:-auto}"
+  benchmark="${10:-0}"
   CASE_LOG="$WORK_DIR/$name.log"
   CASE_OUTPUT="$WORK_DIR/$name.output"
   CASE_INSTALL="$WORK_DIR/$name-install"
@@ -385,7 +418,7 @@ run_online_case() {
     HOME="$WORK_DIR/$name-home" PENGUIN_INSTALL_DIR="$CASE_INSTALL" \
     PENGUIN_VERSION="$version" PENGUIN_DOWNLOAD_BASE_URL="$download_base_url" \
     PENGUIN_DOWNLOAD_FALLBACK_BASE_URL="$download_fallback_base_url" \
-    PENGUIN_DOWNLOAD_SOURCE="$source_mode" \
+    PENGUIN_DOWNLOAD_SOURCE="$source_mode" PENGUIN_DOWNLOAD_BENCHMARK="$benchmark" \
     sh "$installer_path" >"$CASE_OUTPUT" 2>&1
   status=$?
   set -e
@@ -419,6 +452,16 @@ run_online_case stamped-fallback primary-network "" success 3 "" "" "$STAMPED_IN
   || fail_test "stamped installer did not try its own OSS release first"
 grep -q "github.com/.*/releases/download/v0.0.0-test/$HOST_ASSET\$" "$WORK_DIR/stamped-fallback.log" \
   || fail_test "stamped installer did not fall back to the same GitHub version"
+
+run_online_case benchmark-github-fast benchmark-github-fast "" success 7 "" "" "$STAMPED_INSTALLER" auto 1
+[ "$(grep -c "/$HOST_ASSET\$" "$WORK_DIR/benchmark-github-fast.log" | tr -d ' ')" -eq 1 ] \
+  || fail_test "benchmark selected more than one primary bundle download"
+grep -q "github.com/.*/releases/download/v0.0.0-test/$HOST_ASSET\$" "$WORK_DIR/benchmark-github-fast.log" \
+  || fail_test "benchmark did not select the faster GitHub source"
+
+run_online_case benchmark-missing-manifest benchmark-missing-manifest "" success 4 "" "" "$STAMPED_INSTALLER" auto 1
+grep -q "Download source test was inconclusive" "$WORK_DIR/benchmark-missing-manifest.output" \
+  || fail_test "missing benchmark manifest did not fall back to the compatible source policy"
 
 run_online_case stamped-github canonical "" success 2 "" "" "$STAMPED_INSTALLER" github
 grep -q "github.com/.*/releases/download/v0.0.0-test/$HOST_ASSET\$" "$WORK_DIR/stamped-github.log" \
@@ -457,6 +500,7 @@ run_forwarder_case() {
   source="${4:-auto}"
   version="${5:-}"
   expected="${6:-success}"
+  benchmark="${7:-0}"
   CASE_LOG="$WORK_DIR/$name.log"
   CASE_OUTPUT="$WORK_DIR/$name.output"
   CASE_INSTALL="$WORK_DIR/$name-install"
@@ -471,7 +515,7 @@ run_forwarder_case() {
     HOME="$WORK_DIR/$name-home" PENGUIN_INSTALL_DIR="$CASE_INSTALL" \
     PENGUIN_ARCHIVE="$archive" PENGUIN_VERSION="$version" \
     PENGUIN_DOWNLOAD_SOURCE="$source" PENGUIN_DOWNLOAD_BASE_URL="" \
-    PENGUIN_DOWNLOAD_FALLBACK_BASE_URL="" \
+    PENGUIN_DOWNLOAD_FALLBACK_BASE_URL="" PENGUIN_DOWNLOAD_BENCHMARK="$benchmark" \
     sh "$ROOT_DIR/packages/landing/public/install.sh" >"$CASE_OUTPUT" 2>&1
   status=$?
   set -e
@@ -515,5 +559,12 @@ run_forwarder_case forwarder-pinned canonical 3 auto v0.0.0-test
 [ "$(sed -n '2p' "$WORK_DIR/forwarder-pinned.log")" = \
   "https://penguin-harness-releases.oss-cn-beijing.aliyuncs.com/releases/v0.0.0-test/$HOST_ASSET" ] \
   || fail_test "pinned installer did not keep the selected release version"
+
+run_forwarder_case forwarder-benchmark-handoff benchmark-github-fast 8 auto v0.0.0-test success 1
+[ "$(sed -n '1p' "$WORK_DIR/forwarder-benchmark-handoff.log")" = \
+  "https://penguin-harness-releases.oss-cn-beijing.aliyuncs.com/releases/v0.0.0-test/install.sh" ] \
+  || fail_test "benchmark handoff forwarder did not fetch the versioned OSS installer"
+grep -q "github.com/.*/releases/download/v0.0.0-test/$HOST_ASSET\$" "$WORK_DIR/forwarder-benchmark-handoff.log" \
+  || fail_test "forwarder locked the payload source instead of letting the installer benchmark"
 
 echo "Installer bundle, offline, rollback and online tests passed."

--- a/scripts/test-installer.sh
+++ b/scripts/test-installer.sh
@@ -357,7 +357,7 @@ case "$MODE:$base" in
     printf '%s\n' '{"schemaVersion":1,"tag":"v0.0.0-test","releaseBaseUrl":"https://penguin-harness-releases.oss-cn-beijing.aliyuncs.com/releases/v0.0.0-test"}' > "$output"
     ;;
   benchmark-missing-manifest:release-download-manifest.tsv) exit 22 ;;
-  benchmark-github-fast:release-download-manifest.tsv | benchmark-missing-manifest-github:release-download-manifest.tsv)
+  benchmark-github-fast:release-download-manifest.tsv | benchmark-github-slightly-fast:release-download-manifest.tsv | benchmark-missing-manifest-github:release-download-manifest.tsv)
     {
       printf 'penguin-release-download-manifest\t1\tv0.0.0-test\n'
       printf 'probe\tsmall\tprobe-64k.bin\t65536\t%s\n' "$PROBE64_HASH"
@@ -365,17 +365,17 @@ case "$MODE:$base" in
       printf 'asset\t%s\t%s\t%s\n' "$HOST_ASSET" "$BENCHMARK_ASSET_SIZE" "$HOST_ASSET_HASH"
     } > "$output"
     ;;
-  benchmark-github-fast:probe-64k.bin) cp "$PROBE64" "$output" ;;
-  benchmark-github-fast:probe-1m.bin) cp "$PROBE1M" "$output" ;;
-  forwarder-oss:install.sh | forced-oss-payload:install.sh | forwarder-auto-github:install.sh | forwarder-invalid-metadata:install.sh | canonical:install.sh | benchmark-github-fast:install.sh) cp "$ROOT_DIR/install.sh" "$output" ;;
+  benchmark-github-fast:probe-64k.bin | benchmark-github-slightly-fast:probe-64k.bin) cp "$PROBE64" "$output" ;;
+  benchmark-github-fast:probe-1m.bin | benchmark-github-slightly-fast:probe-1m.bin) cp "$PROBE1M" "$output" ;;
+  forwarder-oss:install.sh | forced-oss-payload:install.sh | forwarder-auto-github:install.sh | forwarder-invalid-metadata:install.sh | canonical:install.sh | benchmark-github-fast:install.sh | benchmark-github-slightly-fast:install.sh) cp "$ROOT_DIR/install.sh" "$output" ;;
   404:penguin-*) exit 22 ;;
   network:penguin-*) exit 7 ;;
   outer-sha-mismatch:penguin-*.sha256) printf '%064d  %s\n' 0 "${base%.sha256}" > "$output" ;;
   outer-sha-mismatch:penguin-*) cp "$ARTIFACT_DIR/$base" "$output" ;;
   inner-sha-mismatch:penguin-*.sha256) cp "$BAD_BUNDLE.sha256" "$output" ;;
   inner-sha-mismatch:penguin-*) cp "$BAD_BUNDLE" "$output" ;;
-  benchmark-github-fast:penguin-*.sha256 | benchmark-missing-manifest:penguin-*.sha256) cp "$ARTIFACT_DIR/$base" "$output" ;;
-  benchmark-github-fast:penguin-* | benchmark-missing-manifest:penguin-*) cp "$ARTIFACT_DIR/$base" "$output" ;;
+  benchmark-github-fast:penguin-*.sha256 | benchmark-github-slightly-fast:penguin-*.sha256 | benchmark-missing-manifest:penguin-*.sha256) cp "$ARTIFACT_DIR/$base" "$output" ;;
+  benchmark-github-fast:penguin-* | benchmark-github-slightly-fast:penguin-* | benchmark-missing-manifest:penguin-*) cp "$ARTIFACT_DIR/$base" "$output" ;;
   primary-network:penguin-*.sha256) cp "$ARTIFACT_DIR/$base" "$output" ;;
   primary-network:penguin-*) cp "$ARTIFACT_DIR/$base" "$output" ;;
   forced-oss-payload:penguin-*.sha256) cp "$ARTIFACT_DIR/$base" "$output" ;;
@@ -390,6 +390,8 @@ if [ -n "$writeout" ]; then
   case "$MODE:$url" in
     benchmark-github-fast:https://github.com/*/probe-1m.bin) printf '%s' '0.020 0.120 8738133' ;;
     benchmark-github-fast:*aliyuncs.com*/probe-1m.bin) printf '%s' '0.100 2.100 499321' ;;
+    benchmark-github-slightly-fast:https://github.com/*/probe-1m.bin) printf '%s' '0.020 0.115 9118052' ;;
+    benchmark-github-slightly-fast:*aliyuncs.com*/probe-1m.bin) printf '%s' '0.020 0.120 8738133' ;;
     benchmark-github-fast:*) printf '%s' '0.020 0.060 1092266' ;;
     *) printf '%s' '0.010 0.020 3276800' ;;
   esac
@@ -458,6 +460,9 @@ run_online_case benchmark-github-fast benchmark-github-fast "" success 7 "" "" "
   || fail_test "benchmark selected more than one primary bundle download"
 grep -q "github.com/.*/releases/download/v0.0.0-test/$HOST_ASSET\$" "$WORK_DIR/benchmark-github-fast.log" \
   || fail_test "benchmark did not select the faster GitHub source"
+run_online_case benchmark-github-slightly-fast benchmark-github-slightly-fast "" success 7 "" "" "$STAMPED_INSTALLER" auto 1
+grep -q "github.com/.*/releases/download/v0.0.0-test/$HOST_ASSET\$" "$WORK_DIR/benchmark-github-slightly-fast.log" \
+  || fail_test "benchmark did not select the shorter estimated GitHub source"
 
 run_online_case benchmark-missing-manifest benchmark-missing-manifest "" success 4 "" "" "$STAMPED_INSTALLER" auto 1
 grep -q "Download source test was inconclusive" "$WORK_DIR/benchmark-missing-manifest.output" \


### PR DESCRIPTION
## Summary

- Add release-level download probes and a tag-bound `release-download-manifest.tsv` so GitHub Release and OSS mirror assets can be verified and routed as one immutable distribution unit.
- Mirror the full release distribution set to OSS, including CLI bundles, desktop installers, `latest*.yml`, `.blockmap`, probes, and manifest, while keeping `latest.json` as the final mutable pointer.
- Add opt-in installer source probing through `PENGUIN_DOWNLOAD_SPEED_PROBE=1` and delegate website forwarders / `penguin update` to the stamped installer instead of duplicating large-payload source selection.

## Current speed probe logic

The runtime routing is intentionally conservative and tag-bound:

1. Explicit/offline modes are unchanged and do not probe:
   - local archive / sibling payload
   - `PENGUIN_DOWNLOAD_BASE_URL`
   - `PENGUIN_DOWNLOAD_SOURCE=oss|github`
2. In `auto` mode, speed probing only runs when `PENGUIN_DOWNLOAD_SPEED_PROBE=1` and no explicit base URL is set.
3. The installer first resolves a fixed release tag, then reads the same tag's `release-download-manifest.tsv` from OSS/GitHub release roots.
4. It probes both sources with `probe-64k.bin` to confirm same-tag reachability and probe integrity.
5. If only one source's 64 KiB probe succeeds, that source becomes primary and the other source remains the same-tag fallback.
6. If both small probes fail, probing is inconclusive and the installer falls back to the existing OSS-first, same-version GitHub fallback behavior.
7. For assets smaller than 32 MiB, it skips throughput probing and keeps OSS primary with GitHub fallback.
8. For larger assets, it downloads GitHub's `probe-1m.bin`; if GitHub reaches at least 256 KiB/s, GitHub becomes primary with OSS fallback. Otherwise OSS remains primary with GitHub fallback.
9. Real asset download still has transport fallback: network failure, low speed, stalled transfer, or truncated response retries the same release from the fallback source from scratch.
10. Checksum failures still fail closed and never silently switch sources.

This means the speed probe changes primary/fallback ordering only; it does not relax SHA256 verification, force-source semantics, custom mirror semantics, or old-release compatibility.

## Notes

- `PENGUIN_DOWNLOAD_BENCHMARK` was not used for the public switch to avoid colliding with the repo's agent benchmark terminology.
- Desktop auto-update feed selection and landing-page browser download probing remain separate follow-up work.

## Validation

Passed locally:

- `pnpm format:check`
- `pnpm typecheck`
- `pnpm build`
- `scripts\test-installer.ps1`
- `pnpm --filter @prismshadow/penguin-cli test`
- `pnpm --filter @prismshadow/penguin-web test`
- `pnpm --filter @prismshadow/penguin-desktop test`
- `git diff --check origin/main...HEAD`

Local environment limitation:

- `pnpm test` and `pnpm --filter @prismshadow/penguin-server test` fail on this Windows machine because the OS account cannot create symlinks (`EPERM: operation not permitted, symlink ...`). A direct Node `fs.symlinkSync(...)` probe fails the same way, and every failing test is a symlink fixture setup failure rather than a download-source behavior failure.
- POSIX `sh -n` was not available locally: `sh` is not on PATH, WSL has no `/bin/bash`, and Docker Desktop's Linux engine is not running.
