### PR TITLE
ci: shard the Windows job in two and drop its platform-independent steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,12 +126,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      # pnpm version comes from package.json's packageManager field. standalone: one
-      # self-contained executable instead of a package-tree install, which Windows
-      # Defender otherwise scans file by file (tens of seconds on this runner).
+      # pnpm version comes from package.json's packageManager field.
       - uses: pnpm/action-setup@v6
-        with:
-          standalone: true
 
       - uses: actions/setup-node@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,19 +95,43 @@ jobs:
       - name: Terminal smoke (node-pty under Electron's Node)
         run: node packages/desktop/scripts/terminal-smoke.mjs
 
-  # Windows: the same build/typecheck/test gates on windows-latest (the ubuntu job above stays the
-  # required one). The runner ships Git-Bash on PATH, so core's exec_command tests run through the
-  # shell resolver's bash pick; genuinely POSIX-only tests skip themselves via process.platform
-  # guards (not CI filters), so local Windows devs see the same behavior. Line endings come from
-  # .gitattributes (LF working tree), keeping build outputs and fixtures byte-identical.
-  # No format:check (same files as ubuntu) and no live-LLM e2e here (ubuntu-only budget).
+  # Windows: the same build/test gates on windows-latest (the ubuntu job above stays the
+  # required one), split into two shards so the process-heavy suites don't share a small
+  # runner: `server` gives the pty-streaming suites the whole machine and carries the
+  # installer checks, while `packages` runs core alone first (its exec_command suites spawn
+  # real shells and read their output under timeouts, races they lose when oversubscribed)
+  # and the remaining packages together after it. Every package's tests run exactly once
+  # across the two shards. The runner ships Git-Bash on PATH, so core's exec_command tests
+  # run through the shell resolver's bash pick; genuinely POSIX-only tests skip themselves
+  # via process.platform guards (not CI filters), so local Windows devs see the same
+  # behavior. Line endings come from .gitattributes (LF working tree), keeping build
+  # outputs and fixtures byte-identical. No format:check and no typecheck (same files as
+  # ubuntu, and both results are platform-independent, so the ubuntu job gates them); no
+  # live-LLM e2e here (ubuntu-only budget).
   ci-windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: server
+            tests: pnpm --filter @prismshadow/penguin-server test
+            installer: true
+          - shard: packages
+            tests: >-
+              pnpm --filter @prismshadow/penguin-core test &&
+              pnpm -r --filter '!@prismshadow/penguin-core' --filter '!@prismshadow/penguin-server' test
+            installer: false
+    name: ci-windows (${{ matrix.shard }})
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v5
 
-      # pnpm version comes from package.json's packageManager field.
+      # pnpm version comes from package.json's packageManager field. standalone: one
+      # self-contained executable instead of a package-tree install, which Windows
+      # Defender otherwise scans file by file (tens of seconds on this runner).
       - uses: pnpm/action-setup@v6
+        with:
+          standalone: true
 
       - uses: actions/setup-node@v5
         with:
@@ -120,15 +144,13 @@ jobs:
       - name: Build (tsup)
         run: pnpm build
 
-      - name: Typecheck (tsc)
-        run: pnpm typecheck
-
       - name: Unit tests (vitest)
-        run: pnpm test
+        run: ${{ matrix.tests }}
 
       # The Linux job cannot validate PowerShell syntax; parse (never execute) the installer
       # scripts with the real PowerShell parser so a broken install.ps1 cannot ship.
       - name: Parse installer scripts (PowerShell)
+        if: matrix.installer
         shell: pwsh
         run: |
           $failed = $false
@@ -148,6 +170,7 @@ jobs:
           if ($failed) { exit 1 }
 
       - name: Windows installer tests
+        if: matrix.installer
         shell: pwsh
         run: ./scripts/test-installer.ps1
 

--- a/changelog/unreleased/2026-08-21-ci-windows-speed.md
+++ b/changelog/unreleased/2026-08-21-ci-windows-speed.md
@@ -14,4 +14,3 @@ Split `ci-windows` into two parallel shards and dropped the steps that duplicate
 - The `server` shard runs the server package's suite alone — the process-heaviest suite gets the whole runner to itself — and carries the PowerShell installer parse and the Windows installer tests.
 - The `packages` shard runs core's suite alone first (its `exec_command` tests spawn real shells under timeouts and lose races on an oversubscribed runner), then the remaining six packages together.
 - Dropped the Windows `typecheck` step: tsc's result is platform-independent and the ubuntu job gates it — the reasoning the job already applied to `format:check`.
-- `pnpm/action-setup` on the Windows shards now passes `standalone: true`: one self-contained executable instead of a package-tree install that Windows Defender scans file by file.

--- a/changelog/unreleased/2026-08-21-ci-windows-speed.md
+++ b/changelog/unreleased/2026-08-21-ci-windows-speed.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-21
 - **Type:** process
 - **Scope:** `ci`
+- **PR:** [#385](https://github.com/Prism-Shadow/penguin-harness/pull/385)
 
 [中文版](2026-08-21-ci-windows-speed.zh.md)
 

--- a/changelog/unreleased/2026-08-21-ci-windows-speed.md
+++ b/changelog/unreleased/2026-08-21-ci-windows-speed.md
@@ -1,0 +1,16 @@
+# Split the Windows CI job into two test shards
+
+- **Date:** 2026-08-21
+- **Type:** process
+- **Scope:** `ci`
+
+[中文版](2026-08-21-ci-windows-speed.zh.md)
+
+Split `ci-windows` into two parallel shards and dropped the steps that duplicated platform-independent gates, cutting the Windows wall clock roughly in half while every package's tests still run exactly once on Windows.
+
+## Details
+
+- The `server` shard runs the server package's suite alone — the process-heaviest suite gets the whole runner to itself — and carries the PowerShell installer parse and the Windows installer tests.
+- The `packages` shard runs core's suite alone first (its `exec_command` tests spawn real shells under timeouts and lose races on an oversubscribed runner), then the remaining six packages together.
+- Dropped the Windows `typecheck` step: tsc's result is platform-independent and the ubuntu job gates it — the reasoning the job already applied to `format:check`.
+- `pnpm/action-setup` on the Windows shards now passes `standalone: true`: one self-contained executable instead of a package-tree install that Windows Defender scans file by file.

--- a/changelog/unreleased/2026-08-21-ci-windows-speed.zh.md
+++ b/changelog/unreleased/2026-08-21-ci-windows-speed.zh.md
@@ -1,0 +1,16 @@
+# Windows CI 作业拆分为两个测试分片
+
+- **Date:** 2026-08-21
+- **Type:** process
+- **Scope:** `ci`
+
+[English](2026-08-21-ci-windows-speed.md)
+
+把 `ci-windows` 拆成两个并行分片,并去掉了与平台无关门禁重复的步骤,Windows 侧墙钟时间约减半;每个包的测试在 Windows 上仍然恰好各跑一次。
+
+## 详情
+
+- `server` 分片单独运行 server 包的套件——进程开销最大的套件独占整台 runner——并承担 PowerShell 安装脚本解析与 Windows 安装器测试。
+- `packages` 分片先单独运行 core 的套件(其 `exec_command` 测试会真实拉起 shell 并在超时内读取输出,在超订阅的 runner 上会输掉竞态),再一并运行其余六个包。
+- 去掉了 Windows 上的 `typecheck` 步骤:tsc 的结果与平台无关,由 ubuntu 作业守门——与该作业对 `format:check` 已有的处理同理。
+- Windows 分片的 `pnpm/action-setup` 现在传 `standalone: true`:用单个自包含可执行文件替代会被 Windows Defender 逐文件扫描的包树安装。

--- a/changelog/unreleased/2026-08-21-ci-windows-speed.zh.md
+++ b/changelog/unreleased/2026-08-21-ci-windows-speed.zh.md
@@ -14,4 +14,3 @@
 - `server` 分片单独运行 server 包的套件——进程开销最大的套件独占整台 runner——并承担 PowerShell 安装脚本解析与 Windows 安装器测试。
 - `packages` 分片先单独运行 core 的套件(其 `exec_command` 测试会真实拉起 shell 并在超时内读取输出,在超订阅的 runner 上会输掉竞态),再一并运行其余六个包。
 - 去掉了 Windows 上的 `typecheck` 步骤:tsc 的结果与平台无关,由 ubuntu 作业守门——与该作业对 `format:check` 已有的处理同理。
-- Windows 分片的 `pnpm/action-setup` 现在传 `standalone: true`:用单个自包含可执行文件替代会被 Windows Defender 逐文件扫描的包树安装。

--- a/changelog/unreleased/2026-08-21-ci-windows-speed.zh.md
+++ b/changelog/unreleased/2026-08-21-ci-windows-speed.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-21
 - **Type:** process
 - **Scope:** `ci`
+- **PR:** [#385](https://github.com/Prism-Shadow/penguin-harness/pull/385)
 
 [English](2026-08-21-ci-windows-speed.md)
 


### PR DESCRIPTION
## What this changes

`ci-windows` runs everything in one `windows-latest` job; on current main that is **5m50s** wall, of which the vitest step is 218s because `pnpm -r test` makes wall time the sum of every package's suite while the process-heavy suites fight the small ones for four cores. This PR:

- **Splits the job into two parallel shards.** `ci-windows (server)` runs the server suite alone — the process-heaviest suite gets the whole runner — and keeps the PowerShell installer parse + installer tests. `ci-windows (packages)` runs core alone first (its `exec_command` tests spawn real shells under timeouts), then the remaining six packages together. Every package's tests still run exactly once on Windows.
- **Drops the Windows `typecheck` step (28s).** tsc's result is platform-independent; the ubuntu job — the required check — gates it, the same reasoning the job already applies to `format:check`.

The ubuntu `ci` job, `ci-macos`, and the `runtime` matrix are untouched. A `standalone: true` pnpm install was tried on the shards and reverted: four samples (66/25/36/26s) sat inside the default install's variance band (25/34s on recent main runs).

## Measured timings (this PR's runs vs the latest main run)

| | main (single job) | shard `server` | shard `packages` |
|---|---|---|---|
| toolchain + install | 54s | 69–79s | 54–125s¹ |
| build (tsup) | 31s | 31–32s | 33–44s |
| typecheck | 28s | — | — |
| vitest | 218s | 133–139s | 77–90s |
| installer steps | 10s | 10s | — |
| **job wall** | **5m50s** | **3m54–4m20s** | **3m08–4m23s¹** |

¹ one first-run toolchain outlier (113s of setup); the other two runs were 3m08s.

Wall clock is the slower shard: **~4m20s vs 5m50s**. The remaining bottleneck is the server suite itself (133–139s here, on main's code); #381 makes that suite ~1.7–2x faster on its branch, so with both merged the shards project to roughly **~3m**. Sharding also removes the oversubscription behind the known pty/`exec_command` timing flakes — the same problem the unmerged `ci/windows-serial-tests` experiment attacks by serializing suites at the cost of a longer wall clock; whether to close that branch is its author's call.

## Verification

- Three consecutive runs of this branch's workflow, all jobs green each time (including a manual rerun); no pty/`exec_command` flake surfaced in either shard across the three.
- The `packages` shard's filter selection verified against the real workspace: `pnpm -r --filter '!@prismshadow/penguin-core' --filter '!@prismshadow/penguin-server' exec pwd` selects exactly cli, desktop, docs, landing, skills, web — the workspace root is not selected, so the root `test` script cannot recurse.
- Workflow YAML parsed and matrix/step structure checked locally; `pnpm format:check` and `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)