### PR TITLE
feat(web): allow removing exited background processes

### DIFF
--- a/changelog/unreleased/2026-08-18-remove-exited-processes.md
+++ b/changelog/unreleased/2026-08-18-remove-exited-processes.md
@@ -1,0 +1,5 @@
+# Remove exited background processes
+
+The Web App can now remove exited background processes from a session's process list.
+
+Running processes remain protected from this cleanup action and can still be stopped through the existing control.

--- a/changelog/unreleased/README.md
+++ b/changelog/unreleased/README.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [2026-08-18] Web App: remove exited background processes from a session's process list. ([details](2026-08-18-remove-exited-processes.md))
+
 - [2026-08-18] Core & Web App: an official `MiniMax-M3` preset (1M context, vision) pins AgentHub's `minimax-m3` Responses client and direct endpoint, uses `MINIMAX_*` credential fallback, prices at the standard pay-as-you-go tier (≤512K input), and adds the MiniMax provider glyph plus bilingual docs (requires AgentHub >= 0.4.2). ([details](2026-08-18-minimax-m3-preset.md))
 - [2026-08-14] Match the macOS app icon's visual size to neighbouring apps. ([details](2026-08-14-macos-app-icon-size.md))
 - [2026-08-14] Unknown model IDs can be moved to Custom with the OpenAI-compatible client. ([details](2026-08-14-model-group-protocol.md))

--- a/packages/core/src/environment/environment.ts
+++ b/packages/core/src/environment/environment.ts
@@ -169,6 +169,11 @@ export class Environment implements EnvironmentInterface {
     return this.commandSessions.kill(processId);
   }
 
+  /** Removes one exited background command from the host-visible registry. */
+  removeExitedBackgroundCommand(processId: string): boolean {
+    return this.commandSessions.removeExited(processId);
+  }
+
   /**
    * Lists tools available to the current Session, for context_engine to initialize GenerativeModel.
    * Only lists tools that have been assembled (i.e. supported by the registry) — tool names

--- a/packages/core/src/environment/tools/command/session-manager.ts
+++ b/packages/core/src/environment/tools/command/session-manager.ts
@@ -199,6 +199,14 @@ export class CommandSessionManager {
     return true;
   }
 
+  /** Removes an exited background process from the registry without affecting running processes. */
+  removeExited(processId: string): boolean {
+    const session = this.registry.get(processId);
+    if (!session || session.running) return false;
+    this.registry.remove(processId);
+    return true;
+  }
+
   /** Disposes: removes the fallback registration and kills all sessions (the process 'exit' fallback is hooked up by the registry itself). Idempotent. */
   dispose(): void {
     this.registry.dispose();

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -386,6 +386,8 @@ export interface EnvironmentInterface {
   listBackgroundCommands?(): BackgroundCommandInfo[];
   /** Kills one background command process by id (whole process group); false when the id is unknown. Optional, like listBackgroundCommands. */
   killBackgroundCommand?(processId: string): boolean;
+  /** Removes one exited background command from the host-visible registry. */
+  removeExitedBackgroundCommand?(processId: string): boolean;
   /** Releases runtime resources held by the environment (e.g. managed long-running command sessions); called by the host when the Session ends. Optional, idempotent. */
   dispose?(): void;
 }

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -663,6 +663,11 @@ export class Session {
     return this.environment.killBackgroundCommand?.(processId) ?? false;
   }
 
+  /** Removes one exited background command from the host-visible registry. */
+  removeExitedBackgroundCommand(processId: string): boolean {
+    return this.environment.removeExitedBackgroundCommand?.(processId) ?? false;
+  }
+
   /**
    * Releases runtime resources held by the Session: kills long-running command sessions
    * managed by the Environment. The host calls this when the Session ends (CLI exit, Web

--- a/packages/core/test/background-registry-remove-exited.test.ts
+++ b/packages/core/test/background-registry-remove-exited.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { CommandSessionManager } from "../src/environment/tools/command/session-manager.js";
+
+describe("CommandSessionManager.removeExited", () => {
+  it("removes an exited process but refuses a running process", () => {
+    const manager = new CommandSessionManager();
+    const running = { running: true, kill() {}, killHard() {} } as never;
+    const exited = { running: false, kill() {}, killHard() {} } as never;
+    const runningId = manager.register(running);
+    const exitedId = manager.register(exited);
+
+    expect(manager.removeExited(runningId)).toBe(false);
+    expect(manager.list()).toHaveLength(2);
+    expect(manager.removeExited(exitedId)).toBe(true);
+    expect(manager.list()).toHaveLength(1);
+    manager.dispose();
+  });
+});

--- a/packages/server/src/http/routes/sessions.ts
+++ b/packages/server/src/http/routes/sessions.ts
@@ -851,6 +851,15 @@ export function sessionsRoutes(deps: AppDeps): Hono<AppEnv> {
     return c.body(null, 204);
   });
 
+  app.delete("/:sessionId/processes/:processId", (c) => {
+    const row = resolveSession(c);
+    const removed = deps.manager.removeExitedProcess(row.sessionId, pathParam(c, "processId"));
+    if (!removed) {
+      throw new HttpError(404, "process_not_found", "Process is still running or does not exist.");
+    }
+    return c.body(null, 204);
+  });
+
   // "Retry now" on the reconnect countdown: skip the remaining backoff wait and fire the
   // next retry immediately (attempt counter unchanged). Benign either way — 200 with
   // skipped:false when no reconnect wait is in progress, so a timing race (the wait

--- a/packages/server/src/runtime/session-manager.ts
+++ b/packages/server/src/runtime/session-manager.ts
@@ -110,6 +110,7 @@ export interface RuntimeSession {
   listBackgroundCommands?(): BackgroundCommandInfo[];
   /** Kills one background command process (core `Session.killBackgroundCommand`); false when the id is unknown. Optional, like listBackgroundCommands. */
   killBackgroundCommand?(processId: string): boolean;
+  removeExitedBackgroundCommand?(processId: string): boolean;
   /** Releases environment resources — kills the remaining background processes (core `Session.dispose`). Optional, idempotent. */
   dispose?(): void;
 }
