### PR TITLE
fix(installer): enable speed probing by default

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -8,7 +8,7 @@
 #   $env:PENGUIN_INSTALL_DIR = "<dir>"  install dir; default $env:USERPROFILE\.penguin
 #   $env:PENGUIN_ARCHIVE = "<file>"     install a local Release zip without network access (same as -ArchivePath)
 #   $env:PENGUIN_DOWNLOAD_SOURCE = "auto|oss|github" choose the online source; default auto (OSS, then same-version GitHub)
-#   $env:PENGUIN_DOWNLOAD_SPEED_PROBE = "1" enable same-version OSS/GitHub probe timing in auto mode
+#   $env:PENGUIN_DOWNLOAD_SPEED_PROBE = "0" disable same-version OSS/GitHub probe timing in auto mode
 #   $env:PENGUIN_DOWNLOAD_BASE_URL = "https://..." exact online asset directory selected by the stable forwarder
 #   $env:PENGUIN_DOWNLOAD_FALLBACK_BASE_URL = "https://..." fallback for PENGUIN_DOWNLOAD_BASE_URL
 #
@@ -43,7 +43,10 @@ $OssReleaseRoot = "$OssOrigin/releases"
 $GitHubReleaseRoot = "$Repo/releases/download"
 $GitHubLatestBase = "$Repo/releases/latest/download"
 $Asset = "penguin-win32-x64.zip"
-$SpeedProbeTotalTimeoutSeconds = 8
+$SpeedProbeTotalTimeoutSeconds = 16
+$SpeedProbeManifestTimeoutSeconds = 5
+$SpeedProbeSmallTimeoutSeconds = 5
+$SpeedProbeLargeTimeoutSeconds = 8
 $SpeedProbeGitHubMinBytesPerSecond = 262144
 $PayloadName = "payload.zip"
 # The release workflow replaces this token with the immutable tag before publishing both the
