### PR TITLE
fix(web): merge /api/me's upload limits over the defaults

### DIFF
--- a/changelog/unreleased/2026-08-20-upload-limits-version-skew.md
+++ b/changelog/unreleased/2026-08-20-upload-limits-version-skew.md
@@ -1,0 +1,21 @@
+# A newer Web App no longer crashes on an older server's `/api/me`
+
+- **Date:** 2026-08-20
+- **Type:** fix
+- **Scope:** `web`
+
+[中文版](2026-08-20-upload-limits-version-skew.zh.md)
+
+Opening Upload limits against a server that predates
+[#350](https://github.com/Prism-Shadow/penguin-harness/pull/350) crashed the page with
+`Cannot read properties of undefined (reading 'attachmentLimitMinMb')`.
+
+The Web App and the runtime serving it are routinely different versions — that is what the
+hot channel is for, and the desktop shell also attaches to whatever server is already
+running. `/api/me`'s upload limits were assigned straight into state, so a payload from
+before those fields existed replaced the built-in defaults with `undefined` wholesale, and
+the first component to read a limit off them took the page down.
+
+The payload is merged over the defaults now: a server's answer wins wherever it has one,
+and anything it does not carry keeps the default. Only a display concern either way — the
+server re-validates every upload against its own real limits regardless.

--- a/changelog/unreleased/2026-08-20-upload-limits-version-skew.zh.md
+++ b/changelog/unreleased/2026-08-20-upload-limits-version-skew.zh.md
@@ -1,0 +1,13 @@
+# 较新的 Web App 不再因旧服务端的 `/api/me` 而崩溃
+
+- **Date:** 2026-08-20
+- **Type:** fix
+- **Scope:** `web`
+
+[English](2026-08-20-upload-limits-version-skew.md)
+
+在早于 [#350](https://github.com/Prism-Shadow/penguin-harness/pull/350) 的服务端上打开「上传限制」会让页面崩溃，报 `Cannot read properties of undefined (reading 'attachmentLimitMinMb')`。
+
+Web App 与为它提供服务的运行时本来就经常是不同版本——热更新通道存在的意义正在于此，而桌面外壳也会附着到任何一个已在运行的服务端上。此前 `/api/me` 返回的上传限制被直接赋值进 state，于是一份来自「这些字段还不存在」的年代的载荷，会把内置默认值整个替换成 `undefined`，第一个读取限制的组件就把页面带崩了。
+
+现在这份载荷是叠加在默认值之上的：服务端给出答案的字段以服务端为准，它没有携带的字段保留默认值。两种情况下这都只是显示层面的事——每一次上传，服务端仍然按它自己真实的限制重新校验。

--- a/packages/web/src/state/auth.tsx
+++ b/packages/web/src/state/auth.tsx
@@ -16,6 +16,18 @@ import { ApiError, setUnauthorizedHandler } from "../api/client";
  * against the real limits regardless, so a stale value here can only make the composer's
  * pre-flight check slightly wrong, never let an oversize file through.
  */
+/**
+ * Fills in what a `/api/me` payload did not carry. The Web App and the runtime serving it
+ * are routinely different versions — a hot update pushes the dist without restarting the
+ * server, and the desktop shell attaches to whatever server is already running — so a field
+ * added on one side arrives as `undefined` on the other. Assigning the payload straight
+ * through replaced the defaults with `undefined` wholesale, and the first component to read
+ * a limit off it crashed the page (`Cannot read properties of undefined`).
+ */
+export function withDefaultUploadLimits(limits: Partial<UploadLimits> | undefined): UploadLimits {
+  return { ...DEFAULT_UPLOAD_LIMITS, ...limits };
+}
+
 const DEFAULT_UPLOAD_LIMITS: UploadLimits = {
   attachmentMaxMb: 100,
   attachmentTotalMb: 120,
@@ -89,7 +101,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setPreviewIsolated(res.previewIsolated);
         setDesktopMode(res.desktopMode);
         setSessionVia(res.sessionVia);
-        setUploadLimits(res.uploadLimits);
+        setUploadLimits(withDefaultUploadLimits(res.uploadLimits));
       })
       .catch((err: unknown) => {
         if (cancelled) return;
@@ -117,7 +129,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setPreviewIsolated(me.previewIsolated);
       setDesktopMode(me.desktopMode);
       setSessionVia(me.sessionVia);
-      setUploadLimits(me.uploadLimits);
+      setUploadLimits(withDefaultUploadLimits(me.uploadLimits));
     } catch {
       // Login itself succeeded; keep the optimistic default.
     }
@@ -137,7 +149,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setPreviewIsolated(res.previewIsolated);
     setDesktopMode(res.desktopMode);
     setSessionVia(res.sessionVia);
-    setUploadLimits(res.uploadLimits);
+    setUploadLimits(withDefaultUploadLimits(res.uploadLimits));
   }, []);
 
   return (

--- a/packages/web/test/upload-limits-skew.test.ts
+++ b/packages/web/test/upload-limits-skew.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Upload limits across a version boundary (state/auth.tsx).
+ *
+ * The Web App and the runtime serving it are routinely different versions: a hot update
+ * pushes the dist without restarting the server, and the desktop shell attaches to whatever
+ * server is already running. A `/api/me` payload from the other side of such a boundary is
+ * missing whatever the two sides do not both know about — and assigning it straight through
+ * replaced the whole defaults object, so the first component to read a limit off it crashed
+ * the page with `Cannot read properties of undefined (reading 'attachmentLimitMinMb')`.
+ */
+import { describe, expect, it } from "vitest";
+import { withDefaultUploadLimits } from "../src/state/auth";
+
+describe("withDefaultUploadLimits", () => {
+  it("survives a server that predates the field entirely", () => {
+    // What a runtime older than the admin-settable limits returns: no uploadLimits at all.
+    const limits = withDefaultUploadLimits(undefined);
+    expect(limits.attachmentLimitMinMb).toBeTypeOf("number");
+    expect(limits.attachmentMaxMb).toBeGreaterThan(0);
+  });
+
+  it("fills in only the fields a partial payload is missing", () => {
+    // A runtime that knows the older limits but not the newer range.
+    const limits = withDefaultUploadLimits({
+      attachmentMaxMb: 25,
+      attachmentTotalMb: 50,
+      attachmentMaxCount: 5,
+      imageMaxMb: 10,
+    });
+    expect(limits.attachmentMaxMb).toBe(25); // the server's answer wins where it has one
+    expect(limits.attachmentLimitMinMb).toBeTypeOf("number"); // and the gap is filled
+    expect(limits.attachmentLimitMaxMb).toBeGreaterThanOrEqual(limits.attachmentLimitMinMb);
+  });
+
+  it("passes a complete payload through unchanged", () => {
+    const wire = {
+      attachmentMaxMb: 7,
+      attachmentTotalMb: 8,
+      attachmentMaxCount: 9,
+      imageMaxMb: 10,
+      attachmentLimitMinMb: 11,
+      attachmentLimitMaxMb: 12,
+    };
+    expect(withDefaultUploadLimits(wire)).toEqual(wire);
+  });
+});


### PR DESCRIPTION
Reported from a running app:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'attachmentLimitMinMb')
```

Opening **Upload limits** against a server older than #350 takes the page down.

## Why

The Web App and the runtime serving it are routinely different versions — that is what the hot channel is for, and the desktop shell also attaches to whatever server is already running. All three `/api/me` handlers in `state/auth.tsx` did:

```ts
setUploadLimits(res.uploadLimits);
```

A payload from before those fields existed carries no `uploadLimits`, so this replaced `DEFAULT_UPLOAD_LIMITS` with `undefined` **wholesale** — and `upload-limits-dialog.tsx` reads `uploadLimits.attachmentLimitMinMb` on render. A server that knows the older limits but not the newer range would have done the same to just those two fields.

## What

The payload is merged over the defaults, per field: the server's answer wins wherever it has one, a gap keeps the default. Display only either way — the server re-validates every upload against its own real limits regardless, so a stale value here can never let an oversize file through.

## Verification

`packages/web/test/upload-limits-skew.test.ts` drives the three shapes that cross a version boundary — absent, partial, complete. Reverting the merge reproduces the reported error text verbatim on the first of them:

```
× survives a server that predates the field entirely
  → Cannot read properties of undefined (reading 'attachmentLimitMinMb')
× fills in only the fields a partial payload is missing
  → expected undefined to be type of 'number'
```

Web unit 992/992, typecheck and Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)