### PR TITLE
fix(desktop): quote the app path in the privileged 'penguin' install command

### DIFF
--- a/changelog/unreleased/2026-08-23-desktop-cli-install-quoting.md
+++ b/changelog/unreleased/2026-08-23-desktop-cli-install-quoting.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-23
 - **Type:** fix
 - **Scope:** `desktop`
+- **PR:** [#411](https://github.com/Prism-Shadow/penguin-harness/pull/411)
 
 [中文版](2026-08-23-desktop-cli-install-quoting.zh.md)
 

--- a/changelog/unreleased/2026-08-23-desktop-cli-install-quoting.md
+++ b/changelog/unreleased/2026-08-23-desktop-cli-install-quoting.md
@@ -1,0 +1,28 @@
+# The macOS 'penguin' install quotes the app path it hands to the privileged shell
+
+- **Date:** 2026-08-23
+- **Type:** fix
+- **Scope:** `desktop`
+
+[中文版](2026-08-23-desktop-cli-install-quoting.zh.md)
+
+Installing the `penguin` command on macOS falls back to `osascript … with administrator
+privileges` when linking `/usr/local/bin/penguin` is refused — the ordinary path on a Mac
+without Homebrew, where that directory does not exist and creating it needs root. The
+command it ran interpolated the app bundle's own path into a single-quoted shell word
+without escaping it, so a bundle kept in a directory whose name contains an apostrophe
+produced a command that broke out of its quoting and ran as root. Both quoting layers are
+now applied by a generator in `launcher.ts`, next to the launcher scripts and covered by
+the same unit tests.
+
+## Details
+
+- `shellQuote` renders a value as one POSIX shell word, splicing embedded single quotes as
+  `'\''`; `appleScriptString` renders the resulting command as an AppleScript literal,
+  escaping the backslashes that splice introduces.
+- `adminSymlinkAppleScript` composes the two into the `do shell script …` source that
+  `cli-install.ts` passes to `osascript`, so the escaping is chosen once and asserted
+  directly rather than restated at the call site.
+- The link directory is derived from the link path instead of being spelled out twice.
+- The AppImage wrapper's own refusal of quoted paths is unchanged: it bakes the path into a
+  script that stays on disk, which is a different exposure from a one-shot command.

--- a/changelog/unreleased/2026-08-23-desktop-cli-install-quoting.zh.md
+++ b/changelog/unreleased/2026-08-23-desktop-cli-install-quoting.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-23
 - **Type:** fix
 - **Scope:** `desktop`
+- **PR:** [#411](https://github.com/Prism-Shadow/penguin-harness/pull/411)
 
 [English](2026-08-23-desktop-cli-install-quoting.md)
 

--- a/changelog/unreleased/2026-08-23-desktop-cli-install-quoting.zh.md
+++ b/changelog/unreleased/2026-08-23-desktop-cli-install-quoting.zh.md
@@ -1,0 +1,24 @@
+# macOS 安装 penguin 命令时对交给提权 shell 的应用路径做了引号转义
+
+- **Date:** 2026-08-23
+- **Type:** fix
+- **Scope:** `desktop`
+
+[English](2026-08-23-desktop-cli-install-quoting.md)
+
+在 macOS 上安装 `penguin` 命令时，若直接链接 `/usr/local/bin/penguin` 被拒绝，会退回到
+`osascript … with administrator privileges`——在没有装 Homebrew 的 Mac 上这是常规路径，那里
+该目录并不存在，创建它需要 root。此前拼出来的命令把应用包自身的路径未加转义地插进单引号
+shell 词里，于是一个放在名字含撇号的目录下的应用包会生成一条冲出引号、并以 root 身份执行的
+命令。现在两层引号转义都由 `launcher.ts` 里的生成函数负责，与启动脚本放在一起，由同一批单测
+覆盖。
+
+## 细节
+
+- `shellQuote` 把一个值渲染成单个 POSIX shell 词，内嵌的单引号按 `'\''` 拼接；
+  `appleScriptString` 再把得到的命令渲染成 AppleScript 字符串字面量，转义前一步引入的反斜杠。
+- `adminSymlinkAppleScript` 把两者组合成 `cli-install.ts` 传给 `osascript` 的
+  `do shell script …` 源码，转义规则因此只在一处决定、并被直接断言，而不是在调用点重述。
+- 链接目录改为从链接路径推导，不再写两遍。
+- AppImage 包装脚本对含引号路径的拒绝保持不变：它把路径写进一个长期留在磁盘上的脚本，暴露面
+  与一次性命令不同。

--- a/packages/desktop/src/cli-install.ts
+++ b/packages/desktop/src/cli-install.ts
@@ -22,7 +22,12 @@ import path from "node:path";
 import { promisify } from "node:util";
 import { app, dialog } from "electron";
 import type { BrowserWindow } from "electron";
-import { appImageWrapperScript, cliInstallKind, mergeWindowsUserPath } from "./launcher.js";
+import {
+  adminSymlinkAppleScript,
+  appImageWrapperScript,
+  cliInstallKind,
+  mergeWindowsUserPath,
+} from "./launcher.js";
 import type { CliInstallKind } from "./launcher.js";
 
 const execFileAsync = promisify(execFile);
@@ -56,9 +61,10 @@ function showResult(win: BrowserWindow | null, ok: boolean, detail: string): voi
 /** macOS: /usr/local/bin/penguin symlink, escalating once via osascript on EACCES/EPERM. */
 async function installDarwin(win: BrowserWindow | null): Promise<void> {
   const target = path.join(binDir(), "penguin");
-  const link = "/usr/local/bin/penguin";
+  const linkDir = "/usr/local/bin";
+  const link = path.join(linkDir, "penguin");
   try {
-    fs.mkdirSync("/usr/local/bin", { recursive: true });
+    fs.mkdirSync(linkDir, { recursive: true });
     fs.rmSync(link, { force: true });
     fs.symlinkSync(target, link);
   } catch (err) {
@@ -67,14 +73,11 @@ async function installDarwin(win: BrowserWindow | null): Promise<void> {
       showResult(win, false, String(err));
       return;
     }
-    // Privileged retry; paths contain no single quotes (the bundle path is fixed and
-    // /Applications-style paths at most contain spaces).
-    const shellCmd = `mkdir -p /usr/local/bin && ln -sf '${target}' '${link}'`;
+    // Privileged retry — the common path on a Mac without Homebrew, where /usr/local/bin
+    // does not exist and creating it needs root. The command's quoting is the generator's
+    // job (launcher.ts): the bundle path comes off disk and may hold an apostrophe.
     try {
-      await execFileAsync("osascript", [
-        "-e",
-        `do shell script "${shellCmd.replace(/"/g, '\\"')}" with administrator privileges`,
-      ]);
+      await execFileAsync("osascript", ["-e", adminSymlinkAppleScript(target, link)]);
     } catch (escalated) {
       showResult(
         win,

--- a/packages/desktop/src/launcher.ts
+++ b/packages/desktop/src/launcher.ts
@@ -134,6 +134,44 @@ exec "$APPIMAGE_PATH" -e '${appImageBootstrapJs()}' -- "$@"
 }
 
 /**
+ * A string as one POSIX shell word: single-quoted, with every embedded single quote
+ * spliced as `'\''` (close, escaped quote, reopen). Nothing inside single quotes is
+ * special to the shell, so a quoted word is safe whatever the value holds.
+ */
+export function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+/**
+ * A string as an AppleScript literal for `osascript -e`: backslash and double quote are
+ * the two characters AppleScript escapes inside a quoted string. Applied AFTER
+ * {@link shellQuote}, whose `'\''` splice contributes a backslash of its own.
+ */
+export function appleScriptString(value: string): string {
+  return `"${value.replace(/[\\"]/g, (c) => `\\${c}`)}"`;
+}
+
+/**
+ * The privileged half of the macOS `penguin` install (see cli-install.ts): the
+ * `osascript` source that creates the link directory and points it at the app's bundled
+ * launcher, run when the unprivileged symlink was refused.
+ *
+ * `target` is derived from the app bundle's own location, which the user controls — a
+ * bundle kept under `~/Anne's Apps/` puts an apostrophe in the middle of the command.
+ * Both quoting layers are applied here so the value can never leave its shell word,
+ * which under `with administrator privileges` is the difference between a failed install
+ * and a root shell.
+ */
+export function adminSymlinkAppleScript(target: string, link: string): string {
+  const dir = link.slice(0, link.lastIndexOf("/")) || "/";
+  const command = [
+    `mkdir -p ${shellQuote(dir)}`,
+    `ln -sf ${shellQuote(target)} ${shellQuote(link)}`,
+  ].join(" && ");
+  return `do shell script ${appleScriptString(command)} with administrator privileges`;
+}
+
+/**
  * Idempotent HKCU\\Environment PATH append: returns the new value to write, or null
  * when `binDir` is already present (comparison ignores case, surrounding quotes and
  * trailing slashes). The existing value is preserved verbatim — only `;binDir` is

--- a/packages/desktop/test/launcher.test.ts
+++ b/packages/desktop/test/launcher.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, it } from "vitest";
 import {
+  adminSymlinkAppleScript,
   appImageBootstrapJs,
   appImageWrapperScript,
+  appleScriptString,
   CLI_ENTRY_RELPATH,
   cliInstallKind,
   LINUX_EXECUTABLE,
   MAC_EXECUTABLE,
   mergeWindowsUserPath,
   posixLauncherScript,
+  shellQuote,
   WIN_EXECUTABLE,
   windowsLauncherScript,
 } from "../src/launcher.js";
@@ -107,6 +110,59 @@ describe("appImageBootstrapJs", () => {
   it("is valid JavaScript", () => {
     // eslint-disable-next-line @typescript-eslint/no-implied-eval
     expect(() => new Function(js)).not.toThrow();
+  });
+});
+
+describe("shellQuote", () => {
+  it("wraps a plain value in single quotes", () => {
+    expect(shellQuote("/Applications/PenguinHarness.app")).toBe(
+      "'/Applications/PenguinHarness.app'",
+    );
+  });
+
+  it("splices embedded single quotes so the word never closes early", () => {
+    expect(shellQuote("/Users/anne/Anne's Apps")).toBe(`'/Users/anne/Anne'\\''s Apps'`);
+  });
+
+  it("leaves shell metacharacters inert inside the quotes", () => {
+    expect(shellQuote('a b;$(id)`x`&|>"')).toBe(`'a b;$(id)\`x\`&|>"'`);
+  });
+});
+
+describe("appleScriptString", () => {
+  it("escapes backslashes and double quotes", () => {
+    expect(appleScriptString(`say "hi" \\ bye`)).toBe(`"say \\"hi\\" \\\\ bye"`);
+  });
+});
+
+describe("adminSymlinkAppleScript", () => {
+  const target = "/Applications/PenguinHarness.app/Contents/Resources/app/bin/penguin";
+  const link = "/usr/local/bin/penguin";
+
+  /** The shell command osascript would run: the AppleScript literal, unescaped. */
+  function shellCommandOf(script: string): string {
+    const m = /^do shell script "(.*)" with administrator privileges$/s.exec(script);
+    expect(m).not.toBeNull();
+    return m![1]!.replace(/\\(.)/g, "$1");
+  }
+
+  it("creates the link directory and links the bundled launcher", () => {
+    expect(adminSymlinkAppleScript(target, link)).toBe(
+      `do shell script "mkdir -p '/usr/local/bin' && ln -sf '${target}' '${link}'"` +
+        " with administrator privileges",
+    );
+  });
+
+  it("keeps an apostrophe in the bundle path inside its shell word", () => {
+    // What a user gets by keeping the app in a folder named with an apostrophe — and what
+    // an attacker gets to write if the two escapers are not applied, since this command
+    // runs with administrator privileges.
+    const evil = "/Users/anne/Anne's Apps'; touch /tmp/pwned; '/PenguinHarness.app/bin/penguin";
+    const command = shellCommandOf(adminSymlinkAppleScript(evil, link));
+    expect(command).toBe(`mkdir -p '/usr/local/bin' && ln -sf ${shellQuote(evil)} '${link}'`);
+    // The injected segment survives only as literal text inside the quoted word.
+    expect(command).not.toContain("&& touch");
+    expect(command).not.toContain("; touch /tmp/pwned; '/PenguinHarness");
   });
 });
 


### PR DESCRIPTION
## What

Installing the `penguin` command on macOS builds a shell command and hands it to `osascript … with administrator privileges`. The app bundle's own path was interpolated into a single-quoted shell word with no escaping:

```ts
const shellCmd = `mkdir -p /usr/local/bin && ln -sf '${target}' '${link}'`;
```

`target` comes from `app.getAppPath()`, which the user controls. A bundle kept under, say, `~/Anne's Apps/` closes the quote mid-path and hands the rest to the shell — as root.

The comment justifying the omission ("the bundle path is fixed and /Applications-style paths at most contain spaces") does not hold: macOS allows apostrophes in directory names, and users move `.app` bundles freely.

## Why it matters more than it looks

The escalation is not a rare fallback. On a Mac without Homebrew, `/usr/local/bin` does not exist, `fs.mkdirSync` fails with `EACCES`, and this is the path every install takes.

## How

Two pure escapers plus the composed command generator live in `launcher.ts`, next to the other generated shell text and covered by the same unit tests:

- `shellQuote` — one POSIX shell word, embedded quotes spliced as `'\''`
- `appleScriptString` — AppleScript literal, escaping `\` and `"` (including the backslash the splice above introduces)
- `adminSymlinkAppleScript` — composes the `do shell script …` source

`cli-install.ts` keeps only the platform policy, and derives the link directory from the link path instead of spelling it twice.

`appImageWrapperScript`'s existing refusal of quoted paths is left alone: it bakes the path into a script that stays on disk, a different exposure from a one-shot command, and its guard is already safe.

## Verification

- `packages/desktop` typecheck + tests: 106 passed (6 new, covering both escapers and an injection payload through the composed generator)
- The new `adminSymlinkAppleScript` test fails against the previous implementation
- `prettier --check .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)