@@ -161,9 +164,9 @@ function Test-SafeReleaseAssetName([string]$Value) {
 
 function Read-ReleaseDownloadManifest([string]$Tag, [string]$ManifestPath, [DateTime]$Deadline) {
   Remove-Item -LiteralPath $ManifestPath -Force -ErrorAction SilentlyContinue
-  $TimeoutSec = Get-SpeedProbeTimeoutSec $Deadline 2
+  $TimeoutSec = Get-SpeedProbeTimeoutSec $Deadline $SpeedProbeManifestTimeoutSeconds
   if ($TimeoutSec -le 0 -or -not (Try-DownloadFile "$OssReleaseRoot/$Tag/release-download-manifest.tsv" $ManifestPath $TimeoutSec)) {
-    $TimeoutSec = Get-SpeedProbeTimeoutSec $Deadline 2
+    $TimeoutSec = Get-SpeedProbeTimeoutSec $Deadline $SpeedProbeManifestTimeoutSeconds
     if ($TimeoutSec -le 0 -or -not (Try-DownloadFile "$GitHubReleaseRoot/$Tag/release-download-manifest.tsv" $ManifestPath $TimeoutSec)) {
       return $null
     }
@@ -212,7 +215,7 @@ function Invoke-ProbeDownload(
   [string]$Tmp,
   [string]$Label,
   [DateTime]$Deadline,
-  [int]$MaxTimeoutSec = 2
+  [int]$MaxTimeoutSec = $SpeedProbeSmallTimeoutSeconds
 ) {
   $ProbePath = Join-Path $Tmp "probe-$Label-$($Probe.Name)"
   Remove-Item -LiteralPath $ProbePath -Force -ErrorAction SilentlyContinue
@@ -280,7 +283,7 @@ function Select-SpeedProbeDownloadSources([string]$Tag, [string]$Tmp) {
     return [PSCustomObject]@{ BaseUrl = $OssBase; FallbackBaseUrl = $GitHubBase }
   }
 
-  $GitHubLarge = Invoke-ProbeDownload $GitHubBase $Manifest.LargeProbe $Tmp "github-large" $Deadline 5
+  $GitHubLarge = Invoke-ProbeDownload $GitHubBase $Manifest.LargeProbe $Tmp "github-large" $Deadline $SpeedProbeLargeTimeoutSeconds
   $Choice = Select-SpeedProbeSource $GitHubLarge $Manifest.LargeProbe.Size
   if ($Choice -eq "github") {
     Write-Host "Selected GitHub (meets minimum download speed)."
@@ -342,7 +345,7 @@ $SourceMode = if ($env:PENGUIN_DOWNLOAD_SOURCE) {
 $DownloadSpeedProbe = if ($env:PENGUIN_DOWNLOAD_SPEED_PROBE) {
   $env:PENGUIN_DOWNLOAD_SPEED_PROBE
 } else {
-  "0"
+  "1"
 }
 # An extracted installer bundle keeps install.cmd, this script, payload.zip and its checksum
 # together. `$PSScriptRoot` is empty for the documented `irm ... | iex` path, so online installs

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@
 #   PENGUIN_INSTALL_DIR=<dir> install dir; default ~/.penguin
 #   PENGUIN_ARCHIVE=<file>    install a local Release archive without network access (same as --archive <file>)
 #   PENGUIN_DOWNLOAD_SOURCE=auto|oss|github choose the online source; default auto (OSS, then same-version GitHub)
-#   PENGUIN_DOWNLOAD_SPEED_PROBE=1 enable same-version OSS/GitHub probe timing in auto mode
+#   PENGUIN_DOWNLOAD_SPEED_PROBE=0 disable same-version OSS/GitHub probe timing in auto mode
 #   PENGUIN_DOWNLOAD_BASE_URL=<url> exact online asset directory selected by the stable forwarder
 #   PENGUIN_DOWNLOAD_FALLBACK_BASE_URL=<url> fallback for PENGUIN_DOWNLOAD_BASE_URL
 #   --universal               install the universal package (no bundled Node runtime; needs system Node >= 24)
@@ -41,8 +41,11 @@ ARCHIVE="${PENGUIN_ARCHIVE:-}"
 SOURCE_MODE="${PENGUIN_DOWNLOAD_SOURCE:-auto}"
 DOWNLOAD_BASE_URL="${PENGUIN_DOWNLOAD_BASE_URL:-}"
 DOWNLOAD_FALLBACK_BASE_URL="${PENGUIN_DOWNLOAD_FALLBACK_BASE_URL:-}"
-DOWNLOAD_SPEED_PROBE="${PENGUIN_DOWNLOAD_SPEED_PROBE:-0}"
-SPEED_PROBE_TOTAL_TIMEOUT_SECONDS=8
+DOWNLOAD_SPEED_PROBE="${PENGUIN_DOWNLOAD_SPEED_PROBE:-1}"
+SPEED_PROBE_TOTAL_TIMEOUT_SECONDS=16
+SPEED_PROBE_MANIFEST_TIMEOUT_SECONDS=5
+SPEED_PROBE_SMALL_TIMEOUT_SECONDS=5
+SPEED_PROBE_LARGE_TIMEOUT_SECONDS=8
 SPEED_PROBE_GITHUB_MIN_BYTES_PER_SECOND=262144
 SPEED_PROBE_STARTED_AT=0
 PAYLOAD_NAME="payload.tar.gz"
@@ -309,10 +312,10 @@ load_release_download_manifest() {
   lrdm_tag="$1"
   lrdm_manifest="$TMP/release-download-manifest.tsv"
   rm -f "$lrdm_manifest"
-  if lrdm_timeout="$(speed_probe_curl_timeout 2)" \
+  if lrdm_timeout="$(speed_probe_curl_timeout "$SPEED_PROBE_MANIFEST_TIMEOUT_SECONDS")" \
     && curl -fsSL --connect-timeout "$lrdm_timeout" --max-time "$lrdm_timeout" "$OSS_RELEASE_ROOT/$lrdm_tag/release-download-manifest.tsv" -o "$lrdm_manifest" 2>/dev/null; then
     :
-  elif lrdm_timeout="$(speed_probe_curl_timeout 2)" \
+  elif lrdm_timeout="$(speed_probe_curl_timeout "$SPEED_PROBE_MANIFEST_TIMEOUT_SECONDS")" \
     && curl -fsSL --connect-timeout "$lrdm_timeout" --max-time "$lrdm_timeout" "$GITHUB_RELEASE_ROOT/$lrdm_tag/release-download-manifest.tsv" -o "$lrdm_manifest" 2>/dev/null; then
     :
   else
@@ -353,7 +356,7 @@ probe_download_source() {
   pds_size="$4"
   pds_hash="$5"
   pds_metrics="$6"
-  pds_timeout_cap="${7:-2}"
+  pds_timeout_cap="${7:-$SPEED_PROBE_SMALL_TIMEOUT_SECONDS}"
   pds_body="$TMP/probe-$pds_label-$pds_file"
   pds_write="$pds_metrics.tmp"
   rm -f "$pds_body" "$pds_metrics" "$pds_write"
@@ -464,7 +467,7 @@ speed_probe_release_sources() {
   fi
 
   GITHUB_PROBE_METRICS="$TMP/probe-github-$SPEED_PROBE_LARGE_PROBE.metrics"
-  probe_download_source github "$GITHUB_SPEED_PROBE_BASE_URL" "$SPEED_PROBE_LARGE_PROBE" "$SPEED_PROBE_LARGE_SIZE" "$SPEED_PROBE_LARGE_HASH" "$GITHUB_PROBE_METRICS" 5
+  probe_download_source github "$GITHUB_SPEED_PROBE_BASE_URL" "$SPEED_PROBE_LARGE_PROBE" "$SPEED_PROBE_LARGE_SIZE" "$SPEED_PROBE_LARGE_HASH" "$GITHUB_PROBE_METRICS" "$SPEED_PROBE_LARGE_TIMEOUT_SECONDS"
   brs_choice="$(select_speed_probe_source_from_metrics "$GITHUB_PROBE_METRICS")"
   if [ "$brs_choice" = "github" ]; then
     SPEED_PROBE_BASE_URL="$GITHUB_SPEED_PROBE_BASE_URL"

--- a/scripts/test-installer.ps1
+++ b/scripts/test-installer.ps1
@@ -159,7 +159,11 @@ function Invoke-OnlineCase(
   $Arguments = @{ InstallDir = $InstallDir }
   if ($Version) { $Arguments.Version = $Version }
   if (-not $InstallerPath) { $InstallerPath = $Installer }
-  $env:PENGUIN_DOWNLOAD_SPEED_PROBE = $SpeedProbe
+  if ($SpeedProbe -eq "__unset") {
+    Remove-Item Env:\PENGUIN_DOWNLOAD_SPEED_PROBE -ErrorAction SilentlyContinue
+  } else {
+    $env:PENGUIN_DOWNLOAD_SPEED_PROBE = $SpeedProbe
+  }
   $Succeeded = $true
   $Output = @()
   try { $Output = @(& $InstallerPath @Arguments *>&1) } catch { $Succeeded = $false; $Output += $_ }
@@ -190,7 +194,11 @@ function Invoke-ForwarderCase(
   }
   $env:PENGUIN_INSTALL_DIR = $InstallDir
   $env:PENGUIN_DOWNLOAD_SOURCE = $Source
-  $env:PENGUIN_DOWNLOAD_SPEED_PROBE = $SpeedProbe
+  if ($SpeedProbe -eq "__unset") {
+    Remove-Item Env:\PENGUIN_DOWNLOAD_SPEED_PROBE -ErrorAction SilentlyContinue
+  } else {
+    $env:PENGUIN_DOWNLOAD_SPEED_PROBE = $SpeedProbe
+  }
   Remove-Item Env:\PENGUIN_DOWNLOAD_BASE_URL, Env:\PENGUIN_DOWNLOAD_FALLBACK_BASE_URL -ErrorAction SilentlyContinue
   $Forwarder = Join-Path $RepoRoot "packages\landing\public\install.ps1"
   $Output = @()
@@ -318,6 +326,10 @@ try {
   Assert-True ($speedProbeGitHubFast.Requests[-2] -like "https://github.com/*/releases/download/v0.0.0-test/penguin-win32-x64.zip") `
     "speed probe did not select GitHub when it met the minimum speed"
 
+  $speedProbeDefaultOn = Invoke-OnlineCase "speed-probe-default-on" "speed-probe-github-fast" "" $true 6 $StampedInstaller "__unset"
+  Assert-True ($speedProbeDefaultOn.Requests[-2] -like "https://github.com/*/releases/download/v0.0.0-test/penguin-win32-x64.zip") `
+    "speed probe was not enabled by default"
+
   $speedProbeGitHubBelowThreshold = Invoke-OnlineCase "speed-probe-github-below-threshold" "speed-probe-github-below-threshold" "" $true 6 $StampedInstaller "1"
   Assert-True ($speedProbeGitHubBelowThreshold.Requests[-2] -like "https://penguin-harness-releases.oss-cn-beijing.aliyuncs.com/*/penguin-win32-x64.zip") `
     "speed probe did not keep OSS when GitHub was below the minimum speed"
@@ -394,6 +406,10 @@ try {
     "speed probe handoff forwarder did not fetch the versioned installer"
   Assert-True ($speedProbeForwarder.Requests[-2] -like "https://github.com/*/releases/download/v0.0.0-test/penguin-win32-x64.zip") `
     "forwarder locked the payload source instead of letting the installer run speed probes"
+
+  $speedProbeDefaultForwarder = Invoke-ForwarderCase "forwarder-speed-probe-default-handoff" "speed-probe-github-fast" "auto" 7 "v0.0.0-test" $true "__unset"
+  Assert-True ($speedProbeDefaultForwarder.Requests[-2] -like "https://github.com/*/releases/download/v0.0.0-test/penguin-win32-x64.zip") `
+    "forwarder handoff did not leave speed probing enabled by default"
 
   Remove-Item Env:\PENGUIN_ARCHIVE, Env:\PENGUIN_INSTALL_DIR, Env:\PENGUIN_DOWNLOAD_SOURCE, Env:\PENGUIN_DOWNLOAD_SPEED_PROBE, Env:\PENGUIN_VERSION -ErrorAction SilentlyContinue
 

--- a/scripts/test-installer.sh
+++ b/scripts/test-installer.sh
@@ -416,12 +416,22 @@ run_online_case() {
   CASE_INSTALL="$WORK_DIR/$name-install"
   : > "$CASE_LOG"
   set +e
-  REQUEST_LOG="$CASE_LOG" MODE="$mode" PATH="$STUB_BIN:$PATH" \
-    HOME="$WORK_DIR/$name-home" PENGUIN_INSTALL_DIR="$CASE_INSTALL" \
-    PENGUIN_VERSION="$version" PENGUIN_DOWNLOAD_BASE_URL="$download_base_url" \
-    PENGUIN_DOWNLOAD_FALLBACK_BASE_URL="$download_fallback_base_url" \
-    PENGUIN_DOWNLOAD_SOURCE="$source_mode" PENGUIN_DOWNLOAD_SPEED_PROBE="$speed_probe" \
-    sh "$installer_path" >"$CASE_OUTPUT" 2>&1
+  if [ "$speed_probe" = "__unset" ]; then
+    unset PENGUIN_DOWNLOAD_SPEED_PROBE
+    REQUEST_LOG="$CASE_LOG" MODE="$mode" PATH="$STUB_BIN:$PATH" \
+      HOME="$WORK_DIR/$name-home" PENGUIN_INSTALL_DIR="$CASE_INSTALL" \
+      PENGUIN_VERSION="$version" PENGUIN_DOWNLOAD_BASE_URL="$download_base_url" \
+      PENGUIN_DOWNLOAD_FALLBACK_BASE_URL="$download_fallback_base_url" \
+      PENGUIN_DOWNLOAD_SOURCE="$source_mode" \
+      sh "$installer_path" >"$CASE_OUTPUT" 2>&1
+  else
+    REQUEST_LOG="$CASE_LOG" MODE="$mode" PATH="$STUB_BIN:$PATH" \
+      HOME="$WORK_DIR/$name-home" PENGUIN_INSTALL_DIR="$CASE_INSTALL" \
+      PENGUIN_VERSION="$version" PENGUIN_DOWNLOAD_BASE_URL="$download_base_url" \
+      PENGUIN_DOWNLOAD_FALLBACK_BASE_URL="$download_fallback_base_url" \
+      PENGUIN_DOWNLOAD_SOURCE="$source_mode" PENGUIN_DOWNLOAD_SPEED_PROBE="$speed_probe" \
+      sh "$installer_path" >"$CASE_OUTPUT" 2>&1
+  fi
   status=$?
   set -e
   if [ "$expected" = "success" ]; then
@@ -460,6 +470,9 @@ run_online_case speed-probe-github-fast speed-probe-github-fast "" success 6 "" 
   || fail_test "speed probe selected more than one primary bundle download"
 grep -q "github.com/.*/releases/download/v0.0.0-test/$HOST_ASSET\$" "$WORK_DIR/speed-probe-github-fast.log" \
   || fail_test "speed probe did not select GitHub when it met the minimum speed"
+run_online_case speed-probe-default-on speed-probe-github-fast "" success 6 "" "" "$STAMPED_INSTALLER" auto __unset
+grep -q "github.com/.*/releases/download/v0.0.0-test/$HOST_ASSET\$" "$WORK_DIR/speed-probe-default-on.log" \
+  || fail_test "speed probe was not enabled by default"
 run_online_case speed-probe-github-below-threshold speed-probe-github-below-threshold "" success 6 "" "" "$STAMPED_INSTALLER" auto 1
 grep -q "penguin-harness-releases.oss-cn-beijing.aliyuncs.com/.*/$HOST_ASSET\$" "$WORK_DIR/speed-probe-github-below-threshold.log" \
   || fail_test "speed probe did not keep OSS when GitHub was below the minimum speed"
@@ -522,12 +535,22 @@ run_forwarder_case() {
     archive="$ARTIFACT_DIR/$HOST_ASSET"
   fi
   set +e
-  REQUEST_LOG="$CASE_LOG" MODE="$mode" PATH="$STUB_BIN:$PATH" \
-    HOME="$WORK_DIR/$name-home" PENGUIN_INSTALL_DIR="$CASE_INSTALL" \
-    PENGUIN_ARCHIVE="$archive" PENGUIN_VERSION="$version" \
-    PENGUIN_DOWNLOAD_SOURCE="$source" PENGUIN_DOWNLOAD_BASE_URL="" \
-    PENGUIN_DOWNLOAD_FALLBACK_BASE_URL="" PENGUIN_DOWNLOAD_SPEED_PROBE="$speed_probe" \
-    sh "$ROOT_DIR/packages/landing/public/install.sh" >"$CASE_OUTPUT" 2>&1
+  if [ "$speed_probe" = "__unset" ]; then
+    unset PENGUIN_DOWNLOAD_SPEED_PROBE
+    REQUEST_LOG="$CASE_LOG" MODE="$mode" PATH="$STUB_BIN:$PATH" \
+      HOME="$WORK_DIR/$name-home" PENGUIN_INSTALL_DIR="$CASE_INSTALL" \
+      PENGUIN_ARCHIVE="$archive" PENGUIN_VERSION="$version" \
+      PENGUIN_DOWNLOAD_SOURCE="$source" PENGUIN_DOWNLOAD_BASE_URL="" \
+      PENGUIN_DOWNLOAD_FALLBACK_BASE_URL="" \
+      sh "$ROOT_DIR/packages/landing/public/install.sh" >"$CASE_OUTPUT" 2>&1
+  else
+    REQUEST_LOG="$CASE_LOG" MODE="$mode" PATH="$STUB_BIN:$PATH" \
+      HOME="$WORK_DIR/$name-home" PENGUIN_INSTALL_DIR="$CASE_INSTALL" \
+      PENGUIN_ARCHIVE="$archive" PENGUIN_VERSION="$version" \
+      PENGUIN_DOWNLOAD_SOURCE="$source" PENGUIN_DOWNLOAD_BASE_URL="" \
+      PENGUIN_DOWNLOAD_FALLBACK_BASE_URL="" PENGUIN_DOWNLOAD_SPEED_PROBE="$speed_probe" \
+      sh "$ROOT_DIR/packages/landing/public/install.sh" >"$CASE_OUTPUT" 2>&1
+  fi
   status=$?
   set -e
   if [ "$expected" = "success" ]; then
@@ -579,5 +602,8 @@ run_forwarder_case forwarder-speed-probe-handoff speed-probe-github-fast 7 auto 
   || fail_test "forwarder locked the payload source to OSS instead of letting the installer speed probe"
 grep -q "github.com/.*/releases/download/v0.0.0-test/$HOST_ASSET\$" "$WORK_DIR/forwarder-speed-probe-handoff.log" \
   || fail_test "forwarder locked the payload source instead of letting the installer speed probe"
+run_forwarder_case forwarder-speed-probe-default-handoff speed-probe-github-fast 7 auto v0.0.0-test success __unset
+grep -q "github.com/.*/releases/download/v0.0.0-test/$HOST_ASSET\$" "$WORK_DIR/forwarder-speed-probe-default-handoff.log" \
+  || fail_test "forwarder handoff did not leave speed probing enabled by default"
 
 echo "Installer bundle, offline, rollback and online tests passed."


### PR DESCRIPTION
## Summary
- Enable installer download speed probing by default in `auto` mode, so same-version GitHub/OSS source selection runs without requiring `PENGUIN_DOWNLOAD_SPEED_PROBE=1`.
- Increase the probe timing budget for slow but usable networks: 16s total, 5s manifest, 5s 64 KiB probe, and 8s 1 MiB GitHub probe.
- Preserve explicit behavior: `PENGUIN_DOWNLOAD_SPEED_PROBE=0`, forced `PENGUIN_DOWNLOAD_SOURCE`, and custom `PENGUIN_DOWNLOAD_BASE_URL` still skip speed probing.

## Current Speed-Probe Logic
- Speed probing runs only for online `auto` installs when no explicit download base URL is set.
- The installer first reads the same-release `release-download-manifest.tsv`, then probes the published 64 KiB file for source availability.
- If both sources are viable and the target asset is at least 32 MiB, the installer probes the 1 MiB GitHub file; GitHub is selected only when it reaches the 256 KiB/s minimum speed. Otherwise the installer keeps OSS as primary with same-version GitHub fallback.
- If probing is missing, invalid, timed out, or inconclusive, installation falls back to the existing OSS-first compatibility path.

## Changes
- `install.sh` and `install.ps1` now default `PENGUIN_DOWNLOAD_SPEED_PROBE` to `1` and use named timeout constants.
- POSIX and Windows installer tests can leave `PENGUIN_DOWNLOAD_SPEED_PROBE` unset, covering the default-on behavior.
- Forwarder handoff tests verify that landing installer wrappers leave speed probing enabled for the versioned installer.

## Test Plan
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm build`
- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `git diff --check`
- [x] `powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts\test-installer.ps1`
- [x] Docker: `apk add --no-cache zip >/dev/null && sh scripts/test-installer.sh`
- [x] `pnpm --filter @prismshadow/penguin-cli test`
- [x] `pnpm --filter @prismshadow/penguin-web test`
- [x] `pnpm --filter @prismshadow/penguin-desktop test`
- [ ] `pnpm test` reaches unrelated Windows-local failures in `packages/core`: symlink `EPERM` in `file-tools`/`memory`, plus an `exec-session` timing assertion (`3962ms` vs `<2000ms`).
- [ ] `pnpm --filter @prismshadow/penguin-server test` reaches unrelated Windows symlink `EPERM` failures in symlink coverage tests.