### PR TITLE
docs(skills): record where blog images live in the dev skill

### DIFF
--- a/.agents/skills/penguin-harness-dev/SKILL.md
+++ b/.agents/skills/penguin-harness-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: penguin-harness-dev
-description: Use when developing PenguinHarness itself — changing packages/{core,server,web,cli,desktop,landing,docs,skills}, the built-in model catalog, the installers or the release workflow; writing or auditing changelog entries; deciding what to do about data already on disk; or auditing prose that reads like a leaked authoring session. Covers the two-repo symlink layout, the CI-parity verification chain, the record-and-ship contract, and the seams that are intentional.
+description: Use when developing PenguinHarness itself — changing packages/{core,server,web,cli,desktop,landing,docs,skills}, the built-in model catalog, the installers or the release workflow; writing or auditing changelog entries; writing a blog post or capturing release screenshots; deciding what to do about data already on disk; or auditing prose that reads like a leaked authoring session. Covers the two-repo symlink layout, the CI-parity verification chain, the record-and-ship contract, where blog media is hosted, and the seams that are intentional.
 ---
 
 # Developing PenguinHarness
@@ -73,6 +73,16 @@ Every change ships a changelog entry, in both languages, in `changelog/unrelease
 The PR number exists only once the PR is open: open it, then add the links in a follow-up commit on the same branch.
 
 An entry ships **inside the PR that makes the change** — there is no separate aggregate PR. Released version folders are frozen. `RELEASE.md` is written at release preparation and must be committed **before** the tag — the workflow reads it from the tag's own checkout.
+
+## Blog posts, and where their images live
+
+A post is a pair under `packages/landing/content/blog/`: `<slug>.en.md` and `<slug>.zh.md`, each with `title` / `date` / `category` / `excerpt` frontmatter. Same rule as changelog entries — one without the other is unfinished.
+
+**The images are not in this repo.** Screenshots and demo videos live in the sibling `Prism-Shadow/penguin-harness-community` repo, under `blog-assets/` and `videos/`. A published post's screenshots are never deleted, so that asset class grows without bound in the number of posts written; keeping it out of this history keeps everyone's clone small.
+
+**Posts still write a repo-local path.** Reference an image as `/blog-assets/<name>` — both `![alt](…)` and the raw `<img src="…">` some posts use — and let the renderer resolve it: `blogAssetUrl` in `packages/landing/src/lib/links.ts`, applied by the `img` adapter in `src/pages/blog-post.tsx`. Never paste the raw `raw.githubusercontent` URL into a post. One source of truth for the host, Markdown that stays readable and diffable, and moving the host again is a one-line change instead of a sweep over every post.
+
+Release screenshots are captured, not mocked up: drive the app through the Playwright e2e harness in `packages/web/e2e/` with its mock LLM, against a scratch `PENGUIN_HOME` — never `~/.penguin`, which is the developer's real data. Shoot at `deviceScaleFactor: 2`, crop to the feature rather than the whole window, and check the frame for what must not ship publicly: absolute paths carrying a home directory, API keys, and mock-model filler text.
 
 ## Changing the built-in model catalog
 

--- a/changelog/unreleased/2026-08-19-dev-skill-blog-media.md
+++ b/changelog/unreleased/2026-08-19-dev-skill-blog-media.md
@@ -1,0 +1,16 @@
+# The dev skill records where blog images live
+
+- **Date:** 2026-08-19
+- **Type:** process
+- **Scope:** `skills`
+
+[中文版](2026-08-19-dev-skill-blog-media.zh.md)
+
+`.agents/skills/penguin-harness-dev/SKILL.md` gained a "Blog posts, and where their images live" section covering the post pair under `packages/landing/content/blog/`, the community repo that hosts the images, the `/blog-assets/<name>` path posts write instead of the host URL, and how release screenshots are captured.
+
+## Details
+
+- Screenshots and demo videos live in the sibling `Prism-Shadow/penguin-harness-community` repo under `blog-assets/` and `videos/`, not in this one; the section states why, so the arrangement is not undone by someone who reads it as an accident.
+- Posts reference `/blog-assets/<name>`, resolved at render time by `blogAssetUrl` in `packages/landing/src/lib/links.ts` and the `img` adapter in `src/pages/blog-post.tsx`. Pasting a raw host URL into a post is called out as the thing not to do.
+- Release screenshots are driven through the Playwright e2e harness with its mock LLM against a scratch `PENGUIN_HOME`, at `deviceScaleFactor: 2`, with a frame check for home-directory paths, API keys and mock-model filler.
+- The skill's frontmatter description now names blog posts and screenshots among its triggers.

--- a/changelog/unreleased/2026-08-19-dev-skill-blog-media.zh.md
+++ b/changelog/unreleased/2026-08-19-dev-skill-blog-media.zh.md
@@ -1,0 +1,16 @@
+# 开发 skill 记录了博客图片的存放位置
+
+- **Date:** 2026-08-19
+- **Type:** process
+- **Scope:** `skills`
+
+[English](2026-08-19-dev-skill-blog-media.md)
+
+`.agents/skills/penguin-harness-dev/SKILL.md` 新增「Blog posts, and where their images live」一节，涵盖 `packages/landing/content/blog/` 下成对的文章文件、托管图片的 community 仓库、文章中应当书写的 `/blog-assets/<name>` 路径而非托管地址，以及发布截图的采集方式。
+
+## 细节
+
+- 截图与演示视频存放在同级的 `Prism-Shadow/penguin-harness-community` 仓库的 `blog-assets/` 与 `videos/` 下，而不在本仓库；该节写明了这样安排的原因，以免后来者把它当成疏漏而擅自改回来。
+- 文章引用 `/blog-assets/<name>`，由 `packages/landing/src/lib/links.ts` 中的 `blogAssetUrl` 与 `src/pages/blog-post.tsx` 中的 `img` 适配器在渲染时解析。把托管原始 URL 直接粘进文章被明确列为不应做的事。
+- 发布截图通过 `packages/web/e2e/` 的 Playwright 测试设施与其 mock 模型驱动，使用独立的 `PENGUIN_HOME`，以 `deviceScaleFactor: 2` 拍摄，并检查画面中是否混入了家目录路径、API key 和 mock 模型的填充文本。
+- 该 skill 的 frontmatter 描述现在也把博客文章与截图列入触发场景。


### PR DESCRIPTION
Working out where a blog post's screenshots go meant reading `packages/landing/src/lib/links.ts`. Nothing in the dev skill said it, so the next person writing a post either pastes a raw `raw.githubusercontent` URL into the Markdown or commits the images into this repo — either of which undoes the reason the split exists.

## Changes

`.agents/skills/penguin-harness-dev/SKILL.md` gains a **"Blog posts, and where their images live"** section recording:

- A post is a pair under `packages/landing/content/blog/` (`<slug>.en.md` + `<slug>.zh.md`), same both-languages rule as changelog entries.
- Screenshots and demo videos live in the sibling `Prism-Shadow/penguin-harness-community` repo under `blog-assets/` and `videos/` — with the reason, so it is not read as an accident and "fixed".
- Posts write `/blog-assets/<name>`; `blogAssetUrl` and the `img` adapter in `src/pages/blog-post.tsx` resolve it at render time. Pasting the host URL into a post is called out as the thing not to do.
- Release screenshots are captured through the Playwright e2e harness and its mock LLM against a scratch `PENGUIN_HOME` (never `~/.penguin`), at `deviceScaleFactor: 2`, with a frame check for home-directory paths, API keys and mock-model filler before publishing.

The frontmatter description now names blog posts and screenshots among the skill's triggers. Changelog entry pair added.

## Merge order

This entry belongs to the release **after** 0.2.3, so merge this **after** the 0.2.3 release PR, which renames `changelog/unreleased/` to `changelog/0.2.3/`. Merging this first would sweep the entry into a release it was not part of.

## Verification

`penguin-skills` 22/22 (its frontmatter validation covers the description change), prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AacaCvXidZK76S4AmmkhU