### PR TITLE
fix(web): restore the recalled follow-up's thinking level on the Session

### DIFF
--- a/packages/web/src/features/chat/chat-page.tsx
+++ b/packages/web/src/features/chat/chat-page.tsx
@@ -1095,6 +1095,27 @@ export function ChatPage() {
     [selected, discardSessionDraft],
   );
 
+  // Pins a picked level on the Session so it outlives this tab: PATCH, then swap the
+  // returned row into the session store (the picker reads it back from there). Modeled on
+  // onChangeApprovalMode — a failed write surfaces as a toast and leaves the level as it
+  // was, rather than showing a level the server does not have. Declared above the recall
+  // callbacks because one of them lists it as a dependency, which is evaluated during
+  // render rather than when the callback runs.
+  const applyTurnThinkingLevel = useCallback(
+    (level: string) => {
+      if (!selected) return;
+      void api
+        .patchSession(selected.sessionId, {
+          thinkingLevel: level as SessionPatchRequest["thinkingLevel"],
+        })
+        .then((res) => replace(res.session))
+        .catch((e: unknown) => {
+          toastError(apiErrorText(e));
+        });
+    },
+    [selected, replace],
+  );
+
   // Recall a queued message back into the composer (#287): the DELETE returns the original
   // content (text / images / files) and the input area restores it as the draft. A 409
   // not_pending (steering already delivered, follow-up already started) surfaces as a toast;
@@ -1118,15 +1139,16 @@ export function ChatPage() {
       try {
         const res = await api.recallFollowUp(selected.sessionId, followUpId);
         // The follow-up was queued with a per-turn thinking level: restore it with the draft,
-        // so an unedited resend goes out exactly as it was queued.
-        if (res.thinkingLevel) setTurnThinkingLevel(res.thinkingLevel);
+        // so an unedited resend goes out exactly as it was queued. The level now lives on the
+        // Session (#310), so restoring it pins it there rather than in local state.
+        if (res.thinkingLevel) applyTurnThinkingLevel(res.thinkingLevel);
         return res;
       } catch (e) {
         toastError(apiErrorText(e));
         return null;
       }
     },
-    [selected],
+    [selected, applyTurnThinkingLevel],
   );
 
   const onApprove = useCallback(
@@ -1184,25 +1206,6 @@ export function ChatPage() {
   const onCompact = useCallback(async () => {
     await runCompaction();
   }, [runCompaction]);
-
-  // Pins a picked level on the Session so it outlives this tab: PATCH, then swap the
-  // returned row into the session store (the picker reads it back from there). Modeled on
-  // onChangeApprovalMode — a failed write surfaces as a toast and leaves the level as it
-  // was, rather than showing a level the server does not have.
-  const applyTurnThinkingLevel = useCallback(
-    (level: string) => {
-      if (!selected) return;
-      void api
-        .patchSession(selected.sessionId, {
-          thinkingLevel: level as SessionPatchRequest["thinkingLevel"],
-        })
-        .then((res) => replace(res.session))
-        .catch((e: unknown) => {
-          toastError(apiErrorText(e));
-        });
-    },
-    [selected, replace],
-  );
 
   // Session picker pick: pinned directly while it cannot hurt (empty transcript, a re-pick
   // of the displayed level, or right after a successful compaction), staged behind the


### PR DESCRIPTION
**main's web typecheck is currently failing.** `packages/web/src/features/chat/chat-page.tsx:1122` calls `setTurnThinkingLevel`, which has no definition anywhere in `packages/web/src`:

```
src/features/chat/chat-page.tsx(1122,32): error TS2552: Cannot find name 'setTurnThinkingLevel'.
```

## Cause

#320 and #321 were developed in parallel and merged in sequence. #320 replaced the local per-turn thinking level with a level pinned on the Session (`applyTurnThinkingLevel` writing through `PATCH`, read back as `selected.thinkingLevel`), deleting the local setter. #321 independently added the follow-up recall path, which restores the level a queued message was queued with — by calling that setter. Each PR was green against the main it branched from; only their combination is broken, so neither PR's CI could have caught it.

## Fix

Restore #321's intent in #320's model: a recalled follow-up's level is pinned on the Session. `applyTurnThinkingLevel` moves above the recall callbacks, because the dependency array naming it is evaluated during render rather than when the callback runs — leaving it below would trade the type error for a temporal-dead-zone `ReferenceError` at runtime.

## Verification

`packages/web` typecheck clean, 790 tests across 63 files pass. The break was independently reproduced against an unmodified main tree while updating PR #296, which is what surfaced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AacaCvXidZK76S4AmmkhU