### PR TITLE
feat(core,cli,web,docs,skills): AgentHub 0.4.6 with the DeepSeek vision model

### DIFF
--- a/changelog/unreleased/2026-08-21-agenthub-0.4.6.md
+++ b/changelog/unreleased/2026-08-21-agenthub-0.4.6.md
@@ -1,0 +1,25 @@
+# AgentHub 0.4.6: a DeepSeek vision model, and DeepSeek on the Responses protocol
+
+- **Date:** 2026-08-21
+- **Type:** feature
+- **Scope:** `core`, `cli`, `web`, `model-catalog`, `docs`
+- **Breaking:** yes — a `deepseek-v4*` model pointed at a Chat Completions-only endpoint now needs `client_type = "openai-chat"` set by hand
+
+[中文版](2026-08-21-agenthub-0.4.6.zh.md)
+
+`@prismshadow/agenthub` moved from 0.4.5 to 0.4.6, which adds `deepseek-v4-flash-vision-exp` and moves the first-party DeepSeek client from Chat Completions to the OpenAI Responses API (agenthub [#185](https://github.com/Prism-Shadow/agenthub/pull/185)). The model catalog gained the new model in two groups, and the Web model dialog's base URL hint now reads `/responses` for DeepSeek.
+
+## Details
+
+- `deepseek-v4-flash-vision-exp` joined the DeepSeek group: image input on top of V4 Flash's text capabilities, a 1M context window, and V4 Flash's own price. It is the only vision-capable model in that group: a session running it reads images directly, instead of routing them through the `vision_model` proxy `describe_image` uses for text-only models. A fresh Project still defaults to `deepseek-v4-flash`.
+- `deepseek/deepseek-v4-flash-vision-exp` joined the OpenRouter group at that gateway's published rates ($0.22 input / $0.66 output / $0.007 cache read per million tokens) and its 1,048,576-token context window. DeepSeek is the only provider serving it there.
+- Both rows record the official **off-peak** tier, the same convention the existing DeepSeek rows follow: peak hours (Beijing 9:00–12:00 and 14:00–18:00) bill exactly double, and the cost centre uses one rate, so peak usage is under-counted 2x.
+- The protocol-path hint at the right edge of the base URL field reads `/responses` for the DeepSeek group and for an explicit `deepseek-v4` client type. The gateway rows reselling DeepSeek pin `openai-chat` and keep `/chat/completions`.
+- The shipped `agenthub-models` skill lists the new id in both its official and OpenRouter columns, and records which wire protocol the `deepseek-v4` client speaks.
+- `pnpm-workspace.yaml`'s `minimumReleaseAgeExclude` entry names 0.4.6 and drops 0.4.5, as that file's own note instructed.
+
+## Compatibility
+
+Existing Projects do not pick up the two new catalog rows on their own: presets are copied into `.project_config.toml` when a Project is created, and nothing rewrites them afterwards. Use **sync presets** on the models page to append them; the stored default model is never touched.
+
+A model whose id contains `deepseek-v4` and which carries no `client_type` is routed to the DeepSeek client by its id alone, and that client now posts to `{base_url}/responses`. Entries pointed at `https://api.deepseek.com` are unaffected — DeepSeek serves both protocols. An entry pointed at an endpoint that serves Chat Completions only (a self-hosted server, a relay, a third-party DeepSeek-compatible gateway) starts failing after the upgrade: set `client_type = "openai-chat"` on it, in `.project_config.toml` or through the models page's protocol selector, and the request shape returns to what it was.

--- a/changelog/unreleased/2026-08-21-agenthub-0.4.6.md
+++ b/changelog/unreleased/2026-08-21-agenthub-0.4.6.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-21
 - **Type:** feature
 - **Scope:** `core`, `cli`, `web`, `model-catalog`, `docs`
+- **PR:** [#388](https://github.com/Prism-Shadow/penguin-harness/pull/388)
 - **Breaking:** yes — a `deepseek-v4*` model pointed at a Chat Completions-only endpoint now needs `client_type = "openai-chat"` set by hand
 
 [中文版](2026-08-21-agenthub-0.4.6.zh.md)

--- a/changelog/unreleased/2026-08-21-agenthub-0.4.6.zh.md
+++ b/changelog/unreleased/2026-08-21-agenthub-0.4.6.zh.md
@@ -1,0 +1,25 @@
+# AgentHub 0.4.6：DeepSeek 视觉模型，以及 DeepSeek 改走 Responses 协议
+
+- **Date:** 2026-08-21
+- **Type:** feature
+- **Scope:** `core`, `cli`, `web`, `model-catalog`, `docs`
+- **Breaking:** yes — 指向仅提供 Chat Completions 端点的 `deepseek-v4*` 模型，现在需要手工设置 `client_type = "openai-chat"`
+
+[English](2026-08-21-agenthub-0.4.6.md)
+
+`@prismshadow/agenthub` 从 0.4.5 升到 0.4.6。新版本加入了 `deepseek-v4-flash-vision-exp`，并把第一方 DeepSeek client 从 Chat Completions 改为 OpenAI Responses API（agenthub [#185](https://github.com/Prism-Shadow/agenthub/pull/185)）。模型目录在两个分组中收录了该模型，Web 模型对话框中 base URL 的协议路径提示对 DeepSeek 改为 `/responses`。
+
+## 细节
+
+- `deepseek-v4-flash-vision-exp` 进入 DeepSeek 分组：在 V4 Flash 的文本能力之上支持图像输入，上下文窗口 100 万 Token，价格与 V4 Flash 相同。它是该分组中唯一支持图像输入的模型：以它运行的会话直接读图，无需再经 `describe_image` 为 text-only 模型准备的 `vision_model` 代读路径。新建 Project 的默认模型仍是 `deepseek-v4-flash`。
+- `deepseek/deepseek-v4-flash-vision-exp` 进入 OpenRouter 分组，按该网关公布的价格记录（每百万 Token 输入 $0.22 / 输出 $0.66 / 缓存命中 $0.007），上下文窗口为 1,048,576 Token。该模型在 OpenRouter 上只有 DeepSeek 一家提供。
+- 两条记录都采用官方**低谷时段**档，与既有 DeepSeek 记录一致：高峰时段（北京时间 9:00–12:00、14:00–18:00）按整整双倍计费，而费用中心只用单一价格，因此高峰用量会被低估一半。
+- base URL 输入框右端的协议路径提示，对 DeepSeek 分组以及显式的 `deepseek-v4` client type 均显示 `/responses`。转售 DeepSeek 的网关分组固定 `openai-chat`，仍显示 `/chat/completions`。
+- 随附的 `agenthub-models` skill 在官方与 OpenRouter 两列中都列出了新 id，并记录了 `deepseek-v4` client 使用的传输协议。
+- `pnpm-workspace.yaml` 中 `minimumReleaseAgeExclude` 的条目改为 0.4.6；按该文件自身注释的要求，移除了 0.4.5 的条目。
+
+## 兼容性
+
+既有 Project 不会自动获得这两条新目录记录：预置模型在创建 Project 时写入 `.project_config.toml`，此后不再被改写。在模型页点击**同步预置**即可追加，存储的默认模型不受影响。
+
+model id 中含 `deepseek-v4`、且未填写 `client_type` 的条目，仅凭 id 就会被路由到 DeepSeek client，而该 client 现在向 `{base_url}/responses` 发请求。指向 `https://api.deepseek.com` 的条目不受影响——DeepSeek 两种协议都提供。指向仅提供 Chat Completions 端点的条目（自建服务、中转站、第三方 DeepSeek 兼容网关）在升级后会开始失败：为其设置 `client_type = "openai-chat"` 即可——在 `.project_config.toml` 中填写，或用模型页的协议选择器选择——请求形态即恢复原样。

--- a/changelog/unreleased/2026-08-21-agenthub-0.4.6.zh.md
+++ b/changelog/unreleased/2026-08-21-agenthub-0.4.6.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-21
 - **Type:** feature
 - **Scope:** `core`, `cli`, `web`, `model-catalog`, `docs`
+- **PR:** [#388](https://github.com/Prism-Shadow/penguin-harness/pull/388)
 - **Breaking:** yes — 指向仅提供 Chat Completions 端点的 `deepseek-v4*` 模型，现在需要手工设置 `client_type = "openai-chat"`
 
 [English](2026-08-21-agenthub-0.4.6.md)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/client": "^2.0.0",
-    "@prismshadow/agenthub": "^0.4.5",
+    "@prismshadow/agenthub": "^0.4.6",
     "@prismshadow/penguin-core": "workspace:*",
     "@prismshadow/penguin-server": "workspace:*",
     "@prismshadow/penguin-skills": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/client": "^2.0.0",
-    "@prismshadow/agenthub": "^0.4.5",
+    "@prismshadow/agenthub": "^0.4.6",
     "@prismshadow/penguin-skills": "workspace:*",
     "arktype": "^2.2.3",
     "smol-toml": "^1.3.0",

--- a/packages/core/src/state/model-catalog.ts
+++ b/packages/core/src/state/model-catalog.ts
@@ -3,7 +3,8 @@
  * auto-route, shared by core's default config, server's initial config, and web/cli display.
  * Data verified as of 2026-07-10 (Qwen Token Plan entries: 2026-07-20; MiniMax: 2026-08-03;
  * DeepSeek, Gemini 3.7, GLM-5.3 and the whole OpenAI line-up (direct + OpenRouter):
- * 2026-08-18; the direct Anthropic group: 2026-08-20 — per each provider's docs).
+ * 2026-08-18; the direct Anthropic group: 2026-08-20; the DeepSeek V4 Flash Vision Exp rows:
+ * 2026-08-21 — per each provider's docs).
  * Docs: packages/docs/content/models.{zh,en}.md (site path /docs/models) documents the
  * provider groups and credential resolution described here.
  *
@@ -248,6 +249,16 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     supportsVision: false,
   },
   {
+    // The experimental vision revision of V4 Flash (added 2026-08-21): image input on top of
+    // the base model's text capabilities, at the same published price.
+    modelId: "deepseek-v4-flash-vision-exp",
+    displayName: "DeepSeek V4 Flash Vision Exp",
+    provider: "deepseek",
+    contextWindow: 1000000,
+    pricing: cny(0.05, 1.5, 4.5),
+    supportsVision: true,
+  },
+  {
     modelId: "deepseek-v4-pro",
     displayName: "DeepSeek V4 Pro",
     provider: "deepseek",
@@ -355,6 +366,20 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     contextWindow: 1000000,
     pricing: usd(0.0168, 0.0679, 0.168),
     supportsVision: false,
+    clientType: "openai-chat",
+    baseUrl: OPENROUTER_BASE_URL,
+  },
+  {
+    // DeepSeek serves this one alone on OpenRouter, so the stored rates are its own published
+    // USD list ($0.22 / $0.66 / $0.007 cache read), and the context window is that endpoint's
+    // 1,048,576. Like the direct group, the price is the OFF-PEAK tier: the models API exposes
+    // the peak windows as `pricing.overrides` billing exactly double.
+    modelId: "deepseek/deepseek-v4-flash-vision-exp",
+    displayName: "DeepSeek V4 Flash Vision Exp",
+    provider: "openrouter",
+    contextWindow: 1048576,
+    pricing: usd(0.007, 0.22, 0.66),
+    supportsVision: true,
     clientType: "openai-chat",
     baseUrl: OPENROUTER_BASE_URL,
   },

--- a/packages/core/test/model-catalog.test.ts
+++ b/packages/core/test/model-catalog.test.ts
@@ -131,6 +131,13 @@ describe("model-catalog", () => {
     expect(catalogEntryFor("zhipu", "glm-5.2")?.contextWindow).toBe(1000000);
     expect(catalogEntryFor("qwen-token-plan", "glm-5.2")?.contextWindow).toBe(1048576);
     expect(catalogEntryFor("deepseek", "deepseek-v4-pro")?.provider).toBe("deepseek");
+    // The vision revision is a model of its own in both the direct group and on OpenRouter,
+    // and it is the only vision-capable DeepSeek row in either.
+    expect(catalogEntryFor("deepseek", "deepseek-v4-flash-vision-exp")?.supportsVision).toBe(true);
+    expect(
+      catalogEntryFor("openrouter", "deepseek/deepseek-v4-flash-vision-exp")?.supportsVision,
+    ).toBe(true);
+    expect(catalogEntryFor("deepseek", "deepseek-v4-flash")?.supportsVision).toBe(false);
     expect(catalogEntryFor("qwen-token-plan", "deepseek-v4-pro")?.provider).toBe("qwen-token-plan");
     expect(catalogEntryFor("minimax", "MiniMax-M3")?.displayName).toBe("MiniMax M3");
   });
@@ -167,6 +174,7 @@ describe("model-catalog", () => {
       "anthropic/claude-sonnet-5",
       "deepseek/deepseek-v4-flash-0731",
       "deepseek/deepseek-v4-flash",
+      "deepseek/deepseek-v4-flash-vision-exp",
       "deepseek/deepseek-v4-pro-0813",
       "deepseek/deepseek-v4-pro",
       "google/gemini-3.7-flash",

--- a/packages/docs/content/models.en.md
+++ b/packages/docs/content/models.en.md
@@ -77,7 +77,7 @@ The gateway groups (openrouter / fireworks / siliconflow / qwen-token-plan / qwe
 
 The preset catalog also carries OpenRouter's free tier: the `:free` model variant `nvidia/nemotron-3-ultra-550b-a55b:free` and the `openrouter/free` unified Free Models Router. They cost nothing, but are subject to OpenRouter's free-tier rate limits and data policy.
 
-Some models in the preset catalog: deepseek-v4-pro / deepseek-v4-flash, MiniMax-M3, gemini-3.7-flash, claude-opus-5 / claude-opus-4-8 / claude-sonnet-5, gpt-5.6 / gpt-5.5, glm-5.3, kimi-k3, qwen3.8-max (not exhaustive). The whole OpenAI line-up is listed twice — directly (your own OpenAI key, list prices) and on OpenRouter as `openai/<id>` (the gateway's rates, which follow its running promotions). DeepSeek's direct-group prices record the official off-peak tier (peak hours, Beijing 9:00–12:00 and 14:00–18:00, bill double).
+Some models in the preset catalog: deepseek-v4-pro / deepseek-v4-flash / deepseek-v4-flash-vision-exp (the DeepSeek group's only vision-capable model), MiniMax-M3, gemini-3.7-flash, claude-opus-5 / claude-opus-4-8 / claude-sonnet-5, gpt-5.6 / gpt-5.5, glm-5.3, kimi-k3, qwen3.8-max (not exhaustive). The whole OpenAI line-up is listed twice — directly (your own OpenAI key, list prices) and on OpenRouter as `openai/<id>` (the gateway's rates, which follow its running promotions). DeepSeek's direct-group prices record the official off-peak tier (peak hours, Beijing 9:00–12:00 and 14:00–18:00, bill double).
 
 ## Local / self-hosted OpenAI-compatible endpoints (e.g. vLLM)
 

--- a/packages/docs/content/models.zh.md
+++ b/packages/docs/content/models.zh.md
@@ -77,7 +77,7 @@ api_key = "sk-..."
 
 预置目录还收录了 OpenRouter 的免费档：`:free` 模型变体 `nvidia/nemotron-3-ultra-550b-a55b:free` 与统一路由 `openrouter/free`(Free Models Router)，零成本可用，但受 OpenRouter 免费档速率限制与数据政策约束。
 
-预置目录中的部分模型：deepseek-v4-pro / deepseek-v4-flash、MiniMax-M3、gemini-3.7-flash、claude-opus-5 / claude-opus-4-8 / claude-sonnet-5、gpt-5.6 / gpt-5.5、glm-5.3、kimi-k3、qwen3.8-max 等(非完整清单)。OpenAI 全系列都收录了两份——直连(用自己的 OpenAI Key，记牌价)与 OpenRouter 上的 `openai/<id>`(记网关实际计费价，会随其促销浮动)。DeepSeek 直连分组的价格记录官方低谷时段档(高峰时段——北京时间 9:00–12:00、14:00–18:00——按双倍计费)。
+预置目录中的部分模型：deepseek-v4-pro / deepseek-v4-flash / deepseek-v4-flash-vision-exp(DeepSeek 分组中唯一支持图像输入的模型)、MiniMax-M3、gemini-3.7-flash、claude-opus-5 / claude-opus-4-8 / claude-sonnet-5、gpt-5.6 / gpt-5.5、glm-5.3、kimi-k3、qwen3.8-max 等(非完整清单)。OpenAI 全系列都收录了两份——直连(用自己的 OpenAI Key，记牌价)与 OpenRouter 上的 `openai/<id>`(记网关实际计费价，会随其促销浮动)。DeepSeek 直连分组的价格记录官方低谷时段档(高峰时段——北京时间 9:00–12:00、14:00–18:00——按双倍计费)。
 
 ## 本地 / 自建 OpenAI 兼容端点（如 vLLM）
 

--- a/packages/skills/skills/agenthub-models/SKILL.md
+++ b/packages/skills/skills/agenthub-models/SKILL.md
@@ -3,7 +3,7 @@ name: agenthub-models
 description: Call model APIs through @prismshadow/agenthub — streaming text generation, image generation, speech synthesis, embeddings and the supported-model registry with one client.
 short_description: Call model APIs with one AgentHub client.
 short_description_zh: 用一个 AgentHub 客户端调用模型 API。
-version: 14
+version: 15
 updated: 2026-08-21T00:00:00Z
 ---
 
@@ -64,7 +64,7 @@ Use exact model ids. If an id is not in the table below and the user has not giv
 | Kimi K3          | `kimi-k3`                                                             | OpenRouter `moonshotai/kimi-k3`                                                                                                                 |
 | Kimi K2.7 Code   | —                                                                     | SiliconFlow `moonshotai/Kimi-K2.7-Code`; Fireworks AI `accounts/fireworks/models/kimi-k2p7-code`                                                |
 | Kimi K2.6        | `kimi-k2.6`                                                           | OpenRouter `moonshotai/kimi-k2.6`; SiliconFlow `Pro/moonshotai/Kimi-K2.6`                                                                       |
-| DeepSeek V4      | `deepseek-v4-pro`, `deepseek-v4-flash`                                | OpenRouter `deepseek/deepseek-v4-pro-0813`, `deepseek/deepseek-v4-pro`, `deepseek/deepseek-v4-flash`, `deepseek/deepseek-v4-flash-0731`; Fireworks AI `accounts/fireworks/models/deepseek-v4-flash-0731`; SiliconFlow `deepseek-ai/DeepSeek-V4-Pro`, `deepseek-ai/DeepSeek-V4-Flash` |
+| DeepSeek V4      | `deepseek-v4-pro`, `deepseek-v4-flash`, `deepseek-v4-flash-vision-exp` | OpenRouter `deepseek/deepseek-v4-pro-0813`, `deepseek/deepseek-v4-pro`, `deepseek/deepseek-v4-flash`, `deepseek/deepseek-v4-flash-0731`, `deepseek/deepseek-v4-flash-vision-exp`; Fireworks AI `accounts/fireworks/models/deepseek-v4-flash-0731`; SiliconFlow `deepseek-ai/DeepSeek-V4-Pro`, `deepseek-ai/DeepSeek-V4-Flash` |
 | GLM 5.3          | `glm-5.3`                                                             | OpenRouter `z-ai/glm-5.3`                                                                                                                       |
 | GLM 5.2          | `glm-5.2`                                                             | OpenRouter `z-ai/glm-5.2`; SiliconFlow `zai-org/GLM-5.2`                                                                                        |
 | GLM 5.1          | `glm-5.1`                                                             | —                                                                                                                                               |
@@ -108,6 +108,7 @@ The registry is the curated current line-up, so prefer it when picking a model o
   - `clientType: "ant-messages"` — Anthropic Messages-compatible endpoints (Anthropic, OpenRouter `https://openrouter.ai/api`, DeepSeek `https://api.deepseek.com/anthropic`, Z.AI, MiniMax).
 - Exception: an id served by an OpenAI-compatible gateway that still matches a first-party substring (e.g. OpenRouter's `google/gemini-3.7-flash`, `anthropic/claude-sonnet-5` or `openai/gpt-5.6-sol` on the `/api/v1` endpoint) would auto-route to the vendor protocol client — and a dotted id like `anthropic/claude-opus-4.8` matches nothing and throws. Always pass an explicit `clientType` for gateway ids; never rely on the id. Routing reads `clientType` (or the model id) as a plain lowercased string and never looks at `baseUrl`, so the vendor prefix gives no protection.
 - OpenRouter serves both protocols at `https://openrouter.ai/api/v1`, so its `openai/*` ids work with `clientType: "openai-responses"` as well as `"openai-chat"`; use Responses when you want reasoning items round-tripped.
+- The first-party `deepseek-v4` client posts to `{baseUrl}/responses` (AgentHub 0.4.6 moved it off Chat Completions). A self-hosted endpoint serving a `deepseek-v4*` id over Chat Completions must therefore pass `clientType: "openai-chat"` explicitly rather than rely on id routing.
 - API key: constructor parameter first, then the provider environment variable — `DEEPSEEK_API_KEY`, `ANTHROPIC_API_KEY` (also for `ant-messages`), `OPENAI_API_KEY` (also for `openai-chat`/`openai-responses`), `GEMINI_API_KEY`, `ZAI_API_KEY`, `MOONSHOT_API_KEY`, `MINIMAX_API_KEY`. Base URLs read the same names with `_BASE_URL`.
 
 ## Streaming text

--- a/packages/web/src/features/models/protocol-path.ts
+++ b/packages/web/src/features/models/protocol-path.ts
@@ -1,7 +1,7 @@
 /**
  * Protocol-path suffix for the config dialog's base URL field: the path the AgentHub
  * client appends to a custom base URL, shown inside the field so the user knows which
- * endpoint shape the URL must serve. Verified against the vendored agenthub 0.4.5
+ * endpoint shape the URL must serve. Verified against the vendored agenthub 0.4.6
  * clients and the SDKs they construct:
  * - Anthropic direct (claude-* clients, `@anthropic-ai/sdk`): POST {base}/v1/messages —
  *   the SDK's default base URL (https://api.anthropic.com) carries no /v1; the request
@@ -15,10 +15,13 @@
  *   the SDK joins base URL + API version (v1beta) + the models path.
  * - MiniMax direct (minimax-m3 client): MiniMax's Responses API, POST {base}/responses
  *   (its default base URL https://api.minimax.io/v1 already ends in /v1).
+ * - DeepSeek direct (deepseek-v4 client): DeepSeek's Responses API, POST {base}/responses
+ *   (agenthub 0.4.6 moved this client off Chat Completions; its default base URL
+ *   https://api.deepseek.com carries no /v1, and the request path adds none).
  * - Every OpenAI Chat Completions compatible client — explicit
  *   `client_type: "openai-chat"` (gateways, custom and user-defined groups; the bare
- *   "openai" spelling is a deprecated pre-0.4.2 alias) plus the DeepSeek / GLM / Kimi
- *   direct clients — POST {base}/chat/completions.
+ *   "openai" spelling is a deprecated pre-0.4.2 alias) plus the GLM / Kimi direct
+ *   clients — POST {base}/chat/completions.
  *
  * The three generic protocol clients — `openai-responses`, `ant-messages`,
  * `openai-chat` — are also what the custom-model protocol detection stores.
@@ -46,7 +49,8 @@ export function protocolPathForModel(provider: string, clientType: string): stri
   if (t.includes("gemini")) return "/v1beta/models";
   if (t.includes("gpt")) return "/responses";
   if (t.includes("minimax")) return "/responses";
-  // Any other explicit client type (deepseek-v4 / glm-* / kimi-*): all speak chat completions.
+  if (t.includes("deepseek")) return "/responses";
+  // Any other explicit client type (glm-* / kimi-*): all speak chat completions.
   if (t !== "") return "/chat/completions";
   switch (provider) {
     case "anthropic":
@@ -54,6 +58,8 @@ export function protocolPathForModel(provider: string, clientType: string): stri
     case "openai":
       return "/responses";
     case "minimax":
+      return "/responses";
+    case "deepseek":
       return "/responses";
     case "google":
       return "/v1beta/models";

--- a/packages/web/test/protocol-path.test.ts
+++ b/packages/web/test/protocol-path.test.ts
@@ -2,7 +2,7 @@
  * Protocol-path suffix for the base URL field (pure mapping): which path the AgentHub
  * client appends to a custom base URL, keyed off (provider, clientType). The expected
  * paths mirror the vendored agenthub clients: Anthropic direct posts /v1/messages,
- * OpenAI and MiniMax direct use a Responses API (/responses), Google direct hits
+ * OpenAI, MiniMax and DeepSeek direct use a Responses API (/responses), Google direct hits
  * /v1beta/models/<id>:…, and every OpenAI-compatible client posts /chat/completions.
  */
 import { describe, expect, it } from "vitest";
@@ -14,6 +14,7 @@ describe("protocolPathForModel", () => {
     expect(protocolPathForModel("openai", "")).toBe("/responses");
     expect(protocolPathForModel("google", "")).toBe("/v1beta/models");
     expect(protocolPathForModel("minimax", "")).toBe("/responses");
+    expect(protocolPathForModel("deepseek", "")).toBe("/responses");
   });
 
   it("the MiniMax M3 client speaks MiniMax's Responses API, not chat completions", () => {
@@ -21,8 +22,14 @@ describe("protocolPathForModel", () => {
     expect(protocolPathForModel("myproxy", "minimax-m3")).toBe("/responses");
   });
 
+  it("the DeepSeek V4 client speaks DeepSeek's Responses API (agenthub 0.4.6)", () => {
+    // Until 0.4.6 this client posted /chat/completions; the vendored client now posts
+    // /responses, and the hint has to name the endpoint shape a custom base URL must serve.
+    expect(protocolPathForModel("deepseek", "deepseek-v4")).toBe("/responses");
+    expect(protocolPathForModel("myproxy", "deepseek-v4")).toBe("/responses");
+  });
+
   it("the remaining direct vendors speak chat completions", () => {
-    expect(protocolPathForModel("deepseek", "")).toBe("/chat/completions");
     expect(protocolPathForModel("zhipu", "")).toBe("/chat/completions");
     expect(protocolPathForModel("moonshot", "")).toBe("/chat/completions");
   });
@@ -50,6 +57,9 @@ describe("protocolPathForModel", () => {
   it("an explicit openai-chat client type wins over vendor-group membership", () => {
     expect(protocolPathForModel("anthropic", "openai-chat")).toBe("/chat/completions");
     expect(protocolPathForModel("google", "openai-chat")).toBe("/chat/completions");
+    // The gateway rows reselling DeepSeek pin openai-chat, so they stay on chat completions
+    // even though the vendor's own client moved to /responses.
+    expect(protocolPathForModel("siliconflow", "openai-chat")).toBe("/chat/completions");
   });
 
   it("the generic protocol clients (agenthub 0.4.2) map to their own endpoint shapes", () => {
@@ -69,7 +79,6 @@ describe("protocolPathForModel", () => {
     expect(protocolPathForModel("myproxy", "claude-4-6")).toBe("/v1/messages");
     expect(protocolPathForModel("myproxy", "gemini-3.6")).toBe("/v1beta/models");
     expect(protocolPathForModel("myproxy", "gpt-5.5")).toBe("/responses");
-    expect(protocolPathForModel("myproxy", "deepseek-v4")).toBe("/chat/completions");
     expect(protocolPathForModel("myproxy", "glm-5.2")).toBe("/chat/completions");
     expect(protocolPathForModel("myproxy", "kimi-k3")).toBe("/chat/completions");
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
       '@prismshadow/agenthub':
-        specifier: ^0.4.5
-        version: 0.4.5(supports-color@10.2.2)(ws@8.21.0)(zod@4.4.3)
+        specifier: ^0.4.6
+        version: 0.4.6(supports-color@10.2.2)(ws@8.21.0)(zod@4.4.3)
       '@prismshadow/penguin-core':
         specifier: workspace:*
         version: link:../core
@@ -95,8 +95,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
       '@prismshadow/agenthub':
-        specifier: ^0.4.5
-        version: 0.4.5(supports-color@10.2.2)(ws@8.21.0)(zod@4.4.3)
+        specifier: ^0.4.6
+        version: 0.4.6(supports-color@10.2.2)(ws@8.21.0)(zod@4.4.3)
       '@prismshadow/penguin-skills':
         specifier: workspace:*
         version: link:../skills
@@ -951,8 +951,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@prismshadow/agenthub@0.4.5':
-    resolution: {integrity: sha512-JZSziKpji4Y+zY0fduy20gvxfkUIiZUuZuEcFFh4iu+239vVicRH4g3B99k87QsPp5Z59reakW183PsFFfXPrw==}
+  '@prismshadow/agenthub@0.4.6':
+    resolution: {integrity: sha512-0umTpATCfaPpxI9wRwC19oLJswbBKUOvMOCAQMiVcUXALQ6EoDC7sPnciDuFh2F17MLJZUajsVZWGjaBN4V/tQ==}
 
   '@prismshadow/penguin-cli@file:packages/cli':
     resolution: {directory: packages/cli, type: directory}
@@ -4505,7 +4505,7 @@ snapshots:
     dependencies:
       playwright: 1.61.1
 
-  '@prismshadow/agenthub@0.4.5(supports-color@10.2.2)(ws@8.21.0)':
+  '@prismshadow/agenthub@0.4.6(supports-color@10.2.2)(ws@8.21.0)':
     dependencies:
       '@anthropic-ai/bedrock-sdk': 0.26.4(zod@4.4.3)
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
@@ -4520,7 +4520,7 @@ snapshots:
       - ws
       - zod
 
-  '@prismshadow/agenthub@0.4.5(supports-color@10.2.2)(ws@8.21.0)(zod@4.4.3)':
+  '@prismshadow/agenthub@0.4.6(supports-color@10.2.2)(ws@8.21.0)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/bedrock-sdk': 0.26.4(zod@4.4.3)
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
@@ -4538,7 +4538,7 @@ snapshots:
   '@prismshadow/penguin-cli@file:packages/cli(supports-color@10.2.2)':
     dependencies:
       '@modelcontextprotocol/client': 2.0.0
-      '@prismshadow/agenthub': 0.4.5(supports-color@10.2.2)(ws@8.21.0)
+      '@prismshadow/agenthub': 0.4.6(supports-color@10.2.2)(ws@8.21.0)
       '@prismshadow/penguin-core': file:packages/core(supports-color@10.2.2)
       '@prismshadow/penguin-server': file:packages/server(supports-color@10.2.2)
       '@prismshadow/penguin-skills': file:packages/skills
@@ -4557,7 +4557,7 @@ snapshots:
   '@prismshadow/penguin-core@file:packages/core(supports-color@10.2.2)':
     dependencies:
       '@modelcontextprotocol/client': 2.0.0
-      '@prismshadow/agenthub': 0.4.5(supports-color@10.2.2)(ws@8.21.0)
+      '@prismshadow/agenthub': 0.4.6(supports-color@10.2.2)(ws@8.21.0)
       '@prismshadow/penguin-skills': file:packages/skills
       arktype: 2.2.3
       smol-toml: 1.6.1
@@ -4573,7 +4573,7 @@ snapshots:
   '@prismshadow/penguin-core@file:packages/core(supports-color@10.2.2)(ws@8.21.0)':
     dependencies:
       '@modelcontextprotocol/client': 2.0.0
-      '@prismshadow/agenthub': 0.4.5(supports-color@10.2.2)(ws@8.21.0)
+      '@prismshadow/agenthub': 0.4.6(supports-color@10.2.2)(ws@8.21.0)
       '@prismshadow/penguin-skills': file:packages/skills
       arktype: 2.2.3
       smol-toml: 1.6.1
@@ -4589,7 +4589,7 @@ snapshots:
   '@prismshadow/penguin-core@file:packages/core(supports-color@10.2.2)(ws@8.21.0)(zod@4.4.3)':
     dependencies:
       '@modelcontextprotocol/client': 2.0.0
-      '@prismshadow/agenthub': 0.4.5(supports-color@10.2.2)(ws@8.21.0)(zod@4.4.3)
+      '@prismshadow/agenthub': 0.4.6(supports-color@10.2.2)(ws@8.21.0)(zod@4.4.3)
       '@prismshadow/penguin-skills': file:packages/skills
       arktype: 2.2.3
       smol-toml: 1.6.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,8 +31,8 @@ allowBuilds:
   # targets NSIS only, so the script is deliberately not run.
   electron-winstaller: false
 # pnpm 11 withholds freshly published versions by default (supply-chain gate), which
-# would resolve agenthub back to 0.4.4 and keep an unknown stream event fatal. This package
-# is first-party, so the exemption carries no third-party risk. Remove the entry at the next
-# agenthub bump — by then 0.4.5 is long past the age gate.
+# would resolve agenthub back to 0.4.5 and leave DeepSeek on Chat Completions without the
+# vision model. This package is first-party, so the exemption carries no third-party risk.
+# Remove the entry at the next agenthub bump — by then 0.4.6 is long past the age gate.
 minimumReleaseAgeExclude:
-  - "@prismshadow/agenthub@0.4.5"
+  - "@prismshadow/agenthub@0.4.6"


### PR DESCRIPTION
## What this does

Upgrades `@prismshadow/agenthub` from 0.4.5 to 0.4.6 and adapts to the two changes it brings (agenthub [#185](https://github.com/Prism-Shadow/agenthub/pull/185)).

**`deepseek-v4-flash-vision-exp` joins the catalog, in two groups.**

- DeepSeek group: 1M context, `supportsVision: true`, official **off-peak** CNY tier — cache hit ¥0.05 / cache miss ¥1.5 / output ¥4.5 per million tokens, i.e. V4 Flash's own price ([pricing page](https://api-docs.deepseek.com/zh-cn/quick_start/pricing/)). That matches agenthub's registry entry, which prices it identically.
- OpenRouter group: 1,048,576 context, `usd(0.007, 0.22, 0.66)` — read from the models API, which is authoritative over the model page per the catalog's own convention. DeepSeek is the only provider serving it there, so the two rows agree up to the catalog's 7:1 display conversion.

Both record the **off-peak** tier, the convention the existing DeepSeek rows already follow (issue [#313](https://github.com/Prism-Shadow/penguin-harness/issues/313)). Peak hours — Beijing 9:00–12:00 and 14:00–18:00 — bill exactly double, and the cost centre uses one rate, so peak usage is under-counted 2x. The OpenRouter models API states the same thing structurally: the entry carries a `pricing.overrides` array whose two peak windows double every bucket, and the base `pricing` object is the off-peak rate this row stores.

**DeepSeek moved onto the Responses protocol.** `DeepSeekV4Client` now posts `{base}/responses` instead of `{base}/chat/completions`. The Web model dialog's base URL suffix is a display of exactly that path, so it had to follow: the `deepseek` group and an explicit `deepseek-v4` client type now hint `/responses`. Gateway rows reselling DeepSeek pin `openai-chat` and are unaffected — that pin is already load-bearing for other reasons, and it keeps them on Chat Completions, which is what SiliconFlow serves.

`resolveModelEnv` needed nothing: it matches `deepseek-v4` as a substring, which the new id contains, so it already resolves the `DEEPSEEK_*` pair.

## Breaking

A model id containing `deepseek-v4` with no `client_type` routes to the DeepSeek client by id alone, and that client's request path changed. Entries pointed at `https://api.deepseek.com` are fine — it serves both protocols. An entry pointed at a Chat Completions-only endpoint (self-hosted, a relay, a third-party DeepSeek-compatible gateway) starts failing on upgrade, and the fix is to set `client_type = "openai-chat"` on it. The changelog entry's `## Compatibility` section says so, and the shipped `agenthub-models` skill now records which protocol the client speaks.

No compatibility code was added, so there is no `backward-compatibility.md` in this batch. A migration that stamps `client_type = "openai-chat"` onto existing DeepSeek-id entries in custom groups is possible if the break is judged too sharp — say the word and I will add it.

## Verification

- `pnpm install` (lockfile now resolves 0.4.6), `pnpm -r build`, `pnpm typecheck`, `pnpm format` + `pnpm format:check` — all clean.
- Confirmed against the installed 0.4.6 registry that the new id is present with `input_modalities: ["Text","Image"]`, a 1M window and V4 Flash's price, and that the two SiliconFlow rows moved to `openai-chat` upstream (ours already pinned it).
- Scoped tests, per the catalog's touch list: core `model-catalog.test.ts` (24), web `protocol-path.test.ts` / `model-grouping.test.ts` / `protocol-detect.test.ts` (56), server `models.test.ts` / `models-vision.test.ts` (26), skills package (24), docs `skills-sync` / `search` / `content` (33). All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)