@@ -945,6 +946,14 @@ export class SessionManager {
     const killed = entry.session.killBackgroundCommand?.(processId) ?? false;
     if (killed) entry.lastActivityMs = Date.now();
     return killed;
+  }
+
+  removeExitedProcess(sessionId: string, processId: string): boolean {
+    const entry = this.entries.get(sessionId);
+    if (!entry) return false;
+    const removed = entry.session.removeExitedBackgroundCommand?.(processId) ?? false;
+    if (removed) entry.lastActivityMs = Date.now();
+    return removed;
   }
 
   /**

--- a/packages/web/src/api/endpoints.ts
+++ b/packages/web/src/api/endpoints.ts
@@ -469,6 +469,12 @@ export const killSessionProcess = (sessionId: string, processId: string) =>
     { method: "POST", body: {} },
   );
 
+export const removeExitedSessionProcess = (sessionId: string, processId: string) =>
+  apiFetch<void>(
+    `/api/sessions/${encodeURIComponent(sessionId)}/processes/${encodeURIComponent(processId)}`,
+    { method: "DELETE" },
+  );
+
 /** Mid-run steering: queues a message for the running Task (delivered between turns as a standalone `[user_steering]` user message); 409 not_running when no Task is in progress. */
 export const postSteer = (sessionId: string, body: SteerRequest) =>
   apiFetch<void>(`/api/sessions/${encodeURIComponent(sessionId)}/steer`, {

--- a/packages/web/src/features/chat/chat-page.tsx
+++ b/packages/web/src/features/chat/chat-page.tsx
@@ -758,6 +758,22 @@ export function ChatPage() {
     [selected, procBusy],
   );
 
+  const onRemoveExitedProcess = useCallback(
+    async (processId: string) => {
+      if (!selected || procBusy !== null) return;
+      setProcBusy(processId);
+      try {
+        await api.removeExitedSessionProcess(selected.sessionId, processId);
+      } catch (e) {
+        if (!(e instanceof ApiError && e.status === 404)) toastError(apiErrorText(e));
+      } finally {
+        setProcBusy(null);
+        api.getSessionProcesses(selected.sessionId).then((res) => setProcesses(res.processes)).catch(() => undefined);
+      }
+    },
+    [selected, procBusy],
+  );
+
   // Trace file path for the popover's trace row: the single-session GET is the only
   // surface carrying it, so fetch lazily on open (and once per session — the path only
   // ever moves forward when a new trace file starts, which a reopen picks up).
@@ -1534,9 +1550,14 @@ export function ChatPage() {
                             {procBusy === p.processId ? S.common.loading : S.chat.processStop}
                           </button>
                         ) : (
-                          <span className="shrink-0 text-[11px] text-gray-400 dark:text-gray-500">
-                            {S.chat.processExited}
-                          </span>
+                          <button
+                            type="button"
+                            disabled={procBusy !== null}
+                            onClick={() => void onRemoveExitedProcess(p.processId)}
+                            className="shrink-0 rounded-md border border-gray-200 px-2 py-0.5 text-xs text-gray-600 hover:border-gray-300 hover:bg-gray-50 disabled:opacity-60 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+                          >
+                            {procBusy === p.processId ? S.common.loading : S.common.delete}
+                          </button>
                         )}
                       </li>
                     ))}


### PR DESCRIPTION
## Summary

Closes #312.

- Add an exited-only removal operation to the background command registry.
- Expose it through `DELETE /api/sessions/:sessionId/processes/:processId`.
- Add a Remove action for exited processes in the Web App process list.
- Protect running processes from this cleanup action.
- Add the required unreleased changelog entry.

## Compatibility

Existing stop behavior for running processes is unchanged. The new endpoint returns 404 when the process is running, missing, or the session runtime is unavailable.

## Validation

- `git diff --check` — passed.
- `corepack pnpm install --frozen-lockfile --ignore-scripts` — not completed: pnpm produced no output and timed out in this environment.
- `pnpm test`, `pnpm format:check`, `pnpm typecheck`, and `pnpm build` — not run because dependencies could not be installed; the host Node version is 22.23.2 while the repository requires Node >=24.