### PR TITLE
perf(server,tooling): make the unit-test suite ~1.7x faster, and trim prose-pinned assertions

### DIFF
--- a/changelog/unreleased/2026-08-20-faster-unit-tests.md
+++ b/changelog/unreleased/2026-08-20-faster-unit-tests.md
@@ -1,0 +1,60 @@
+# A faster unit-test suite, and assertions that stop transcribing prose
+
+- **Date:** 2026-08-20
+- **Type:** process
+- **Scope:** `server`, `core`, `web`, `skills`, `tooling`
+
+[中文版](2026-08-20-faster-unit-tests.zh.md)
+
+`pnpm -r test` went from a 64.7s median to 38.7s, and the server package — which the
+workspace's dependency order puts on the critical path — from 51.5s to 13.4s, measured over
+five interleaved before/after runs on an 8-core Linux box. Two changes account for it: a
+token scrypt cost for password hashing in tests, and a module registry the server's vitest
+workers keep across the files they run. A separate sweep replaced assertions that
+transcribed prose out of shipped documents and i18n dictionaries with the invariants
+underneath them.
+
+## Password hashing in tests
+
+- `hashPassword` took the scrypt work factor as a defaulted argument, and `buildAppDeps`
+  gained a `passwordHashCost` override alongside the `loader` / `titles` / `updateCheck`
+  test doubles it already accepted. The server's test helper passes the lowest legal
+  factor. Nothing on the production path passes the argument, and `buildAppDeps` is not in
+  the package's `exports`, so no configuration reaches it.
+- The stored format, the recorded parameters and the verification path are the same either
+  way: the factor travels inside the hash string, so `verifyPassword` re-derives at
+  whatever cost wrote it and hashes already on disk keep verifying.
+- `password.test.ts` calls the unparameterized form and now asserts the production factor
+  is 16384, so lowering the default has to be a deliberate edit to that test.
+
+## Worker isolation
+
+- `packages/server/vitest.config.ts` set `isolate: false`, so a worker keeps its module
+  registry across the files it runs. Every file in that suite imports the whole app graph,
+  core's bundle included. Fork spawns went from one per test file to one per worker.
+- The pool stayed `forks`: `process.env` is per-process, and several files in this suite
+  mutate and restore it, so a thread pool would let them race.
+- The same config set `restoreMocks: true`, so a spy whose inline `mockRestore()` is
+  skipped by a failing assertion cannot stay installed for the rest of the worker.
+- `packages/server/test/isolation.test.ts` fails if any file in the suite registers a
+  module mock — the one thing a shared registry cannot tolerate, and the one whose damage
+  would surface in an unrelated file.
+
+## Assertions that transcribed prose
+
+- `packages/skills`: three tests pinned about 140 exact sentences from `benchmark-design`,
+  `agent-evaluation`, `agent-optimization` and `remote-claude-code`. Five tests replaced
+  them, pinning what an agent executes — the launch statements and their CLI flags, the
+  tmux commands, the Evaluator protocol's block scalars and absent `max_score` — and the
+  section ordering those documents depend on.
+- `packages/web`: kernel field labels, memory chat drafts, compaction titles and nav toggle
+  names assert through the dictionaries instead of transcribing their values, and the
+  kernel-label test covers every key in both dictionaries rather than two of them. The
+  example-task drafts keep their parameter markers, forbidden markers and length bounds,
+  and let the scenario copy change.
+- `packages/core`: the default system prompt's guardrail test kept what a reword must not
+  change — no service port number, no vault CLI command — and the ordering that puts the
+  retry rule inside `# Stop rules`.
+- `packages/cli`: the readiness probe's firewall hint is checked for the port number and
+  for being distinct from the refused-connection hint, rather than by both translations of
+  the sentence.

--- a/changelog/unreleased/2026-08-20-faster-unit-tests.md
+++ b/changelog/unreleased/2026-08-20-faster-unit-tests.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-20
 - **Type:** process
 - **Scope:** `server`, `core`, `web`, `skills`, `tooling`
