### PR TITLE
ci: run the Windows job's package suites one at a time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,8 +123,14 @@ jobs:
       - name: Typecheck (tsc)
         run: pnpm typecheck
 
+      # One package at a time. `pnpm -r test` runs packages in parallel, and this runner has
+      # two cores: core's exec_command suites spawn real shells and read their output under
+      # timeouts, so they lose races against the other packages' suites and fail differently
+      # on each run (a truncated stream, a command that never resolved). The assertions are
+      # right; the machine was oversubscribed. Ubuntu and macOS have the cores to spare and
+      # keep the default.
       - name: Unit tests (vitest)
-        run: pnpm test
+        run: pnpm -r --workspace-concurrency=1 test
 
       # The Linux job cannot validate PowerShell syntax; parse (never execute) the installer
       # scripts with the real PowerShell parser so a broken install.ps1 cannot ship.


### PR DESCRIPTION
`ci-windows` failed three times on the terminal branch (#285) before it merged, each on a **different** core test, and passed on re-run of the same commit:

| run | failing test | symptom |
| --- | --- | --- |
| `d65d80a2` | `environment.test.ts` — truncation | output did not start with `1\n2\n3\n` |
| `5c0187ff` | `engine.test.ts` — carry-over after exhausted retries | expected `'x'`, got `''` |
| `9c3c5291` | `environment.test.ts` — truncation disabled | `[exit code: 127]` instead of output |

That branch touched no `packages/core` code, and `main` was green throughout — so the assertions were right and the machine was not.

## Why

`pnpm -r test` runs packages in parallel and `windows-latest` has two cores. #285 added several hundred server and web tests to that job, and core's `exec_command` suites spawn real shells and read their output under timeouts (`seq 1 100000` through a pipe, among others). They lose the race, differently each time.

Now that #285 is on `main`, `main`'s Windows job carries the same load, so this is no longer branch-local.

## What

The Windows job runs one package at a time. Ubuntu and macOS have the cores to spare and keep the default, so **the required job's wall clock is unchanged**; only the advisory Windows job trades some minutes for determinism.

No test semantics change — nothing is skipped, no timeout is relaxed.

## Verification

Re-running the failed Windows job on the same commit passed, which is what established this as contention rather than a defect. The change itself is one line plus its rationale; the Windows job on this PR is the check that matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)