### PR TITLE
fix(tooling): point the penguin dev script at the real CLI entry

### DIFF
--- a/changelog/unreleased/2026-08-19-penguin-dev-script-entry.md
+++ b/changelog/unreleased/2026-08-19-penguin-dev-script-entry.md
@@ -1,0 +1,16 @@
+# `pnpm penguin` runs the CLI again
+
+- **Date:** 2026-08-19
+- **Type:** fix
+- **Scope:** `tooling`, `cli`
+
+[中文版](2026-08-19-penguin-dev-script-entry.zh.md)
+
+The repo root's `pnpm penguin` script now runs `packages/cli/src/penguin.ts`, the source file the `penguin` bin is built from, instead of `packages/cli/src/index.ts`.
+
+Splitting the CLI entry in [#298](https://github.com/Prism-Shadow/penguin-harness/pull/298) left `index.ts` exporting `cli()` and moved the invocation into `penguin.ts`. That change updated `packages/cli`'s own `penguin` script and the bin, but not the root one, so from 2026-08-18 every `pnpm penguin <args>` at the repo root imported the module, ran nothing and exited 0 — no output, no error, and `dotenv/config` never loaded. `pnpm penguin chat` looked like a CLI that refused to start.
+
+## Details
+
+- A drift guard in `packages/cli/test/dev-script-entry.test.ts` derives the expected source entry from `bin.penguin` and asserts both dev scripts run it, so a future entry rename cannot silently strand one of them.
+- The installed and globally linked `penguin` commands were never affected: they run the bin, which has pointed at `dist/penguin.js` throughout.

--- a/changelog/unreleased/2026-08-19-penguin-dev-script-entry.zh.md
+++ b/changelog/unreleased/2026-08-19-penguin-dev-script-entry.zh.md
@@ -1,0 +1,16 @@
+# `pnpm penguin` 恢复可用
+
+- **Date:** 2026-08-19
+- **Type:** fix
+- **Scope:** `tooling`, `cli`
+
+[English](2026-08-19-penguin-dev-script-entry.md)
+
+仓库根目录的 `pnpm penguin` 脚本改为运行 `packages/cli/src/penguin.ts`——也就是 `penguin` 可执行文件所构建自的那个源文件——不再运行 `packages/cli/src/index.ts`。
+
+[#298](https://github.com/Prism-Shadow/penguin-harness/pull/298) 拆分 CLI 入口后，`index.ts` 只负责导出 `cli()`，真正的调用挪到了 `penguin.ts`。那次改动同步了 `packages/cli` 自己的 `penguin` 脚本和 bin，却漏掉了根目录这一份，于是自 2026-08-18 起，在仓库根目录执行的每一次 `pnpm penguin <args>` 都只是导入模块、什么也不执行、以 0 退出——没有输出，没有报错，`dotenv/config` 也从未加载。`pnpm penguin chat` 看上去就像一个拒绝启动的 CLI。
+
+## 细节
+
+- `packages/cli/test/dev-script-entry.test.ts` 中的漂移守卫会从 `bin.penguin` 推导出应有的源入口，并断言两个开发脚本都指向它，因此日后再改入口文件名，不会再有哪一个被悄悄落下。
+- 已安装以及全局链接的 `penguin` 命令自始至终不受影响：它们运行的是 bin，而 bin 一直指向 `dist/penguin.js`。

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:e2e": "pnpm --filter @prismshadow/penguin-core test:e2e",
     "build": "pnpm -r build && pnpm link:cli",
     "link:cli": "pnpm --dir packages/cli link --global || echo '[link:cli] pnpm global directory not configured; skipping the global penguin link (run pnpm setup once first)'",
-    "penguin": "node scripts/run-with-env.mjs PENGUIN_HOME=~/.penguin/dev-data PORT=7369 -- tsx packages/cli/src/index.ts",
+    "penguin": "node scripts/run-with-env.mjs PENGUIN_HOME=~/.penguin/dev-data PORT=7369 -- tsx packages/cli/src/penguin.ts",
     "dev": "concurrently -n server,web -c cyan,magenta \"pnpm dev:server\" \"pnpm dev:web\"",
     "dev:server": "pnpm --filter @prismshadow/penguin-server dev",
     "dev:web": "node scripts/dev-prebuild.mjs && pnpm --filter @prismshadow/penguin-web dev",

--- a/packages/cli/test/dev-script-entry.test.ts
+++ b/packages/cli/test/dev-script-entry.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Drift guard for the source entry the dev runners execute.
+ *
+ * Only `src/penguin.ts` runs the CLI: it calls `cli()` and sets the exit code, and tsup
+ * builds it into the `penguin` bin. `src/index.ts` merely exports `cli()`, so a runner
+ * pointed at it imports the module, executes nothing and exits 0 — indistinguishable, at
+ * the terminal, from a CLI that started and printed nothing. Splitting the entry in #298
+ * updated this package's own `penguin` script and left the repo root's behind, which is
+ * exactly that silent no-op. If this test fails, point the failing script at the source
+ * file matching the bin.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const cliDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = path.resolve(cliDir, "..", "..");
+
+const readScripts = (pkgPath: string): Record<string, string> =>
+  (JSON.parse(readFileSync(pkgPath, "utf8")) as { scripts?: Record<string, string> }).scripts ?? {};
+
+const cliPkg = JSON.parse(readFileSync(path.join(cliDir, "package.json"), "utf8")) as {
+  bin: Record<string, string | undefined>;
+};
+
+const binEntry = cliPkg.bin.penguin;
+if (binEntry === undefined) throw new Error("packages/cli/package.json declares no penguin bin");
+
+/** `./dist/penguin.js` -> `penguin.ts`: the source file the bin is built from. */
+const entrySource = `${path.basename(binEntry, ".js")}.ts`;
+
+describe("dev runner entry", () => {
+  it("is the source file the penguin bin is built from", () => {
+    expect(entrySource).toBe("penguin.ts");
+  });
+
+  it.each([
+    ["repo root", path.join(repoRoot, "package.json"), `packages/cli/src/${entrySource}`],
+    ["packages/cli", path.join(cliDir, "package.json"), `src/${entrySource}`],
+  ])("%s runs it through tsx", (_name, pkgPath, expected) => {
+    const script = readScripts(pkgPath).penguin;
+    expect(script).toBeDefined();
+    expect(script).toContain(`tsx ${expected}`);
+  });
+});


### PR DESCRIPTION
`pnpm penguin <args>` at the repo root has been a silent no-op since 2026-08-18: it prints nothing, errors nothing, and exits 0. `pnpm penguin chat` therefore looks like a CLI that refuses to start.

## Cause

Splitting the CLI entry in #298 left `packages/cli/src/index.ts` exporting `cli()` and moved the invocation into `src/penguin.ts`. That change updated `packages/cli`'s own `penguin` script and `bin.penguin` (→ `dist/penguin.js`), but the repo root's script kept running `tsx packages/cli/src/index.ts` — which now imports the module, executes nothing and exits 0. `dotenv/config`, imported only by `penguin.ts`, also stopped loading for dev runs.

Installed and globally linked `penguin` commands were never affected: they run the bin.

## Changes

- Root `package.json`: the `penguin` script runs `packages/cli/src/penguin.ts`.
- `packages/cli/test/dev-script-entry.test.ts`: a drift guard that derives the expected source entry from `bin.penguin` and asserts both dev scripts run it, so a future entry rename cannot strand one of them silently. Mutation-checked — reverting the one-line fix fails the test.
- Changelog entry pair.

## Verification

`pnpm penguin chat` starts and reaches the REPL prompt; `pnpm penguin --help` prints the command list. CLI suite 248 passed (18 files), typecheck and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AacaCvXidZK76S4AmmkhU