+- **PR:** [#381](https://github.com/Prism-Shadow/penguin-harness/pull/381)
 
 [中文版](2026-08-20-faster-unit-tests.zh.md)
 

--- a/changelog/unreleased/2026-08-20-faster-unit-tests.zh.md
+++ b/changelog/unreleased/2026-08-20-faster-unit-tests.zh.md
@@ -1,0 +1,50 @@
+# 更快的单元测试套件，以及不再誊写文案的断言
+
+- **Date:** 2026-08-20
+- **Type:** process
+- **Scope:** `server`, `core`, `web`, `skills`, `tooling`
+
+[English](2026-08-20-faster-unit-tests.md)
+
+`pnpm -r test` 的中位耗时从 64.7 秒降到 38.7 秒，server 包——工作区的依赖顺序把它放在关键
+路径上——从 51.5 秒降到 13.4 秒；数据取自一台 8 核 Linux 机器上交替执行的五轮改前/改后测量。
+两处改动带来了这个结果：测试中密码哈希改用极低的 scrypt 开销，以及 server 的 vitest worker
+在它负责的多个文件之间保留模块注册表。另有一轮清扫，把誊写自发布文档与 i18n 词典的断言换成了
+它们背后真正的不变式。
+
+## 测试中的密码哈希
+
+- `hashPassword` 把 scrypt 的开销因子改成带默认值的参数，`buildAppDeps` 在原有的 `loader` /
+  `titles` / `updateCheck` 测试替身之外新增 `passwordHashCost` 覆盖项。服务端的测试 helper
+  传入合法的最小因子。生产路径不传这个参数，而 `buildAppDeps` 不在包的 `exports` 里，任何
+  配置都够不到它。
+- 两种情况下存储格式、记录的参数与校验路径完全一致：因子写在哈希串内部，`verifyPassword`
+  按写入时的开销重新推导，已经落盘的哈希照常校验通过。
+- `password.test.ts` 调用不带参数的形式，并新增断言：生产开销因子为 16384——要调低默认值，
+  就得先动这个测试。
+
+## Worker 隔离
+
+- `packages/server/vitest.config.ts` 设置 `isolate: false`，worker 在它负责的多个文件之间保留
+  模块注册表。该套件里每个文件都会导入整个 app 依赖图，其中包含 core 的产物包。fork 的创建
+  次数从每个测试文件一次降为每个 worker 一次。
+- 进程池仍是 `forks`：`process.env` 是进程级的，而这里有若干文件会修改并还原它，换成线程池
+  会让它们互相竞争。
+- 同一份配置设置了 `restoreMocks: true`：某个 spy 的行内 `mockRestore()` 若被它上方失败的断言
+  跳过，也不会在该 worker 余下的运行里一直生效。
+- `packages/server/test/isolation.test.ts` 会在套件中任何文件注册模块 mock 时失败——那是共享
+  注册表唯一无法容忍的东西，也是出事后会在无关文件里显形的那一种。
+
+## 誊写文案的断言
+
+- `packages/skills`：三个测试固定了约 140 条来自 `benchmark-design`、`agent-evaluation`、
+  `agent-optimization` 与 `remote-claude-code` 的原句。改为五个测试，只固定 agent 会执行的
+  东西——启动语句及其 CLI 参数、tmux 命令、Evaluator 协议的块标量与不该出现的 `max_score`
+  ——以及这些文档依赖的章节先后顺序。
+- `packages/web`：kernel 字段标签、记忆对话草稿、压缩标题与导航开关名称改为经由词典断言，而不是
+  誊写词典的值；kernel 标签测试的覆盖面也从两个键扩大到两份词典的全部键。示例任务草稿保留参数
+  标记、禁止出现的标记与长度上限，场景文案可以自由改动。
+- `packages/core`：默认系统提示词的护栏测试保留了改写不得触碰的部分——不出现服务端口号、不出现
+  vault CLI 命令——以及把重试规则固定在 `# Stop rules` 之内的顺序断言。
+- `packages/cli`：探活失败的防火墙提示改为检查其中是否含端口号、以及是否与连接被拒的提示不同，
+  而不是把这句话的两种译文都写死。

--- a/changelog/unreleased/2026-08-20-faster-unit-tests.zh.md
+++ b/changelog/unreleased/2026-08-20-faster-unit-tests.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-20
 - **Type:** process
 - **Scope:** `server`, `core`, `web`, `skills`, `tooling`
+- **PR:** [#381](https://github.com/Prism-Shadow/penguin-harness/pull/381)
 
 [English](2026-08-20-faster-unit-tests.md)
 

--- a/packages/cli/test/serve.test.ts
+++ b/packages/cli/test/serve.test.ts
@@ -177,11 +177,17 @@ describe("readiness probe diagnostics", () => {
 
   it("includes actionable localized firewall guidance for connection timeouts", () => {
     const detail = "UND_ERR_CONNECT_TIMEOUT: Connect Timeout Error";
-    expect(
-      getMessages("en").webProbeFailed("http://127.0.0.1:7364/", detail, "timeout", 7364),
-    ).toContain("Allow PenguinHarness to communicate on local port 7364");
-    expect(
-      getMessages("zh").webProbeFailed("http://127.0.0.1:7364/", detail, "timeout", 7364),
-    ).toContain("请允许 PenguinHarness 在本机端口 7364 上通信");
+    const url = "http://127.0.0.1:7364/";
+    for (const lang of ["en", "zh"] as const) {
+      const timeout = getMessages(lang).webProbeFailed(url, detail, "timeout", 7364);
+      // Actionable means naming the port the user has to let through, not just reporting a
+      // timeout; the probe error stays visible either way.
+      expect(timeout, lang).toContain("7364");
+      expect(timeout, lang).toContain(detail);
+      // The kind picks the hint: a timeout must not read like a refused connection.
+      expect(timeout, lang).not.toBe(
+        getMessages(lang).webProbeFailed(url, detail, "refused", 7364),
+      );
+    }
   });
 });

--- a/packages/core/test/state.test.ts
+++ b/packages/core/test/state.test.ts
@@ -501,12 +501,6 @@ describe("assembleSystemPrompt", () => {
     );
     expect(prompt).toContain("AGENTS.md");
     expect(prompt).toContain("PenguinHarness");
-    // File system's two file-delivery conventions: a workspace file is mentioned in the reply
-    // by its **workspace-relative path** in backticks (the frontend renders a message file card
-    // from this); scratchpad only holds intermediate artifacts, and final deliverables must
-    // land in the Workspace.
-    expect(prompt).toContain("mention its workspace-relative path in backticks");
-    expect(prompt).toContain("always place final deliverables in the workspace");
     // The default template wraps AGENTS.md in a [developer_instructions] block.
     expect(prompt).toContain("[developer_instructions]");
     expect(prompt).toContain("[/developer_instructions]");
@@ -530,21 +524,18 @@ describe("assembleSystemPrompt", () => {
   it("default prompt carries the port and API-key guardrails", async () => {
     const state = await loadOrInitAgentState();
     const prompt = assembleSystemPrompt(state);
-    // Ports: never kill listeners or take PenguinHarness service ports; numbers are deliberately not listed.
-    expect(prompt).toContain("pick another free port");
-    expect(prompt).toContain("PenguinHarness service port");
+    // The wording of these rules is tuned freely; what must not drift is what they never say.
+    // Ports: the service numbers are deliberately not listed, so a model cannot read one out
+    // of the prompt and go looking for it.
     expect(prompt).not.toContain("7364");
     // Auth/key failures live entirely in Stop rules, as a special case of the
-    // unresolvable-error rule: retry at most once, then stop and ask the user to update the key
-    // outside the chat — no CLI commands, no secret values in the conversation.
+    // unresolvable-error rule: retry once, then stop and ask the user to update the key
+    // outside the chat — never through a command that would put the secret on a command line.
+    expect(prompt).not.toContain("penguin config vault set");
     // Position, not presence: `# Stop rules` exists either way, so only the ordering pins that
     // the retry rule sits inside that section instead of back up in Constraints.
     expect(prompt.indexOf("# Stop rules")).toBeLessThan(prompt.indexOf("retry at most once"));
     expect(prompt.indexOf("retry at most once")).toBeLessThan(prompt.indexOf("# Tool use"));
-    expect(prompt).toContain("stop calling tools");
-    expect(prompt).toContain("never be pasted into the conversation");
-    expect(prompt).toContain("next conversation");
-    expect(prompt).not.toContain("penguin config vault set");
   });
 
   it("replaces AGENTS.md and specific Session environment fields at template locations", () => {

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -154,6 +154,11 @@ export interface BuildDepsOverrides {
   titles?: TitleNotifier;
   /** Test double: update-check service with a stubbed fetch/clock (avoids real network calls). */
   updateCheck?: UpdateCheckService;
+  /**
+   * Test double: scrypt work factor for password hashes written through this app.
+   * Omitted in production, where the KDF runs at full strength.
+   */
+  passwordHashCost?: number;
   log?: (line: string) => void;
   now?: () => Date;
 }
@@ -297,6 +302,9 @@ export function buildAppDeps(config: ServerConfig, overrides: BuildDepsOverrides
     onPasswordChanged,
     sessionTtlMs: config.authSessionTtlMs,
     sessionRenewMs: config.authSessionRenewMs,
+    ...(overrides.passwordHashCost !== undefined
+      ? { passwordHashCost: overrides.passwordHashCost }
+      : {}),
     ...(overrides.now ? { now: overrides.now } : {}),
   });
   const adminService = new AdminService({
@@ -305,6 +313,9 @@ export function buildAppDeps(config: ServerConfig, overrides: BuildDepsOverrides
     projects: projectsRepo,
     projectService,
     onPasswordChanged,
+    ...(overrides.passwordHashCost !== undefined
+      ? { passwordHashCost: overrides.passwordHashCost }
+      : {}),
     ...(overrides.now ? { now: overrides.now } : {}),
   });
   const sessionService = new SessionService({

--- a/packages/server/src/auth/password.ts
+++ b/packages/server/src/auth/password.ts
@@ -9,7 +9,14 @@
  */
 import { randomBytes, scrypt, timingSafeEqual } from "node:crypto";
 
-const SCRYPT_N = 16384;
+/**
+ * Work factor for new hashes. `hashPassword` takes it as a defaulted argument so the server's
+ * own test suite can hash at a token cost: almost every case there seeds an admin, provisions
+ * users and logs them in, and one derivation at this strength costs on the order of 100ms.
+ * Nothing on the production path passes the argument, and no configuration reaches it —
+ * `buildAppDeps`, which carries the test override, is not part of this package's exports.
+ */
+export const SCRYPT_COST = 16384;
 const SCRYPT_R = 8;
 const SCRYPT_P = 1;
 const SALT_BYTES = 16;
@@ -31,13 +38,17 @@ function scryptAsync(
   });
 }
 
-/** Generates a password hash in `scrypt$N$r$p$salt$hash` format. */
-export async function hashPassword(password: string): Promise<string> {
+/**
+ * Generates a password hash in `scrypt$N$r$p$salt$hash` format. `cost` is scrypt's N and
+ * is recorded in the hash, so `verifyPassword` re-derives at whatever cost produced the
+ * stored string.
+ */
+export async function hashPassword(password: string, cost: number = SCRYPT_COST): Promise<string> {
   const salt = randomBytes(SALT_BYTES);
-  const key = await scryptAsync(password, salt, KEY_BYTES, SCRYPT_N, SCRYPT_R, SCRYPT_P);
+  const key = await scryptAsync(password, salt, KEY_BYTES, cost, SCRYPT_R, SCRYPT_P);
   return [
     "scrypt",
-    String(SCRYPT_N),
+    String(cost),
     String(SCRYPT_R),
     String(SCRYPT_P),
     salt.toString("base64"),

--- a/packages/server/src/auth/service.ts
+++ b/packages/server/src/auth/service.ts
@@ -17,7 +17,7 @@ import type { UserInfo } from "../api/types.js";
 import { HttpError } from "../http/errors.js";
 import type { AuthSessionsRepo } from "../db/repos/auth-sessions.js";
 import type { UserRow, UsersRepo } from "../db/repos/users.js";
-import { hashPassword, verifyPassword } from "./password.js";
+import { SCRYPT_COST, hashPassword, verifyPassword } from "./password.js";
 
 export const MIN_PASSWORD_LENGTH = 8;
 
@@ -89,14 +89,21 @@ export interface AuthServiceDeps {
   onPasswordChanged?: (userId: string) => void;
   sessionTtlMs: number;
   sessionRenewMs: number;
+  /**
+   * Test double: scrypt work factor for hashes this service writes. Omitted in
+   * production, where {@link SCRYPT_COST} applies.
+   */
+  passwordHashCost?: number;
   now?: () => Date;
 }
 
 export class AuthService {
   private readonly now: () => Date;
+  private readonly hashCost: number;
 
   constructor(private readonly deps: AuthServiceDeps) {
     this.now = deps.now ?? (() => new Date());
+    this.hashCost = deps.passwordHashCost ?? SCRYPT_COST;
   }
 
   /**
@@ -121,7 +128,7 @@ export class AuthService {
     }
     const user: UserRow = {
       userId: ADMIN_USER_ID,
-      passwordHash: await hashPassword(password),
+      passwordHash: await hashPassword(password, this.hashCost),
       isAdmin: true,
       passwordIsInitial: true,
       createdAt: this.now().toISOString(),
@@ -205,7 +212,7 @@ export class AuthService {
     if (newPassword.length < MIN_PASSWORD_LENGTH) {
       throw new HttpError(400, "invalid_password", "Password must be at least 8 characters.");
     }
-    this.deps.users.updatePassword(userId, await hashPassword(newPassword), false);
+    this.deps.users.updatePassword(userId, await hashPassword(newPassword, this.hashCost), false);
     this.deps.onPasswordChanged?.(userId);
   }
 
@@ -219,7 +226,7 @@ export class AuthService {
     if (newPassword.length < MIN_PASSWORD_LENGTH) {
       throw new HttpError(400, "invalid_password", "Password must be at least 8 characters.");
     }
-    this.deps.users.updatePassword(userId, await hashPassword(newPassword), false);
+    this.deps.users.updatePassword(userId, await hashPassword(newPassword, this.hashCost), false);
     this.deps.onPasswordChanged?.(userId);
   }
 

--- a/packages/server/src/services/admin-service.ts
+++ b/packages/server/src/services/admin-service.ts
@@ -13,7 +13,7 @@
 import type { UserInfo } from "../api/types.js";
 import { HttpError } from "../http/errors.js";
 import { MIN_PASSWORD_LENGTH, toUserInfo } from "../auth/service.js";
-import { hashPassword } from "../auth/password.js";
+import { SCRYPT_COST, hashPassword } from "../auth/password.js";
 import type { AuthSessionsRepo } from "../db/repos/auth-sessions.js";
 import type { ProjectsRepo } from "../db/repos/projects.js";
 import type { UserRow, UsersRepo } from "../db/repos/users.js";
@@ -32,14 +32,21 @@ export interface AdminServiceDeps {
    * initial-password.ts); test constructions may omit it.
    */
   onPasswordChanged?: (userId: string) => void;
+  /**
+   * Test double: scrypt work factor for hashes this service writes. Omitted in
+   * production, where {@link SCRYPT_COST} applies.
+   */
+  passwordHashCost?: number;
   now?: () => Date;
 }
 
 export class AdminService {
   private readonly now: () => Date;
+  private readonly hashCost: number;
 
   constructor(private readonly deps: AdminServiceDeps) {
     this.now = deps.now ?? (() => new Date());
+    this.hashCost = deps.passwordHashCost ?? SCRYPT_COST;
   }
 
   listUsers(): UserInfo[] {
@@ -62,7 +69,7 @@ export class AdminService {
     }
     const user: UserRow = {
       userId,
-      passwordHash: await hashPassword(password),
+      passwordHash: await hashPassword(password, this.hashCost),
       isAdmin: false,
       passwordIsInitial: true,
       createdAt: this.now().toISOString(),
@@ -86,7 +93,7 @@ export class AdminService {
     if (password.length < MIN_PASSWORD_LENGTH) {
       throw new HttpError(400, "invalid_password", "Password must be at least 8 characters.");
     }
-    this.deps.users.updatePassword(userId, await hashPassword(password), true);
+    this.deps.users.updatePassword(userId, await hashPassword(password, this.hashCost), true);
     this.deps.authSessions.deleteByUser(userId);
     this.deps.onPasswordChanged?.(userId);
   }

--- a/packages/server/test/helpers.ts
+++ b/packages/server/test/helpers.ts
@@ -30,6 +30,15 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 /** Fixed seeded-admin password injected into every test app (in production the seed generates a random one). */
 export const TEST_ADMIN_PASSWORD = "penguin-0000";
 
+/**
+ * scrypt work factor for test apps: the lowest legal one. Nearly every case here seeds an
+ * admin, provisions users and logs them in, and at production strength those derivations
+ * cost more than everything else the suite does combined. The stored format, the recorded
+ * parameters and the verification path are unchanged — only the derivation is cheap — and
+ * the production strength itself is asserted in password.test.ts, which uses the default.
+ */
+const TEST_PASSWORD_HASH_COST = 2;
+
 export function testConfig(root: string): ServerConfig {
   return {
     root,
@@ -71,7 +80,10 @@ export async function createTestApp(options: TestAppOptions = {}): Promise<TestA
   const { beforeSeed, config, ...overrides } = options;
   const root = await makeTempRoot();
   if (beforeSeed) await beforeSeed(root);
-  const deps = buildAppDeps({ ...testConfig(root), ...config }, { log: () => {}, ...overrides });
+  const deps = buildAppDeps(
+    { ...testConfig(root), ...config },
+    { log: () => {}, passwordHashCost: TEST_PASSWORD_HASH_COST, ...overrides },
+  );
   // Consistent with the startup entrypoint: seed the built-in admin (owning default_project),
   // keeping the password it returns (only null if a beforeSeed hook ever pre-created users).
   const adminPassword = (await deps.authService.seedAdmin()) ?? TEST_ADMIN_PASSWORD;

--- a/packages/server/test/isolation.test.ts
+++ b/packages/server/test/isolation.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Guards the one precondition vitest.config.ts's `isolate: false` rests on. Workers here
+ * reuse their module registry across the files they run, so a module mock registered by one
+ * file would still be in place for every file that follows it in the same worker — a failure
+ * that shows up in an unrelated file and does not reproduce alone. Nothing in this suite
+ * needs module mocking today; a file that starts to needs its own isolated project instead.
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const testDir = import.meta.dirname;
+
+describe("suite-wide isolation preconditions", () => {
+  it("no test file registers a module mock", async () => {
+    const files = (await fs.readdir(testDir)).filter((name) => name.endsWith(".test.ts"));
+    // A sanity floor: an empty listing would make this test pass without checking anything.
+    expect(files.length).toBeGreaterThan(50);
+
+    const offenders: string[] = [];
+    for (const name of files) {
+      const source = await fs.readFile(path.join(testDir, name), "utf8");
+      if (/\bvi\s*\.\s*(mock|doMock|unmock|doUnmock|resetModules)\s*\(/.test(source)) {
+        offenders.push(name);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/server/test/isolation.test.ts
+++ b/packages/server/test/isolation.test.ts
@@ -2,8 +2,8 @@
  * Guards the one precondition vitest.config.ts's `isolate: false` rests on. Workers here
  * reuse their module registry across the files they run, so a module mock registered by one
  * file would still be in place for every file that follows it in the same worker — a failure
- * that shows up in an unrelated file and does not reproduce alone. Nothing in this suite
- * needs module mocking today; a file that starts to needs its own isolated project instead.
+ * that shows up in an unrelated file and does not reproduce alone. A file that needs module
+ * mocking needs its own vitest project, isolated, rather than a mock registered in this one.
  */
 import fs from "node:fs/promises";
 import path from "node:path";

--- a/packages/server/test/password.test.ts
+++ b/packages/server/test/password.test.ts
@@ -1,9 +1,10 @@
 /**
  * Unit tests for scrypt password hashing: format, verification, salt randomness,
- * and fallback behavior for invalid stored strings.
+ * and fallback behavior for invalid stored strings. These call `hashPassword` without a
+ * cost argument, so they are the one place the production work factor is exercised.
  */
 import { describe, expect, it } from "vitest";
-import { hashPassword, verifyPassword } from "../src/auth/password.js";
+import { SCRYPT_COST, hashPassword, verifyPassword } from "../src/auth/password.js";
 
 describe("password", () => {
   it("hash format is scrypt$N$r$p$salt$hash and verifies", async () => {
@@ -11,7 +12,10 @@ describe("password", () => {
     const parts = stored.split("$");
     expect(parts).toHaveLength(6);
     expect(parts[0]).toBe("scrypt");
-    expect(Number(parts[1])).toBeGreaterThan(0);
+    // The default work factor is what production hashes at; `hashPassword`'s cost argument
+    // exists for the test suite and must never lower what an unparameterized call writes.
+    expect(SCRYPT_COST).toBe(16384);
+    expect(Number(parts[1])).toBe(SCRYPT_COST);
     await expect(verifyPassword("hello-world-123", stored)).resolves.toBe(true);
   });
 

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -1,28 +1,28 @@
 /**
- * Vitest config for the server. Two non-default settings.
+ * Vitest config for the server: platform-aware deadlines, and a shared module registry.
  *
- * The platform-aware deadlines mirror core's rationale: these tests build full app instances
- * over real SQLite files and Agent State trees, and the Windows CI runners' I/O variance
- * (Defender first-touch scans, slow handle release) pushes individually fast tests and
- * cleanup hooks past the 5s/10s defaults — a different file on each run. Larger deadlines
- * change nothing for passing tests; POSIX keeps the defaults to fail fast during local
- * development. The hook timeout matters here specifically: `cleanup()` removes the whole
- * test root, and on win32 that rm can legitimately take retries (see helpers.ts).
+ * The deadlines mirror core's rationale: these tests build full app instances over real
+ * SQLite files and Agent State trees, and the Windows CI runners' I/O variance (Defender
+ * first-touch scans, slow handle release) pushes individually fast tests and cleanup hooks
+ * past the 5s/10s defaults — a different file on each run. Larger deadlines change nothing
+ * for passing tests; POSIX keeps the defaults to fail fast during local development. The
+ * hook timeout matters here specifically: `cleanup()` removes the whole test root, and on
+ * win32 that rm can legitimately take retries (see helpers.ts).
  *
  * `isolate: false` lets a worker reuse its module registry across the files it runs instead
  * of discarding it after each one. Every file here imports the whole app graph, core's
- * bundle included, and evaluating it once per file was the largest single cost in the suite;
- * sharing it also drops fork spawns from one per file to one per worker, which is worth more
- * on the two-core Windows runner than anywhere else. What makes it safe: no file in this
- * suite mocks a module — `vi.mock` would leak into every later file in the same fork, which
- * `test/isolation.test.ts` guards against — the few that mutate `process.env` save and
- * restore it, and files inside a worker still run one at a time. The pool stays `forks` for
- * the same reason it must: `process.env` is per-process, so a thread pool would let those
- * env-mutating files race.
+ * bundle included, so evaluating that graph once per file rather than once per worker
+ * dominated the suite's wall clock; sharing it also drops fork spawns from one per file to
+ * one per worker, which is worth more on the two-core Windows runner than anywhere else.
+ * What makes it safe: no file in this suite mocks a module — `vi.mock` would leak into
+ * every later file in the same fork, which `test/isolation.test.ts` guards against — the
+ * few that mutate `process.env` save and restore it, and files inside a worker still run
+ * one at a time. The pool stays `forks` for that last reason: `process.env` is per-process,
+ * so a thread pool would let those env-mutating files race each other.
  *
- * `restoreMocks` makes the spy half of that mechanical rather than a reading of the suite: a
- * `vi.spyOn` whose inline `mockRestore()` is skipped by a failing assertion above it would
- * otherwise stay installed for every later file in the same worker.
+ * `restoreMocks` makes the spy half of that mechanical rather than a reading of the suite:
+ * a `vi.spyOn` whose inline `mockRestore()` is skipped by a failing assertion above it
+ * would otherwise stay installed for every later file in the same worker.
  */
 import { defineConfig } from "vitest/config";
 

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -1,18 +1,36 @@
 /**
- * Vitest config for the server. Mirrors core's platform-aware deadline rationale: these
- * tests build full app instances over real SQLite files and Agent State trees, and the
- * Windows CI runners' I/O variance (Defender first-touch scans, slow handle release)
- * pushes individually fast tests and cleanup hooks past the 5s/10s defaults — a
- * different file on each run. Larger deadlines change nothing for passing tests; POSIX
- * keeps the defaults to fail fast during local development. The hook timeout matters
- * here specifically: `cleanup()` removes the whole test root, and on win32 that rm can
- * legitimately take retries (see helpers.ts).
+ * Vitest config for the server. Two non-default settings.
+ *
+ * The platform-aware deadlines mirror core's rationale: these tests build full app instances
+ * over real SQLite files and Agent State trees, and the Windows CI runners' I/O variance
+ * (Defender first-touch scans, slow handle release) pushes individually fast tests and
+ * cleanup hooks past the 5s/10s defaults — a different file on each run. Larger deadlines
+ * change nothing for passing tests; POSIX keeps the defaults to fail fast during local
+ * development. The hook timeout matters here specifically: `cleanup()` removes the whole
+ * test root, and on win32 that rm can legitimately take retries (see helpers.ts).
+ *
+ * `isolate: false` lets a worker reuse its module registry across the files it runs instead
+ * of discarding it after each one. Every file here imports the whole app graph, core's
+ * bundle included, and evaluating it once per file was the largest single cost in the suite;
+ * sharing it also drops fork spawns from one per file to one per worker, which is worth more
+ * on the two-core Windows runner than anywhere else. What makes it safe: no file in this
+ * suite mocks a module — `vi.mock` would leak into every later file in the same fork, which
+ * `test/isolation.test.ts` guards against — the few that mutate `process.env` save and
+ * restore it, and files inside a worker still run one at a time. The pool stays `forks` for
+ * the same reason it must: `process.env` is per-process, so a thread pool would let those
+ * env-mutating files race.
+ *
+ * `restoreMocks` makes the spy half of that mechanical rather than a reading of the suite: a
+ * `vi.spyOn` whose inline `mockRestore()` is skipped by a failing assertion above it would
+ * otherwise stay installed for every later file in the same worker.
  */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
     environment: "node",
+    isolate: false,
+    restoreMocks: true,
     testTimeout: process.platform === "win32" ? 30_000 : 5_000,
     hookTimeout: process.platform === "win32" ? 30_000 : 10_000,
   },

--- a/packages/skills/test/skills.test.ts
+++ b/packages/skills/test/skills.test.ts
@@ -242,267 +242,66 @@ describe("librarySkill", () => {
     expect(librarySkill("no-such-skill")).toBeUndefined();
   });
 
-  it("benchmark-design records the selected one-Run Pilot as the Formal Baseline", () => {
-    const content = librarySkill("benchmark-design")?.content;
-    expect(content).toBeDefined();
+  /**
+   * The agent-tuning skills tell an agent what to type: shell statements, CLI flags and
+   * the YAML shape an Evaluator must emit. Those literals are a contract — a typo in one
+   * breaks a run — so they are pinned here. The prose around them is not: it is edited
+   * every time a skill is reworded, and pinning sentences only made the suite fail on
+   * rewrites that changed nothing an agent executes.
+   */
+  it("agent-evaluation spells the launch environment out as separate shell statements", () => {
+    const evaluation = librarySkill("agent-evaluation")!.content;
 
-    const pilotIndex = content!.indexOf("## Refine the Benchmark");
-    const baselineIndex = content!.indexOf("## Freeze and record the Formal Baseline");
-    const normalizedContent = content!.replace(/\s+/g, " ");
-
-    expect(pilotIndex).toBeGreaterThan(-1);
-    expect(baselineIndex).toBeGreaterThan(pilotIndex);
-    expect(normalizedContent).toContain("Keep unselected Pilot results out of the Scoreboard");
-    expect(normalizedContent).toContain("requested valid-iteration limit");
-    expect(normalizedContent).toContain("lowest-scoring valid Pilot revision");
-    expect(normalizedContent).toContain("retain only one temporary restorable copy");
-    expect(normalizedContent).toContain("Store it outside `benchmarks/`");
-    expect(normalizedContent).toContain("delete the temporary lowest-revision copy");
-    expect(normalizedContent).toContain("A single iteration may refine multiple Cases");
-    expect(normalizedContent).toContain(
-      "do not require the public Statement to uniquely determine the Gold",
-    );
-    expect(normalizedContent).toContain("stable reusable policy, priority, inference boundary");
-    expect(normalizedContent).toContain(
-      "do not disclose every decisive premise or priority merely to make the public task complete",
-    );
-    expect(normalizedContent).toContain(
-      "Allocate most points within each Case to decisions or concise artifacts",
-    );
-    expect(normalizedContent).toContain(
-      "Keep generic format compliance, evidence enumeration, and analysis completeness from creating a high score floor",
-    );
-    expect(normalizedContent).toContain(
-      "Before the first dispatch of every new or changed Case revision",
-    );
-    expect(normalizedContent).toContain("current Statement is internally coherent");
-    expect(normalizedContent).toContain("current Rubric is consistent with the current Statement");
-    expect(normalizedContent).toContain("must not refer to an earlier revision or missing context");
-    expect(normalizedContent).toContain(
-      "every scoring item applies to the Case's actual requested output",
-    );
-    expect(normalizedContent).toContain(
-      "does not require the public Statement to contain enough information",
-    );
-    expect(normalizedContent).toContain(
-      "Prefer refinements that create one or more scored separating decisions",
-    );
-    expect(normalizedContent).toContain(
-      "Adding another explicit rule, exception, source, or checklist is not a difficulty increase",
-    );
-    expect(normalizedContent).toContain("Separating prediction");
-    expect(normalizedContent).toContain(
-      "If both behaviors are expected to reach the same scored result, choose another refinement",
-    );
-    expect(normalizedContent).toContain("A Rubric-only refinement is allowed but not preferred");
-    expect(normalizedContent).toContain(
-      "Do not add points merely because the previous Test Agent omitted a phrase",
-    );
-    expect(normalizedContent).toContain(
-      "Run a complete consistency review and final leak check across every Case",
-    );
-    expect(normalizedContent).toContain(
-      "Do not run another difficulty refinement merely to create more score margin",
-    );
-    expect(normalizedContent).toContain("missing the desired score alone is not a failure");
-    expect(normalizedContent).toContain("`runs = 1`");
-    expect(normalizedContent).toContain(
-      "Do not launch a fresh Formal matrix, rerun the selected Pilot, or backfill it",
-    );
-    expect(normalizedContent).toContain("Accept the selected Pilot result as the Formal Baseline");
-    expect(normalizedContent).toContain(
-      "Record the Formal Baseline even when its score does not meet the desired baseline score",
-    );
-  });
-
-  it("evaluation is the only subagent leaf and optimization has a bounded valid-round loop", () => {
-    const creation = librarySkill("agent-creation")!.content.replace(/\s+/g, " ");
-    const evaluation = librarySkill("agent-evaluation")!.content.replace(/\s+/g, " ");
-    const benchmarkDesignRaw = librarySkill("benchmark-design")!.content;
-    const benchmarkDesign = benchmarkDesignRaw.replace(/\s+/g, " ");
-    const optimizationRaw = librarySkill("agent-optimization")!.content;
-    const optimization = optimizationRaw.replace(/\s+/g, " ");
-
-    expect(creation).toContain("inherit the current Builder Session's `Provider` and `Model ID`");
-    expect(creation).toContain(
-      "read `model.thinking_level` from the Builder's own `agent_state/system_config.yaml`",
-    );
-    expect(creation).toContain("Write the resolved `thinking_level` into a brand-new target Agent");
-    expect(creation).toContain("never add either field to `system_config.yaml`");
-    expect(evaluation).toContain("request from a `run_subagent` caller");
-    expect(evaluation).toContain("Use the Penguin CLI only to launch the specified Test Agent");
     expect(evaluation).toContain('PROJECT_ID="$(basename "$PROJECT_DIR")"');
     expect(evaluation).toContain('PENGUIN_HOME="$(dirname "$PROJECT_DIR")"');
     expect(evaluation).toContain("export PENGUIN_HOME");
     expect(evaluation).toContain('--project-id "$PROJECT_ID"');
-    expect(evaluation).toContain("Perform these as separate shell statements in this order");
-    expect(evaluation).toContain("Never compress the assignments onto one command line");
-    expect(evaluation).toContain("Do not impose a numeric retry limit");
-    expect(evaluation).toContain("Never browse, query a pricing service");
-    expect(evaluation).toContain("resend only the clean protocol YAML");
     expect(evaluation).toContain('--workspace "<absolute_unique_workspace_path>"');
-    expect(evaluation).toContain("resolve it to an absolute canonical path");
-    expect(evaluation).toContain("`provider` and `model_id` must both be non-empty");
-    expect(evaluation).toContain("Never omit either model flag");
-    expect(evaluation).toContain(
-      "Read and snapshot `model.thinking_level` from this Target Agent config",
-    );
-    expect(evaluation).toContain("not Trace metadata—for `thinking_level`");
-    expect(evaluation).toContain("outside `0..100`");
+    // The assignment is its own statement: prefixed onto `penguin run` it would apply to
+    // that one command and leave the rest of the sequence pointing at the wrong home.
     expect(evaluation).not.toContain('PENGUIN_HOME="$(dirname "$PROJECT_DIR")" penguin run');
-    expect(benchmarkDesign).toContain(
-      "otherwise inherit the current Builder Session's complete `Provider` and `Model ID`",
-    );
-    expect(benchmarkDesign).toContain(
-      "Read `thinking_level` from the Test Agent's `model.thinking_level`",
-    );
-    expect(benchmarkDesign).toContain(
-      "Pass the resolved `(provider, model_id)` explicitly in every Pilot Evaluator request",
-    );
-    expect(benchmarkDesign).toContain("Every Case Rubric has a fixed maximum of 100 points");
-    expect(benchmarkDesign).toContain("average of the Case scores");
-    expect(benchmarkDesign).toContain("ignore `null` values when averaging cost");
-    expect(benchmarkDesign).toContain("stored values are authoritative");
-    expect(benchmarkDesign).toContain("obtain the current UTC timestamp from the environment");
-    expect(benchmarkDesignRaw).toMatch(/summary_title:\s*>-\n\s+<public title>/);
-    expect(benchmarkDesignRaw).toMatch(/summary:\s*>-\n\s+<public summary>/);
-    expect(benchmarkDesign).toContain(
-      "parse the complete `scoreboard.yaml` and verify the appended Evaluation",
-    );
-    expect(benchmarkDesignRaw).not.toMatch(/\n\s+max_score:/);
-    expect(benchmarkDesign).toContain(
-      "Before reading `status`, `score`, or any other protocol field",
-    );
-    expect(benchmarkDesign).toContain("Ask the same Evaluator to resend only the clean YAML");
-    expect(optimization).toContain("Delegate every evaluation to an `agent-evaluation` subagent");
-    expect(optimization).toContain("a positive `runs` value");
-    expect(optimization).toContain(
-      "do not infer it from `benchmark_config.toml` or the Formal Baseline",
-    );
-    expect(optimization).toContain(
-      "The initial Formal Baseline has one Run per Case; do not rerun or backfill it",
-    );
-    expect(optimization).toContain(
-      "Compare each Candidate's stored top-level average directly with the current Reference score even when their Run counts differ",
-    );
-    expect(optimization).toContain("frozen Case set × requested `runs` matrix");
-    expect(optimization).toContain("Before reading `status`, `score`, or any other protocol field");
-    expect(optimization).toContain("Ask the same Evaluator to resend only the clean YAML");
-    expect(optimizationRaw).toMatch(/summary_title:\s*>-\n\s+<public title>/);
-    expect(optimizationRaw).toMatch(/summary:\s*>-\n\s+<public summary>/);
-    expect(optimization).toContain(
-      "parse the complete `scoreboard.yaml` and verify the appended Evaluation",
-    );
-    expect(optimization).toContain(
-      "A round counts only after one Candidate has a complete valid Evaluation",
-    );
-    expect(optimization).toContain("keep the same Candidate and incomplete matrix");
-    expect(optimization).toContain(
-      "Do not inspect private Evaluator State or abandon the Candidate",
-    );
-    expect(optimization).toContain(
-      "Immediately append and verify every accepted Candidate Evaluation",
-    );
-    expect(optimization).toContain(
-      "distinguish the acceptance decision from whether its stated hypothesis was supported",
-    );
-    expect(optimization).toContain(
-      "At the round limit, retain the highest-scoring accepted Reference",
-    );
-    expect(optimization).toContain("Read the evaluation `(provider, model_id, thinking_level)`");
-    expect(optimization).toContain(
-      "require its actual `provider`, `model_id`, and `thinking_level` to equal the Reference runtime",
-    );
-    expect(optimization).toContain("Do not edit `system_prompt` unless requested");
-    expect(optimization).toContain("change `model.thinking_level`");
-    expect(optimization).toContain(
-      "ensure `<target>/snapshots/v<Reference version>.tar.gz` exists",
-    );
-    expect(optimization).toContain("Reuse it when present");
-    expect(optimization).toContain("create it yourself before editing");
-    expect(optimization).toContain("excluding `.vault.toml`");
-    expect(optimization).toContain("never overwrite an existing same-version snapshot");
-    expect(optimization).not.toContain("stop and ask the user to export");
-    expect(optimization).toContain("fixed `0..100` scale");
-    expect(optimization).toContain("average of the Case scores");
-    expect(optimization).toContain("stored values are authoritative");
-    expect(optimization).toContain("Obtain the current UTC timestamp from the environment");
-    expect(optimizationRaw).not.toMatch(/\n\s+max_score:/);
   });
 
-  it("remote-claude-code relays verbatim, steps keys one at a time, and splits model+level switches", () => {
-    // Issue #307: the four TUI-driving rules, version-bumped alongside the content change.
-    const skill = librarySkill("remote-claude-code")!;
-    expect(skill.version).toBeGreaterThanOrEqual(2);
-    const content = skill.content.replace(/\s+/g, " ");
+  it("the Evaluator protocol YAML keeps its block scalars and carries no max_score", () => {
+    for (const name of ["benchmark-design", "agent-optimization"]) {
+      const content = librarySkill(name)!.content;
+      expect(content, name).toMatch(/summary_title:\s*>-\n\s+<public title>/);
+      expect(content, name).toMatch(/summary:\s*>-\n\s+<public summary>/);
+      // Every Case Rubric is fixed at 100 points, so a per-Case maximum would be a second
+      // source of truth for the same number.
+      expect(content, name).not.toMatch(/\n\s+max_score:/);
+    }
+  });
 
-    // 1) Pure relay: user messages reach Claude Code word-for-word, no local work.
-    expect(content).toContain(
-      "## 4. Relaying a conversation — the user's words go through verbatim",
-    );
-    expect(content).toContain("you are a message pipe — nothing more");
-    expect(content).toContain("Forward every user message to Claude Code **verbatim**");
-    expect(content).toContain("the user is talking to Claude Code, not to you");
-    expect(content).toContain(
-      "When in doubt whether a message is task or control, relay it verbatim",
-    );
+  it("benchmark-design refines before it freezes the Formal Baseline", () => {
+    const content = librarySkill("benchmark-design")!.content;
+    const refineIndex = content.indexOf("## Refine the Benchmark");
+    const baselineIndex = content.indexOf("## Freeze and record the Formal Baseline");
 
-    // 2) "switch to fable5 max" style requests set the model AND the thinking level.
-    expect(content).toContain('"switch to fable5 max"');
-    expect(content).toContain("means **two** settings");
-    expect(content).toContain("Never read the pair as one unknown model name");
-    expect(content).toContain("shows **both** the new model and the new thinking level");
+    expect(refineIndex).toBeGreaterThan(-1);
+    expect(baselineIndex).toBeGreaterThan(refineIndex);
+  });
 
-    // 2b) The rule generalizes past its own examples: any language, level-only and model-only too.
-    expect(content).toContain("any** message naming a model, a thinking level, or both");
-    expect(content).toContain("**Level only**");
-    expect(content).toContain("**Model only**");
-    expect(content).toContain(
-      "A level word sitting next to a model name is always the thinking level",
-    );
+  it("remote-claude-code drives tmux through the commands it names", () => {
+    // Issue #307: relaying verbatim survives the transport only through the paste buffer —
+    // `send-keys -l` splits newlines and eats a trailing `;`.
+    const content = librarySkill("remote-claude-code")!.content;
 
-    // 3) Key-sequence races: one key per send-keys call, capture-verified between keys.
-    expect(content).toContain("acts on the **previous** selection");
-    expect(content).toContain("one key per `send-keys` call");
-    expect(content).toContain("never fire the next key on faith");
-    // ... and a bounded failure branch when the capture shows the state was NOT reached.
-    expect(content).toContain("**Nothing changed**");
-    expect(content).toContain("**The wrong thing changed**");
-    expect(content).toContain('Never "fix" a wrong state by pressing on toward the goal');
-    expect(content).toContain("Show the user the captured screen and ask");
-
-    // 4) Post-run composer text is an AI suggestion, not pending user input.
-    expect(content).toContain("cannot reliably tell the two apart");
-    expect(content).toContain("never treat post-run input-line text as pending user input");
-    expect(content).toContain("new text makes the suggestion disappear on its own");
-
-    // 5) Verbatim delivery survives the transport: `send-keys -l` splits newlines and eats a
-    // trailing `;`, so anything non-trivial goes through load-buffer/paste-buffer.
-    expect(content).toContain("goes through the paste buffer");
     expect(content).toContain("tmux load-buffer -");
     expect(content).toContain("tmux paste-buffer -d -p -t <sess>");
-    expect(content).toContain("The landed check is **exact, not approximate**");
-    expect(content).toContain("**Already submitted**");
-
-    // 6) The decision on a permission prompt is the user's, never the relaying agent's.
-    expect(content).toContain("Never approve a tool call on the user's behalf");
-    expect(content).toContain("**Questions travel back, not to you.**");
-
-    // 7) Mid-run messages, session/work boundary, dead session, untruncated reporting.
-    expect(content).toContain("**A message that arrives mid-turn waits.**");
-    expect(content).toContain("Escape twice in a row is not a stronger interrupt");
-    expect(content).toContain("**Split by subject, not by phrasing.**");
     expect(content).toContain("tmux has-session -t <sess>");
-    expect(content).toContain("claude --continue");
     expect(content).toContain("capture-pane -p -S -200");
+    expect(content).toContain("claude --continue");
+  });
 
-    // The keystroke rule (§3.3) precedes the relay contract (§4) that leans on it.
-    const stepIndex = skill.content.indexOf("### 3.3 One keystroke at a time");
-    const relayIndex = skill.content.indexOf("## 4. Relaying a conversation");
+  it("remote-claude-code states the keystroke rule before the relay contract that leans on it", () => {
+    const content = librarySkill("remote-claude-code")!.content;
+    const stepIndex = content.indexOf("### 3.3 One keystroke at a time");
+    const relayIndex = content.indexOf("## 4. Relaying a conversation");
+
     expect(stepIndex).toBeGreaterThan(-1);
     expect(relayIndex).toBeGreaterThan(stepIndex);
   });
-
   it("rejects illegal-character names (path traversal guard) and never hits the filesystem", () => {
     for (const name of ["../penguin-sdk", "..", "penguin-sdk/SKILL.md", "a/../b", ".", ""]) {
       expect(librarySkill(name), name).toBeUndefined();

--- a/packages/web/test/compaction-summary.test.ts
+++ b/packages/web/test/compaction-summary.test.ts
@@ -38,18 +38,12 @@ describe("compactionSummaryText", () => {
 });
 
 describe("compactionTitle (the row is titled by its mode)", () => {
-  it("names a summarize row compaction and a discard row clear, in both locales", () => {
-    expect(zh.chat.compactionTitle("summarize")).toBe("压缩");
-    expect(zh.chat.compactionTitle("discard")).toBe("清空");
-    expect(en.chat.compactionTitle("summarize")).toBe("Compaction");
-    expect(en.chat.compactionTitle("discard")).toBe("Clear");
-  });
-
   it("never labels a discard as compaction — the whole point of titling by mode", () => {
     for (const [locale, dict] of [
       ["zh", zh],
       ["en", en],
     ] as const) {
+      expect(dict.chat.compactionTitle("summarize"), locale).toBeTruthy();
       expect(
         dict.chat.compactionTitle("discard"),
         `${locale} still calls a discard a compaction`,
@@ -58,7 +52,15 @@ describe("compactionTitle (the row is titled by its mode)", () => {
   });
 
   it("falls back to the compaction title for any other mode (an unknown/legacy value)", () => {
-    expect(zh.chat.compactionTitle("")).toBe("压缩");
-    expect(en.chat.compactionTitle("future-mode")).toBe("Compaction");
+    for (const [locale, dict] of [
+      ["zh", zh],
+      ["en", en],
+    ] as const) {
+      for (const mode of ["", "future-mode"]) {
+        expect(dict.chat.compactionTitle(mode), `${locale} ${mode}`).toBe(
+          dict.chat.compactionTitle("summarize"),
+        );
+      }
+    }
   });
 });

--- a/packages/web/test/example-tasks.test.ts
+++ b/packages/web/test/example-tasks.test.ts
@@ -23,22 +23,16 @@ describe("draft example tasks", () => {
       buildPrompt: zh.chat.exampleTasks.agentBenchmarkBuild.prompt,
       optimizationPrompt: zh.chat.exampleTasks.agentOptimization.prompt,
       buildMarkers: [
-        "依次使用 `agent-creation` 和 `benchmark-design`",
         "id：`finite_choice_agent`",
         "installed_skills：`[]`",
         "id：`contextual-choice-adaptation`",
         "desired_baseline_score：`<75`",
         "pilot_iteration_limit：`5`",
-        "足球投注决策",
-        "售后政策与工单事实",
-        "投资策略、历史市场与当前指标",
       ],
       buildForbiddenMarkers: ["thinking_level", "provider", "model_id", "runs："],
       optimizationMarkers: [
-        "使用 `agent-optimization`",
         "test_agent_id：`finite_choice_agent`",
         "benchmark_id：`contextual-choice-adaptation`",
-        "提高信息不完整、规则冲突和有限选项决策中的稳定性",
         "runs：`3`",
         "desired_score：`>=95`",
         "candidate_round_limit：`5`",
@@ -49,22 +43,16 @@ describe("draft example tasks", () => {
       buildPrompt: en.chat.exampleTasks.agentBenchmarkBuild.prompt,
       optimizationPrompt: en.chat.exampleTasks.agentOptimization.prompt,
       buildMarkers: [
-        "Use `agent-creation` followed by `benchmark-design`",
         "id: `finite_choice_agent`",
         "installed_skills: `[]`",
         "id: `contextual-choice-adaptation`",
         "desired_baseline_score: `<75`",
         "pilot_iteration_limit: `5`",
-        "football betting decisions",
-        "policy and ticket facts",
-        "strategy, historical markets, and current indicators",
       ],
       buildForbiddenMarkers: ["thinking_level", "provider", "model_id", "runs:"],
       optimizationMarkers: [
-        "Use `agent-optimization`",
         "test_agent_id: `finite_choice_agent`",
         "benchmark_id: `contextual-choice-adaptation`",
-        "improve stability under incomplete information, conflicting rules, and finite choices",
         "runs: `3`",
         "desired_score: `>=95`",
         "candidate_round_limit: `5`",
@@ -91,6 +79,14 @@ describe("draft example tasks", () => {
       for (const marker of optimizationMarkers) {
         expect(normalizedOptimization).toContain(marker);
       }
+
+      // The build draft names both skills, in the order it runs them; the scenario copy each
+      // one is described with is free to change.
+      expect(normalizedBuild).toContain("`agent-creation`");
+      expect(normalizedBuild.indexOf("`agent-creation`")).toBeLessThan(
+        normalizedBuild.indexOf("`benchmark-design`"),
+      );
+      expect(normalizedOptimization).toContain("`agent-optimization`");
 
       expect(normalizedBuild).not.toContain("penguin run");
       expect(normalizedOptimization).not.toContain("penguin run");

--- a/packages/web/test/kernel-labels.test.ts
+++ b/packages/web/test/kernel-labels.test.ts
@@ -12,16 +12,26 @@ afterEach(() => setActiveStrings(zh));
 
 describe("kernelFieldLabel", () => {
   it("maps fixed paths through the active dictionary", () => {
-    expect(kernelFieldLabel("system_prompt")).toBe("系统提示词模板");
-    expect(kernelFieldLabel("memory.prompt")).toBe("记忆提示词");
-    setActiveStrings(en);
-    expect(kernelFieldLabel("system_prompt")).toBe("system prompt template");
+    for (const [locale, dict] of [
+      ["zh", zh],
+      ["en", en],
+    ] as const) {
+      setActiveStrings(dict);
+      for (const path of Object.keys(dict.agent.kernelFields)) {
+        expect(kernelFieldLabel(path), `${locale} ${path}`).toBe(dict.agent.kernelFields[path]);
+      }
+    }
   });
 
   it("renders per-tool paths with the tool name", () => {
-    expect(kernelFieldLabel("tools.builtin.read_file")).toBe("工具 read_file");
-    setActiveStrings(en);
-    expect(kernelFieldLabel("tools.builtin.my_tool")).toBe("tool my_tool");
+    for (const dict of [zh, en]) {
+      setActiveStrings(dict);
+      // The tool name is interpolated, not dropped, and the rest comes from the dictionary.
+      expect(kernelFieldLabel("tools.builtin.read_file")).toBe(
+        dict.agent.kernelFieldTool("read_file"),
+      );
+      expect(kernelFieldLabel("tools.builtin.read_file")).toContain("read_file");
+    }
   });
 
   it("covers every fixed kernel merge leaf in both dictionaries (no raw-path fallbacks for known paths)", () => {

--- a/packages/web/test/memory-chat-prompts.test.ts
+++ b/packages/web/test/memory-chat-prompts.test.ts
@@ -33,26 +33,31 @@ describe("buildMemoryEditPrompt", () => {
   });
 
   it("follows the active dictionary", () => {
-    setActiveStrings(en);
-    expect(buildMemoryEditPrompt("t")).toContain("Please update a memory");
-    setActiveStrings(zh);
-    expect(buildMemoryEditPrompt("t")).toContain("请帮我更新一条记忆");
+    for (const dict of [en, zh]) {
+      setActiveStrings(dict);
+      expect(buildMemoryEditPrompt("t")).toBe(
+        `${dict.memory.editPromptLead("t")}\n${dict.memory.editPromptTail}`,
+      );
+    }
   });
 });
 
 describe("buildMemoryAddPrompt", () => {
   it("names the scope by kind and ends with the trimmed content", () => {
     const user = buildMemoryAddPrompt("user", "  喜欢用 pnpm，Node 版本固定 24  ");
-    expect(user).toContain("用户记忆");
+    expect(user).toContain(S.memory.addPromptLead.user);
     expect(user.endsWith("喜欢用 pnpm，Node 版本固定 24")).toBe(true);
-    expect(buildMemoryAddPrompt("workspace", "c")).toContain("工作区");
+    // The two scopes read differently, so a wrong lead cannot pass as the right one.
+    expect(S.memory.addPromptLead.workspace).not.toBe(S.memory.addPromptLead.user);
+    expect(buildMemoryAddPrompt("workspace", "c")).toContain(S.memory.addPromptLead.workspace);
   });
 
   it("follows the active dictionary", () => {
-    setActiveStrings(en);
-    expect(buildMemoryAddPrompt("user", "c")).toContain("user memory");
-    expect(buildMemoryAddPrompt("workspace", "c")).toContain("workspace");
-    setActiveStrings(zh);
-    expect(buildMemoryAddPrompt("user", "c")).toContain("请把下面的内容整理成记忆");
+    for (const dict of [en, zh]) {
+      setActiveStrings(dict);
+      for (const kind of ["user", "workspace"] as const) {
+        expect(buildMemoryAddPrompt(kind, "c")).toBe(`${dict.memory.addPromptLead[kind]}\nc`);
+      }
+    }
   });
 });

--- a/packages/web/test/nav-group-collapse.test.ts
+++ b/packages/web/test/nav-group-collapse.test.ts
@@ -61,7 +61,7 @@ describe("NAV_GROUP_KEYS", () => {
     // outside the group container — the manifest never governs it.
     expect(NAV_GROUP_KEYS as readonly string[]).not.toContain("newChat");
     expect(NAV_GROUP_KEYS as readonly string[]).not.toContain("chat");
-    expect(zh.chat.newSessionMenu).toBe("新建对话");
+    expect(zh.chat.newSessionMenu).toBeTruthy();
   });
 });
 
@@ -72,10 +72,15 @@ describe("visibleNavKeys", () => {
   });
 
   it("the chevron-button toggle's accessible names exist in both languages (icon-only button: aria + tooltip carry them)", () => {
-    expect(zh.nav.collapseGroup).toBe("折叠");
-    expect(zh.nav.expandGroup).toBe("展开");
-    expect(en.nav.collapseGroup).toBe("Collapse");
-    expect(en.nav.expandGroup).toBe("Expand");
+    for (const [locale, dict] of [
+      ["zh", zh],
+      ["en", en],
+    ] as const) {
+      expect(dict.nav.collapseGroup, locale).toBeTruthy();
+      expect(dict.nav.expandGroup, locale).toBeTruthy();
+      // One button, two states: the same name for both would leave the state unreadable.
+      expect(dict.nav.collapseGroup, locale).not.toBe(dict.nav.expandGroup);
+    }
   });
 });
 

--- a/packages/web/test/skill-slash.test.ts
+++ b/packages/web/test/skill-slash.test.ts
@@ -122,9 +122,15 @@ describe("skillSlashItems (slash skill command item assembly)", () => {
 });
 
 describe("quickInvokeText (prefill text for skill-library quick invoke, zh/en dictionaries)", () => {
-  it('same convention as the empty-body auto-invoke text: "use the X skill", localized per dictionary', () => {
-    expect(zh.skills.quickInvokeText("agent-creation")).toBe("使用 agent-creation 技能");
-    expect(en.skills.quickInvokeText("agent-creation")).toBe("use the agent-creation skill");
+  it("reads exactly as the empty-body auto-invoke text for the same single skill", () => {
+    for (const [locale, dict] of [
+      ["zh", zh],
+      ["en", en],
+    ] as const) {
+      expect(dict.skills.quickInvokeText("agent-creation"), locale).toBe(
+        dict.chat.skillsAutoMessage(["agent-creation"]),
+      );
+    }
   });
 });
 

--- a/packages/web/test/trace-compaction-badge.test.ts
+++ b/packages/web/test/trace-compaction-badge.test.ts
@@ -28,25 +28,24 @@ describe("compactionBadgeLabel", () => {
     const summarize = { taskIndex: 1, compaction: true, compactionMode: "summarize" } as never;
     const discard = { taskIndex: 1, compaction: true, compactionMode: "discard" } as never;
 
-    expect(compactionBadgeLabel(summarize)).toBe("压缩");
-    expect(compactionBadgeLabel(discard)).toBe("清空");
-
-    setActiveStrings(en);
-    expect(compactionBadgeLabel(summarize)).toBe("Compaction");
-    expect(compactionBadgeLabel(discard)).toBe("Clear");
-  });
-
-  it("reuses the chat row's title rather than a second Trace-local pair of strings", () => {
-    const discard = { taskIndex: 1, compaction: true, compactionMode: "discard" } as never;
-    expect(compactionBadgeLabel(discard)).toBe(zh.chat.compactionTitle("discard"));
-    setActiveStrings(en);
-    expect(compactionBadgeLabel(discard)).toBe(en.chat.compactionTitle("discard"));
+    for (const [locale, dict] of [
+      ["zh", zh],
+      ["en", en],
+    ] as const) {
+      setActiveStrings(dict);
+      expect(compactionBadgeLabel(summarize), locale).toBe(dict.chat.compactionTitle("summarize"));
+      expect(compactionBadgeLabel(discard), locale).toBe(dict.chat.compactionTitle("discard"));
+      // Reuses the chat row's title rather than a second Trace-local pair of strings, and the
+      // two modes stay distinguishable.
+      expect(compactionBadgeLabel(discard), locale).not.toBe(compactionBadgeLabel(summarize));
+    }
   });
 
   it("falls back to the compaction title when the mode is absent (a round analyzed by an older server)", () => {
     const legacy = { taskIndex: 1, compaction: true } as never;
-    expect(compactionBadgeLabel(legacy)).toBe("压缩");
-    setActiveStrings(en);
-    expect(compactionBadgeLabel(legacy)).toBe("Compaction");
+    for (const dict of [zh, en]) {
+      setActiveStrings(dict);
+      expect(compactionBadgeLabel(legacy)).toBe(dict.chat.compactionTitle("summarize"));
+    }
   });
 });


### PR DESCRIPTION
## What this does

Two independent pieces of work, both about the unit-test suite.

**Speed.** `pnpm -r test` runs packages in dependency order, so the critical path is
`skills → core → server → …`, and the server suite dominated it. Profiling it found two
costs, in this order:

1. **scrypt.** Almost every case in the server suite builds a fresh app: `createTestApp`
   seeds an admin (one hash), most tests then `provisionUser` (admin login, user hash, user
   login). Instrumenting the module counted **528 derivations across 123 tests** — 4.3 per
   test — and at N=16384 each costs ~100ms. Dropping the work factor on a five-file subset
   took its summed test time from 45–54s to ~17s.
2. **Module evaluation.** With `isolate: true` (the default) vitest evaluates each test
   file's whole import graph in a fresh worker. Every file here imports the server app,
   which pulls core's bundle; `collect` summed to ~2–4s per file across the suite, and
   `prepare` (fork spawn) to ~0.2s per file.

The fix for (1) is a defaulted `cost` argument on `hashPassword` plus a `passwordHashCost`
test override on `buildAppDeps`, next to the `loader` / `titles` / `updateCheck` doubles it
already took. `buildAppDeps` is not in the server package's `exports` map, so the knob is
internal to the package; production passes nothing and no configuration reaches it. The
stored format and the verification path are unchanged — scrypt's N travels inside the hash
string — so hashes already on disk keep verifying, and `password.test.ts` (which calls the
unparameterized form) now pins the production factor at 16384.

The fix for (2) is `isolate: false` in the server's vitest config. `test/isolation.test.ts`
guards its one precondition: no file in the suite may register a module mock.

**String assertions.** A sweep for assertions that pin exact prose. The big one was
`packages/skills/test/skills.test.ts`, where three tests carried ~140 `toContain` calls
quoting sentences out of four shipped SKILL.md documents.

## Numbers

Five interleaved before/after rounds on this 8-core Linux box (medians; the box is shared,
so runs were paired inside each round to keep both arms under the same load):

| target | before | after | |
| --- | --- | --- | --- |
| `pnpm -r test` | **64.7s** | **38.7s** | 1.67x |
| `packages/server` | **51.5s** | **13.4s** | 3.84x |
| `packages/core` | 10.6s | 10.2s | 1.04x |

Per-round paired ratios: `pnpm -r test` 1.69 / 1.80 / 1.80 / 1.99 / 1.59; `server` 4.95 /
3.60 / 4.28 / 3.75 / 2.42.

Three more rounds for the packages whose test *content* changed but whose config did not —
unchanged, as expected:

| package | before | after |
| --- | --- | --- |
| `web` | 6.62s | 6.54s |
| `cli` | 4.16s | 4.24s |
| `skills` | 1.43s | 1.40s |
| `docs` | 1.86s | 1.87s |
| `landing` | 1.95s | 1.93s |
| `desktop` | 1.56s | 1.59s |

The aggregate improves less than `server` alone because `pnpm -r test` runs packages in
dependency order: `skills → core → server → {web, cli, desktop}`. With server at 13.4s,
`core` (10.2s) is now the next item on that path.

Test counts across every run: `core` 844, `cli` 292, `desktop` 55, `landing` 39, `docs` 53;
`server` 788 → 789 (`isolation.test.ts`), `web` 989 → 987 (two label tests folded into
neighbours), `skills` 22 → 24 (three prose tests replaced by five).

## Levers considered and dropped

- **`pool: "threads"`** — measured ~10% on the server suite (38.4s vs 43.1s median), and it
  is unsafe here: `process.env` is per-process, and `models.test.ts` sets `OPENAI_API_KEY`
  while `protocol-detect.test.ts` and `session-index.test.ts` delete it. Under forks those
  files are in separate processes; under threads they would race. Dropped.
- **`isolate: false` for `core` and `cli`** — both register module mocks
  (`core/test/workspace.test.ts` mocks `node:crypto`, `core/test/agent.test.ts` mocks two
  internal modules, two `cli` chat tests mock the core package). A mock registered by one
  file would still be installed for every later file in the same worker. Dropped.
- **`isolate: false` for `web`** — `web/test/terminal-dock-scope.test.ts` calls
  `vi.resetModules()` to simulate a page reload, which under a shared registry would reset
  the registry for every file after it. Web is also not on the critical path. Dropped.
- **Splitting `core/test/mcp-tools.test.ts`** — it is core's longest file (it spawns real
  stdio MCP servers), so core's floor is roughly its duration. Measured after the fix at 10.2s against server's 13.4s, so it would move the
  aggregate by a few percent at best, and `core` cannot take `isolate: false` anyway (see
  above). Not worth the churn in a file that is currently well organised by transport.

## Verification

- `pnpm format` then `pnpm format:check` — clean.
- `pnpm --filter <pkg> typecheck` for `server`, `core`, `web`, `cli`, `skills` — clean.
- `packages/server`: **12 green runs** at 78 files / 789 tests under `isolate: false` — 8
  sequential, 4 with `--sequence.shuffle`, plus one `--poolOptions.forks.singleFork` run
  (every file in one process, in order). No run reported a different count.
- `packages/core` 844, `packages/web` 987, `packages/cli` 292, `packages/skills` 24 — all
  green.
- The suite's one flake, `terminal-stream.test.ts > replays input modes a program enabled to
  a reattaching client`, appeared **twice, both times under `isolate: true`** — once on
  pristine `main` and once on this branch before the config change — and in no
  `isolate: false` run. It waits on real pty output and only failed while the box was above
  load 15.

## Windows

`ci-windows` runs the same suites, and `origin/ci/windows-serial-tests` (unmerged) makes
that job run packages one at a time. Nothing here touches `ci.yml`, so the two compose:
serial packages outside, one fork per worker inside. The platform-aware timeouts and their
rationale in both vitest config headers are unchanged and still true. The direction of the
change favours that runner — process creation is the expensive operation on Windows, and
`prepare` went from one spawn per test file to one per worker — but the residual risk is
that a file handle left open by one file now outlives it inside the worker, where before
the process exit released it. `createTestApp`'s cleanup already retries `EBUSY`/`ENOTEMPTY`
ten times for exactly that class of problem.

The first run says the direction held: `ci-windows` passed in **5m12s** on this branch,
against 6m34s / 8m36s / 6m41s for the three most recent `ci` workflow runs on `main`. The
ubuntu `ci` job went 3m18s / 3m18s / 4m11s → **2m2s**, and `ci-macos` passed as well.

## Not done

- `packages/web/test/session-row-menu.test.ts` and
  `packages/web/test/workspace-registry.test.ts` carry Chinese prose in comments and one
  test name, and the former cites `design/specs/06-PROTOTYPE.md` from a test name. Both
  break standing repo rules, but neither is an assertion and neither file is otherwise
  touched here — flagging rather than bundling unrelated churn into a perf PR.
- `packages/server/test/terminal-stream.test.ts > replays input modes a program enabled to
  a reattaching client` is flaky under load on **pristine main** as well as on this branch
  (it waits on real pty output). Not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Z4mn56LTt4qJR3m9GjHka
