### PR TITLE
feat(web): add Token Hub activity entry

### DIFF
--- a/changelog/unreleased/2026-08-20-token-hub-activity-entry.md
+++ b/changelog/unreleased/2026-08-20-token-hub-activity-entry.md
@@ -1,0 +1,15 @@
+# Token Hub activity entry
+
+- **Date:** 2026-08-20
+- **Type:** feature
+- **Scope:** `web`
+
+[中文版](2026-08-20-token-hub-activity-entry.zh.md)
+
+Added a signed-in account-menu entry that opens the Token Hub campaign center in a separate browser tab.
+
+## Details
+
+- The entry uses `https://penguin.ooo/activities` by default.
+- Deployments can set `VITE_TOKEN_HUB_ACTIVITY_URL` at Web App build time to use another Token Hub origin or a specific generated campaign link.
+- External-link handling continues to use the system browser in the desktop app.

--- a/changelog/unreleased/2026-08-20-token-hub-activity-entry.md
+++ b/changelog/unreleased/2026-08-20-token-hub-activity-entry.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-20
 - **Type:** feature
 - **Scope:** `web`
+- **PR:** [#356](https://github.com/Prism-Shadow/penguin-harness/pull/356)
 
 [中文版](2026-08-20-token-hub-activity-entry.zh.md)
 

--- a/changelog/unreleased/2026-08-20-token-hub-activity-entry.zh.md
+++ b/changelog/unreleased/2026-08-20-token-hub-activity-entry.zh.md
@@ -1,0 +1,15 @@
+# Token Hub 活动入口
+
+- **Date:** 2026-08-20
+- **Type:** feature
+- **Scope:** `web`
+
+[English](2026-08-20-token-hub-activity-entry.md)
+
+在已登录账号菜单中增加了 Token Hub 活动中心入口，并在独立浏览器标签页中打开。
+
+## 细节
+
+- 入口默认使用 `https://penguin.ooo/activities`。
+- 部署时可在 Web App 构建阶段设置 `VITE_TOKEN_HUB_ACTIVITY_URL`，指向其他 Token Hub 域名或某个已生成的活动链接。
+- 桌面应用继续通过系统浏览器处理该外部链接。

--- a/changelog/unreleased/2026-08-20-token-hub-activity-entry.zh.md
+++ b/changelog/unreleased/2026-08-20-token-hub-activity-entry.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-20
 - **Type:** feature
 - **Scope:** `web`
+- **PR:** [#356](https://github.com/Prism-Shadow/penguin-harness/pull/356)
 
 [English](2026-08-20-token-hub-activity-entry.md)
 

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -213,6 +213,14 @@ function AddBadgeIcon({ base, size = 15 }: { base: string; size?: number }) {
 const menuItemClass =
   "block w-full px-3.5 py-2 text-left text-sm transition-colors duration-150 hover:bg-gray-100 dark:hover:bg-gray-800";
 
+/**
+ * Stable Token Hub campaign-center entry. Deployments can point at another Hub origin or a
+ * specific generated campaign without changing the Web App code.
+ */
+const TOKEN_HUB_ACTIVITY_URL = String(
+  import.meta.env.VITE_TOKEN_HUB_ACTIVITY_URL || "https://penguin.ooo/activities",
+).trim();
+
 /** Section-header icon control (search / list settings / create): the grouping-toggle button look — active renders as a pressed fill. */
 const headerControlClass = (active: boolean) =>
   `flex h-6 w-6 shrink-0 items-center justify-center rounded-md transition-colors duration-150 ${
@@ -1763,6 +1771,15 @@ export function Sidebar({
             </SettingRow>
           </div>
           <div className="mt-1 border-t border-gray-100 pt-1 dark:border-gray-800">
+            <a
+              className={`${menuItemClass} text-gray-700 no-underline dark:text-gray-300`}
+              href={TOKEN_HUB_ACTIVITY_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => setUserOpen(false)}
+            >
+              {S.account.tokenRewards}
+            </a>
             {/* Hidden in the desktop shell's own window: it signs in through the shell's
                 one-shot token rather than a login form, and the seed password of a
                 desktop-created root is fully random and never printed — there is no

--- a/packages/web/src/lib/strings-en.ts
+++ b/packages/web/src/lib/strings-en.ts
@@ -165,6 +165,7 @@ export const en: Strings = {
   },
 
   account: {
+    tokenRewards: "Claim API Tokens",
     changePassword: "Change password",
     oldPassword: "Current password",
     oldPasswordHint:

--- a/packages/web/src/lib/strings.ts
+++ b/packages/web/src/lib/strings.ts
@@ -163,6 +163,7 @@ export const zh = {
   },
 
   account: {
+    tokenRewards: "领取 API Token",
     changePassword: "修改密码",
     oldPassword: "当前密码",
     oldPasswordHint: "内置管理员的初始密码在服务端首次启动时打印（形如 penguin-1234）",


### PR DESCRIPTION
## Summary

- add a signed-in account-menu entry for Token Hub reward campaigns
- open the campaign center in a separate browser/system-browser tab
- allow deployments to override the destination with `VITE_TOKEN_HUB_ACTIVITY_URL`
- add bilingual changelog entries

## Verification

- `pnpm --filter @prismshadow/penguin-web test` (74 files, 969 tests)
- `pnpm --filter @prismshadow/penguin-web typecheck`
- `pnpm --filter @prismshadow/penguin-web build`
- `pnpm format`
- `pnpm format:check`
- `git diff --check`