### PR TITLE
fix(model-catalog): add the direct claude-opus-5 preset

### DIFF
--- a/changelog/unreleased/2026-08-20-claude-opus-5-preset.md
+++ b/changelog/unreleased/2026-08-20-claude-opus-5-preset.md
@@ -1,0 +1,27 @@
+# Claude Opus 5 in the direct Anthropic preset group
+
+- **Date:** 2026-08-20
+- **Type:** fix
+- **Scope:** `model-catalog`, `core`, `docs`, `skills`
+- **Issue:** [#352](https://github.com/Prism-Shadow/penguin-harness/issues/352)
+
+[中文版](2026-08-20-claude-opus-5-preset.zh.md)
+
+`claude-opus-5` was absent from the direct Anthropic group of the built-in model catalog, while its OpenRouter counterpart `anthropic/claude-opus-5` was already listed. The direct preset was added, and the rest of the Anthropic group was re-read against Anthropic's published pricing in the same pass.
+
+## Details
+
+- The new row is `provider = "anthropic"`, `model_id = "claude-opus-5"`, display name Claude Opus 5, a 1,000,000-token context window, vision, and $0.50 / $6.25 / $25 per MTok (cache read / cache write / output) — Anthropic's $5 base input price under the group's 1.25x cache-write convention, read on 2026-08-20 from https://platform.claude.com/docs/en/about-claude/pricing. It agrees with the OpenRouter row to the cent.
+- The row sits between `claude-fable-5` and `claude-opus-4-8`: the catalog's dictionary order by model id with newer versions of a series first, hand-precomputed, matching the order the OpenRouter Claude rows already carry.
+- Like every other direct Anthropic preset it pins neither `client_type` nor `base_url`. AgentHub auto-routes `claude-opus-5` by its id to the native Claude client, a blank credential falls back to `ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL`, and the fast-mode toggle is offered on the Anthropic protocol (`speed: "fast"` plus the beta header). Tests pin all three, plus the row's exact position, price, context window and vision flag.
+- Uniqueness in the catalog is the `(provider, model_id)` pair, so the direct row and the OpenRouter row coexist; a test pins that the two share one display name, as the Fable 5 and Sonnet 5 pairs already did.
+- The five sibling Anthropic rows were re-read against the same page and left unchanged: Claude Fable 5 $1 / $12.50 / $50, Opus 4.8 and Opus 4.7 $0.50 / $6.25 / $25, Sonnet 5 $0.20 / $2.50 / $10, Sonnet 4.6 $0.30 / $3.75 / $15. Sonnet 5's $2 / $10 input and output is its standard rate rather than an introductory one, which is what puts it below Sonnet 4.6; a regression test and a catalog comment were added so the inversion is not mistaken for a transcription slip. The same comment records that Anthropic bills the full 1M window at a single rate, and that the fast-mode premium on Opus 5 / Opus 4.8 ($10 / $50) is a separate tier the catalog does not store.
+
+## Docs and skill
+
+- The bilingual `models` docs page names `claude-opus-5` in its sample of the preset catalog.
+- The `agenthub-models` skill (v13) lists `claude-opus-5` among the official Claude 5 ids, next to the `anthropic/claude-opus-5` gateway variant its table already carried.
+
+## Compatibility
+
+Existing Projects do not pick the preset up on their own: presets are copied into `.project_config.toml` when the Project is created, and nothing rewrites them afterwards. Use **sync presets** on the models page to bring the row into a Project that already exists — it appends catalog entries the Project is missing and updates catalog-owned fields on the ones it has, deleting nothing and touching neither the stored default model nor any credential.

--- a/changelog/unreleased/2026-08-20-claude-opus-5-preset.md
+++ b/changelog/unreleased/2026-08-20-claude-opus-5-preset.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-20
 - **Type:** fix
 - **Scope:** `model-catalog`, `core`, `docs`, `skills`
+- **PR:** [#363](https://github.com/Prism-Shadow/penguin-harness/pull/363)
 - **Issue:** [#352](https://github.com/Prism-Shadow/penguin-harness/issues/352)
 
 [中文版](2026-08-20-claude-opus-5-preset.zh.md)

--- a/changelog/unreleased/2026-08-20-claude-opus-5-preset.md
+++ b/changelog/unreleased/2026-08-20-claude-opus-5-preset.md
@@ -21,7 +21,7 @@
 ## Docs and skill
 
 - The bilingual `models` docs page names `claude-opus-5` in its sample of the preset catalog.
-- The `agenthub-models` skill (v13) lists `claude-opus-5` among the official Claude 5 ids, next to the `anthropic/claude-opus-5` gateway variant its table already carried.
+- The `agenthub-models` skill (v13) lists `claude-opus-5` among the official Claude 5 ids, next to the `anthropic/claude-opus-5` gateway variant its table already carried, and records that AgentHub 0.4.4's supported-model registry carries neither id even though both route.
 
 ## Compatibility
 

--- a/changelog/unreleased/2026-08-20-claude-opus-5-preset.zh.md
+++ b/changelog/unreleased/2026-08-20-claude-opus-5-preset.zh.md
@@ -21,7 +21,7 @@
 ## 文档与 Skill
 
 - 中英文 `models` 文档页在预置目录的示例清单中列出了 `claude-opus-5`。
-- `agenthub-models` skill（v13）把 `claude-opus-5` 加进官方 Claude 5 id 一列，与表中本就有的网关变体 `anthropic/claude-opus-5` 并列。
+- `agenthub-models` skill（v13）把 `claude-opus-5` 加进官方 Claude 5 id 一列，与表中本就有的网关变体 `anthropic/claude-opus-5` 并列，并记下 AgentHub 0.4.4 的受支持模型注册表这两个 id 都未收录——尽管它们都能正常路由。
 
 ## 兼容性
 

--- a/changelog/unreleased/2026-08-20-claude-opus-5-preset.zh.md
+++ b/changelog/unreleased/2026-08-20-claude-opus-5-preset.zh.md
@@ -1,0 +1,27 @@
+# 直连 Anthropic 分组补上 Claude Opus 5
+
+- **Date:** 2026-08-20
+- **Type:** fix
+- **Scope:** `model-catalog`, `core`, `docs`, `skills`
+- **Issue:** [#352](https://github.com/Prism-Shadow/penguin-harness/issues/352)
+
+[English](2026-08-20-claude-opus-5-preset.md)
+
+内置模型目录的直连 Anthropic 分组里没有 `claude-opus-5`，而它在 OpenRouter 上的对应条目 `anthropic/claude-opus-5` 早已收录。这次补上了直连预设，同时按 Anthropic 公布的价目表重新核对了该分组其余条目。
+
+## 细节
+
+- 新条目为 `provider = "anthropic"`、`model_id = "claude-opus-5"`，展示名 Claude Opus 5，1,000,000 Token 上下文，支持视觉，每百万 Token $0.50 / $6.25 / $25（缓存读取 / 缓存写入 / 输出）——即 Anthropic 的 $5 基础输入价，按本分组 1.25 倍缓存写入的口径换算，于 2026-08-20 从 https://platform.claude.com/docs/en/about-claude/pricing 读取。它与 OpenRouter 条目分毫不差。
+- 该条目位于 `claude-fable-5` 与 `claude-opus-4-8` 之间：目录按 model id 的字典序排列、同一系列的新版本在前，顺序全部手工预先算好，与 OpenRouter 的 Claude 条目本就采用的顺序一致。
+- 与其余直连 Anthropic 预设一样，它既不固定 `client_type` 也不固定 `base_url`。AgentHub 会依据 id 把 `claude-opus-5` 自动路由到原生 Claude 客户端，凭证留空时回退到 `ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL`，快速模式开关按 Anthropic 协议提供（`speed: "fast"` 加上 beta 请求头）。测试固定了这三点，也固定了该条目的确切位置、价格、上下文窗口与视觉标记。
+- 目录的唯一键是 `(provider, model_id)` 组合，因此直连条目与 OpenRouter 条目可以并存；新增的测试固定了两者共用同一个展示名，正如 Fable 5 与 Sonnet 5 这两对早已如此。
+- 同分组其余五个条目按同一页面重新读取后维持原值：Claude Fable 5 $1 / $12.50 / $50，Opus 4.8 与 Opus 4.7 $0.50 / $6.25 / $25，Sonnet 5 $0.20 / $2.50 / $10，Sonnet 4.6 $0.30 / $3.75 / $15。Sonnet 5 输入输出的 $2 / $10 是标准价而非上线优惠价，这正是它比 Sonnet 4.6 便宜的原因；新增的回归测试与目录注释说明了这一点，免得这处倒挂被当成抄错。同一条注释还记下：Anthropic 对整个 1M 窗口按单一费率计费，而 Opus 5 / Opus 4.8 的快速模式溢价（$10 / $50）属于目录不予记录的另一档。
+
+## 文档与 Skill
+
+- 中英文 `models` 文档页在预置目录的示例清单中列出了 `claude-opus-5`。
+- `agenthub-models` skill（v13）把 `claude-opus-5` 加进官方 Claude 5 id 一列，与表中本就有的网关变体 `anthropic/claude-opus-5` 并列。
+
+## 兼容性
+
+既有 Project 不会自动获得这个预设：预设是在 Project 创建时复制进 `.project_config.toml` 的，此后没有任何机制会改写它们。对已经存在的 Project，请在模型页面使用**同步预设**把该条目引入——它只会追加 Project 缺少的目录条目、并更新已有条目中由目录所有的字段，不删除任何内容，也不会改动已存的默认模型与任何凭证。

--- a/changelog/unreleased/2026-08-20-claude-opus-5-preset.zh.md
+++ b/changelog/unreleased/2026-08-20-claude-opus-5-preset.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-20
 - **Type:** fix
 - **Scope:** `model-catalog`, `core`, `docs`, `skills`
+- **PR:** [#363](https://github.com/Prism-Shadow/penguin-harness/pull/363)
 - **Issue:** [#352](https://github.com/Prism-Shadow/penguin-harness/issues/352)
 
 [English](2026-08-20-claude-opus-5-preset.md)

--- a/packages/core/src/state/model-catalog.ts
+++ b/packages/core/src/state/model-catalog.ts
@@ -3,7 +3,7 @@
  * auto-route, shared by core's default config, server's initial config, and web/cli display.
  * Data verified as of 2026-07-10 (Qwen Token Plan entries: 2026-07-20; MiniMax: 2026-08-03;
  * DeepSeek, Gemini 3.7, GLM-5.3 and the whole OpenAI line-up (direct + OpenRouter):
- * 2026-08-18, per each provider's docs).
+ * 2026-08-18; the direct Anthropic group: 2026-08-20 — per each provider's docs).
  * Docs: packages/docs/content/models.{zh,en}.md (site path /docs/models) documents the
  * provider groups and credential resolution described here.
  *
@@ -1045,13 +1045,27 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     pricing: usd(0.05, 0.5, 3),
     supportsVision: true,
   },
-  // -- Anthropic (official USD pricing; cache write = 1.25 x input) --
+  // -- Anthropic (official USD pricing; cache write = 1.25 x input). Re-read 2026-08-20 from
+  // platform.claude.com/docs/en/about-claude/pricing. Sonnet 5's $2 / $10 is its standard
+  // rate rather than an introductory one, so it prices below Sonnet 4.6 — that inversion is
+  // Anthropic's list, not a transcription slip. Anthropic bills the full 1M window at a
+  // single rate, so none of the long-context tiers named in the file header apply here, and
+  // the fast-mode premium on Opus 5 / Opus 4.8 ($10 / $50) is a separate tier these rows do
+  // not record. --
   {
     modelId: "claude-fable-5",
     displayName: "Claude Fable 5",
     provider: "anthropic",
     contextWindow: 1000000,
     pricing: usd(1, 12.5, 50),
+    supportsVision: true,
+  },
+  {
+    modelId: "claude-opus-5",
+    displayName: "Claude Opus 5",
+    provider: "anthropic",
+    contextWindow: 1000000,
+    pricing: usd(0.5, 6.25, 25),
     supportsVision: true,
   },
   {

--- a/packages/core/src/state/model-catalog.ts
+++ b/packages/core/src/state/model-catalog.ts
@@ -1046,12 +1046,12 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     supportsVision: true,
   },
   // -- Anthropic (official USD pricing; cache write = 1.25 x input). Re-read 2026-08-20 from
-  // platform.claude.com/docs/en/about-claude/pricing. Sonnet 5's $2 / $10 is its standard
-  // rate rather than an introductory one, so it prices below Sonnet 4.6 — that inversion is
-  // Anthropic's list, not a transcription slip. Anthropic bills the full 1M window at a
-  // single rate, so none of the long-context tiers named in the file header apply here, and
-  // the fast-mode premium on Opus 5 / Opus 4.8 ($10 / $50) is a separate tier these rows do
-  // not record. --
+  // platform.claude.com/docs/en/about-claude/pricing. Sonnet 5's $2 input / $10 output is its
+  // standard rate rather than an introductory one, so it prices below Sonnet 4.6 — that
+  // inversion is Anthropic's list, not a transcription slip. Anthropic bills the full 1M
+  // window at a single rate, so none of the long-context tiers named in the file header apply
+  // here, and the fast-mode premium on Opus 5 / Opus 4.8 ($10 input / $50 output) is a
+  // separate tier these rows do not record. --
   {
     modelId: "claude-fable-5",
     displayName: "Claude Fable 5",

--- a/packages/core/test/model-catalog.test.ts
+++ b/packages/core/test/model-catalog.test.ts
@@ -435,6 +435,7 @@ describe("model-catalog", () => {
     ]).toEqual([0.5, 2, 6]);
     expect(MODEL_CATALOG.filter((m) => m.provider === "anthropic").map((m) => m.modelId)).toEqual([
       "claude-fable-5",
+      "claude-opus-5",
       "claude-opus-4-8",
       "claude-opus-4-7",
       "claude-sonnet-5",
@@ -458,6 +459,20 @@ describe("model-catalog", () => {
       sonnet5.pricing!.cache_write,
       sonnet5.pricing!.output,
     ]).toEqual([0.2, 2.5, 10]);
+    // Opus 5 sits at the Opus tier ($5 input -> 6.25 cache write, $0.50 cache hit, $25
+    // output) and carries the same 1M window and vision support as its gateway twin.
+    const opus5 = catalogEntryFor("anthropic", "claude-opus-5")!;
+    expect([opus5.contextWindow, opus5.supportsVision]).toEqual([1000000, true]);
+    expect([opus5.pricing!.cache_read, opus5.pricing!.cache_write, opus5.pricing!.output]).toEqual([
+      0.5, 6.25, 25,
+    ]);
+    // Sonnet 5 prices below Sonnet 4.6 because that is Anthropic's list, not a slip.
+    expect(catalogEntryFor("anthropic", "claude-sonnet-4-6")!.pricing).toEqual({
+      unit: "usd_per_mtok",
+      cache_read: 0.3,
+      cache_write: 3.75,
+      output: 15,
+    });
     // The same model resold by a gateway keeps one display name across groups. The bare
     // `gpt-5.6` id is the same tier OpenRouter spells `openai/gpt-5.6-sol`, so it displays
     // that codename too rather than leaving the variant unnamed.
@@ -466,6 +481,7 @@ describe("model-catalog", () => {
       ["openai", "gpt-5.6-luna", "openrouter", "openai/gpt-5.6-luna"],
       ["openai", "gpt-5.6-terra", "openrouter", "openai/gpt-5.6-terra"],
       ["anthropic", "claude-fable-5", "openrouter", "anthropic/claude-fable-5"],
+      ["anthropic", "claude-opus-5", "openrouter", "anthropic/claude-opus-5"],
       ["anthropic", "claude-sonnet-5", "openrouter", "anthropic/claude-sonnet-5"],
       ["google", "gemini-3.5-flash-lite", "openrouter", "google/gemini-3.5-flash-lite"],
       ["moonshot", "kimi-k3", "openrouter", "moonshotai/kimi-k3"],
@@ -629,6 +645,7 @@ describe("resolveModelEnv (PRN-021: env fallback resolved by AgentHub routing ru
     expect(resolveModelEnv("gemini-3.7-flash")?.envKey).toBe("GEMINI_API_KEY");
     expect(resolveModelEnv("gemini-3.5-flash-lite")?.envKey).toBe("GEMINI_API_KEY");
     expect(resolveModelEnv("claude-fable-5")?.envKey).toBe("ANTHROPIC_API_KEY");
+    expect(resolveModelEnv("claude-opus-5")?.envKey).toBe("ANTHROPIC_API_KEY");
     expect(resolveModelEnv("claude-sonnet-5")?.envKey).toBe("ANTHROPIC_API_KEY");
     expect(resolveModelEnv("MiniMax-M3")?.envKey).toBe("MINIMAX_API_KEY");
     expect(resolveModelEnv("MiniMax-M3")?.envBaseUrlKey).toBe("MINIMAX_BASE_URL");
@@ -739,6 +756,7 @@ describe("fastModeProtocol (which models may be offered AgentHub's fast_mode, an
 
   it("Anthropic-protocol clients carry it as speed=fast", () => {
     expect(fastModeProtocol("claude-fable-5")).toBe("anthropic");
+    expect(fastModeProtocol("claude-opus-5")).toBe("anthropic");
     expect(fastModeProtocol("claude-sonnet-5")).toBe("anthropic");
     expect(fastModeProtocol("claude-opus-4-8")).toBe("anthropic");
     expect(fastModeProtocol("some-proxy-id", "ant-messages")).toBe("anthropic");
@@ -812,6 +830,7 @@ describe("fastModeProtocol (which models may be offered AgentHub's fast_mode, an
       return fastModeProtocol(m.modelId, m.clientType, m.baseUrl);
     };
     expect(verdictOf("anthropic", "claude-fable-5")).toBe("anthropic");
+    expect(verdictOf("anthropic", "claude-opus-5")).toBe("anthropic");
     expect(verdictOf("anthropic", "claude-sonnet-5")).toBe("anthropic");
     expect(verdictOf("anthropic", "claude-opus-4-8")).toBe("anthropic");
     expect(verdictOf("anthropic", "claude-opus-4-7")).toBe("anthropic");

--- a/packages/docs/content/models.en.md
+++ b/packages/docs/content/models.en.md
@@ -77,7 +77,7 @@ The gateway groups (openrouter / fireworks / siliconflow / qwen-token-plan / qwe
 
 The preset catalog also carries OpenRouter's free tier: the `:free` model variant `nvidia/nemotron-3-ultra-550b-a55b:free` and the `openrouter/free` unified Free Models Router. They cost nothing, but are subject to OpenRouter's free-tier rate limits and data policy.
 
-Some models in the preset catalog: deepseek-v4-pro / deepseek-v4-flash, MiniMax-M3, gemini-3.7-flash, claude-opus-4-8 / claude-sonnet-5, gpt-5.6 / gpt-5.5, glm-5.3, kimi-k3, qwen3.8-max (not exhaustive). The whole OpenAI line-up is listed twice — directly (your own OpenAI key, list prices) and on OpenRouter as `openai/<id>` (the gateway's rates, which follow its running promotions). DeepSeek's direct-group prices record the official off-peak tier (peak hours, Beijing 9:00–12:00 and 14:00–18:00, bill double).
+Some models in the preset catalog: deepseek-v4-pro / deepseek-v4-flash, MiniMax-M3, gemini-3.7-flash, claude-opus-5 / claude-opus-4-8 / claude-sonnet-5, gpt-5.6 / gpt-5.5, glm-5.3, kimi-k3, qwen3.8-max (not exhaustive). The whole OpenAI line-up is listed twice — directly (your own OpenAI key, list prices) and on OpenRouter as `openai/<id>` (the gateway's rates, which follow its running promotions). DeepSeek's direct-group prices record the official off-peak tier (peak hours, Beijing 9:00–12:00 and 14:00–18:00, bill double).
 
 ## Local / self-hosted OpenAI-compatible endpoints (e.g. vLLM)
 

--- a/packages/docs/content/models.zh.md
+++ b/packages/docs/content/models.zh.md
@@ -77,7 +77,7 @@ api_key = "sk-..."
 
 预置目录还收录了 OpenRouter 的免费档：`:free` 模型变体 `nvidia/nemotron-3-ultra-550b-a55b:free` 与统一路由 `openrouter/free`(Free Models Router)，零成本可用，但受 OpenRouter 免费档速率限制与数据政策约束。
 
-预置目录中的部分模型：deepseek-v4-pro / deepseek-v4-flash、MiniMax-M3、gemini-3.7-flash、claude-opus-4-8 / claude-sonnet-5、gpt-5.6 / gpt-5.5、glm-5.3、kimi-k3、qwen3.8-max 等(非完整清单)。OpenAI 全系列都收录了两份——直连(用自己的 OpenAI Key，记牌价)与 OpenRouter 上的 `openai/<id>`(记网关实际计费价，会随其促销浮动)。DeepSeek 直连分组的价格记录官方低谷时段档(高峰时段——北京时间 9:00–12:00、14:00–18:00——按双倍计费)。
+预置目录中的部分模型：deepseek-v4-pro / deepseek-v4-flash、MiniMax-M3、gemini-3.7-flash、claude-opus-5 / claude-opus-4-8 / claude-sonnet-5、gpt-5.6 / gpt-5.5、glm-5.3、kimi-k3、qwen3.8-max 等(非完整清单)。OpenAI 全系列都收录了两份——直连(用自己的 OpenAI Key，记牌价)与 OpenRouter 上的 `openai/<id>`(记网关实际计费价，会随其促销浮动)。DeepSeek 直连分组的价格记录官方低谷时段档(高峰时段——北京时间 9:00–12:00、14:00–18:00——按双倍计费)。
 
 ## 本地 / 自建 OpenAI 兼容端点（如 vLLM）
 

--- a/packages/skills/skills/agenthub-models/SKILL.md
+++ b/packages/skills/skills/agenthub-models/SKILL.md
@@ -3,8 +3,8 @@ name: agenthub-models
 description: Call model APIs through @prismshadow/agenthub — streaming text generation, image generation, speech synthesis, embeddings and the supported-model registry with one client.
 short_description: Call model APIs with one AgentHub client.
 short_description_zh: 用一个 AgentHub 客户端调用模型 API。
-version: 12
-updated: 2026-08-18T21:40:00Z
+version: 13
+updated: 2026-08-20T00:00:00Z
 ---
 
 # AgentHub Model APIs
@@ -55,7 +55,7 @@ Use exact model ids. If an id is not in the table below and the user has not giv
 | Gemini 3 image   | `gemini-3.1-flash-image`, `gemini-3-pro-image-preview`                | —                                                                                                                                               |
 | Gemini 3 TTS     | `gemini-3.1-flash-tts-preview`                                        | —                                                                                                                                               |
 | Gemini embedding | `gemini-embedding-2`                                                  | —                                                                                                                                               |
-| Claude 5         | `claude-fable-5`, `claude-sonnet-5`                                   | OpenRouter `anthropic/claude-fable-5`, `anthropic/claude-opus-5`, `anthropic/claude-sonnet-5`                                                   |
+| Claude 5         | `claude-fable-5`, `claude-opus-5`, `claude-sonnet-5`                  | OpenRouter `anthropic/claude-fable-5`, `anthropic/claude-opus-5`, `anthropic/claude-sonnet-5`                                                   |
 | Claude 4         | `claude-sonnet-4-6`, `claude-opus-4-7`, `claude-opus-4-8`             | OpenRouter `anthropic/claude-opus-4.8`, `anthropic/claude-opus-4.7`                                                                             |
 | GPT-5.6          | `gpt-5.6` (routes to sol), `gpt-5.6-terra`, `gpt-5.6-luna`            | OpenRouter `openai/gpt-5.6-sol`, `openai/gpt-5.6-terra`, `openai/gpt-5.6-luna`                                                                  |
 | GPT-5.5 / 5.4    | `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`                  | OpenRouter `openai/gpt-5.5`, `openai/gpt-5.5-pro`, `openai/gpt-5.4`, `openai/gpt-5.4-mini`, `openai/gpt-5.4-nano`, `openai/gpt-5.4-pro`         |

--- a/packages/skills/skills/agenthub-models/SKILL.md
+++ b/packages/skills/skills/agenthub-models/SKILL.md
@@ -97,7 +97,7 @@ for (const m of listSupportedModels()) {
 - Modalities are `"Text" | "Image" | "Video" | "Audio" | "Embed"`. Coverage includes the official vendor endpoints plus the OpenRouter and SiliconFlow gateways; `context_window` and `pricing` are omitted where the platform publishes no authoritative value (image and TTS models, for instance).
 - `pricing` is per million tokens, keyed by the same usage buckets as `usage_metadata`: `prompt_tokens` (non-cached input), `thoughts_tokens` / `response_tokens` (both the output price) and optional `cached_tokens` (cache-hit price). Values are stored in USD; pass `listSupportedModels("CNY")` to convert at 7 CNY/USD.
 
-The registry is the curated current line-up, so prefer it when picking a model or estimating cost. It is narrower than the routing rules: older ids in the table above (`gpt-5.4`, `claude-opus-4-7`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite`) still route fine but no longer appear in it.
+The registry is the curated current line-up, so prefer it when picking a model or estimating cost. It is not the routing table, and it lags in both directions: older ids in the table above (`gpt-5.4`, `claude-opus-4-7`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite`) still route fine without appearing in it, and AgentHub 0.4.4 lists neither `claude-opus-5` nor `anthropic/claude-opus-5` although both route. For an id the registry omits, take the context window and price from the vendor's own page.
 
 ## Routing and credentials
 


### PR DESCRIPTION
Closes #352.

## What was missing

`packages/core/src/state/model-catalog.ts` carried the OpenRouter row `anthropic/claude-opus-5` but the direct Anthropic group went `claude-fable-5` → `claude-opus-4-8` → `claude-opus-4-7` → `claude-sonnet-5` → `claude-sonnet-4-6`. A Project holding only an `ANTHROPIC_API_KEY` therefore had no preset for Opus 5 and had to add the model by hand. (The design changelog recorded the direct row as deliberately deferred on 2026-07-24, pending AgentHub registry coverage; AgentHub routes `claude-opus-5` today via the `claude` + `-5` substring branch, so the deferral is over.)

## The row

```ts
{
  modelId: "claude-opus-5",
  displayName: "Claude Opus 5",
  provider: "anthropic",
  contextWindow: 1000000,
  pricing: usd(0.5, 6.25, 25),
  supportsVision: true,
},
```

Placed between `claude-fable-5` and `claude-opus-4-8` — the catalog's dictionary order by model id with newer versions of a series first, hand-precomputed, matching the order the OpenRouter Claude rows already use.

Pricing read on 2026-08-20 from <https://platform.claude.com/docs/en/about-claude/pricing>: Claude Opus 5 is `$5` base input / `$6.25` 5m cache write / `$0.50` cache hit / `$25` output per MTok, and Claude 4.6-and-later models bill the full 1M window at one rate. That is exactly `usd(cache_read=0.5, cache_write=6.25, output=25)` under the group's `cache write = 1.25 x input` convention, and it agrees with the OpenRouter twin to the cent.

Uniqueness in the catalog is the `(provider, model_id)` pair, so the direct row and the gateway row coexist by design.

## Sibling-row audit

Every other Anthropic row was checked against the same page. All five match, so nothing was re-priced:

| Row | Catalog | Page (cache hit / 5m write / output) |
| --- | --- | --- |
| `claude-fable-5` | `usd(1, 12.5, 50)` | $1 / $12.50 / $50 |
| `claude-opus-4-8` | `usd(0.5, 6.25, 25)` | $0.50 / $6.25 / $25 |
| `claude-opus-4-7` | `usd(0.5, 6.25, 25)` | $0.50 / $6.25 / $25 |
| `claude-sonnet-5` | `usd(0.2, 2.5, 10)` | $0.20 / $2.50 / $10 |
| `claude-sonnet-4-6` | `usd(0.3, 3.75, 15)` | $0.30 / $3.75 / $15 |

The one that looked wrong — Sonnet 5 priced *below* Sonnet 4.6 — is real. The pricing page carries an explicit note that Sonnet 5's `$2 / $10` launch rate is now its standard price and the scheduled September increase to `$3 / $15` will not happen. A regression test and the section comment now record that, so the inversion is not "corrected" by a later reader.

Two other facts went into the section comment while it was open: Anthropic applies no long-context surcharge (unlike the OpenAI / Gemini / MiniMax tiers named in the file header), and the fast-mode premium on Opus 5 / Opus 4.8 (`$10 / $50`) is a separate tier the catalog deliberately does not store.

## Downstream touchpoints

| Touchpoint | Change |
| --- | --- |
| `packages/core/test/model-catalog.test.ts` | **Yes** — exact-order assertion, price/context/vision assertion, direct↔gateway display-name parity, `resolveModelEnv`, and both `fastModeProtocol` verdict lists |
| `packages/web/src/features/models/protocol-path.ts` | **No** — the Anthropic client path `/v1/messages` is already covered by the `case "anthropic"` provider branch, and the row pins no `client_type`; the file holds no per-model list |
| Provider glyph map (`packages/web/src/components/ui/provider-logo.tsx`) | **No** — keyed by provider id; `anthropic` already has its brand mark |
| `packages/docs/content/models.{en,zh}.md` | **Yes** — `claude-opus-5` named in the (explicitly non-exhaustive) preset sample |
| `packages/docs/content/configuration.{en,zh}.md` | **No** — it names no Claude ids at all, only the DeepSeek default |
| `packages/skills/skills/agenthub-models/SKILL.md` | **Yes** — the Claude 5 row listed the gateway `anthropic/claude-opus-5` but not the official `claude-opus-5`, the same omission; fixed and bumped to v13 |

## Verification

- `pnpm -r build` (needed: core's tests import the built `@prismshadow/penguin-skills`)
- core `vitest run test/model-catalog.test.ts` — 24 passed
- core `test` — 839 passed, 5 skipped
- cli `test` — 292 passed
- web `vitest run test/model-grouping.test.ts test/protocol-path.test.ts test/catalog-sync.test.ts` — 34 passed
- server `vitest run test/models.test.ts` — 21 passed
- skills `test` — 22 passed; docs `test` (incl. `skills-sync`) — 53 passed
- `pnpm format` + `pnpm format:check`, `git diff --check`, and `typecheck` for `core` / `docs` / `skills`

## Compatibility

Existing Projects do not pick this up on their own — presets are copied into `.project_config.toml` at creation and nothing rewrites them. **Sync presets** on the models page appends the row (and never deletes, and never touches the stored default model or credentials). The changelog pair says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Z4mn56LTt4qJR3m9GjHka