### PR TITLE
fix(desktop,web): the updates-unavailable copy names the AppImage rule

### DIFF
--- a/changelog/unreleased/2026-08-23-update-unavailable-copy.md
+++ b/changelog/unreleased/2026-08-23-update-unavailable-copy.md
@@ -1,0 +1,21 @@
+# The updates-unavailable copy names the AppImage rule instead of assuming dpkg
+
+- **Date:** 2026-08-23
+- **Type:** fix
+- **Scope:** `desktop`, `web`
+
+[中文版](2026-08-23-update-unavailable-copy.zh.md)
+
+On Linux the shell can only replace an AppImage, so every other form — a `.deb` install,
+but also an unpacked tree — lands in the same unsupported state. Both places that report it
+said the copy came from a system package manager and to update it there, which is wrong
+advice for anyone not running a `.deb`. The desktop dialog and the account-menu row now
+state the rule and give both routes: the package manager for a package install, a manual
+download otherwise.
+
+## Details
+
+- The web string was renamed `clientUnsupportedPackage` → `clientUnsupportedNonAppImage`
+  in both dictionaries, so the key names the condition it renders for.
+- `electron-builder.yml`'s `extraMetadata` comment no longer claims `name` decides the app
+  data directory; the shell's own `app.setName()` runs before anything reads `userData`.

--- a/changelog/unreleased/2026-08-23-update-unavailable-copy.md
+++ b/changelog/unreleased/2026-08-23-update-unavailable-copy.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-23
 - **Type:** fix
 - **Scope:** `desktop`, `web`
+- **PR:** [#413](https://github.com/Prism-Shadow/penguin-harness/pull/413)
 
 [中文版](2026-08-23-update-unavailable-copy.zh.md)
 

--- a/changelog/unreleased/2026-08-23-update-unavailable-copy.zh.md
+++ b/changelog/unreleased/2026-08-23-update-unavailable-copy.zh.md
@@ -1,0 +1,19 @@
+# 不支持更新时的文案改为说明 AppImage 规则，不再假定用户装的是 dpkg 包
+
+- **Date:** 2026-08-23
+- **Type:** fix
+- **Scope:** `desktop`, `web`
+
+[English](2026-08-23-update-unavailable-copy.md)
+
+在 Linux 上外壳只能替换 AppImage，因此其余所有形态——`.deb` 安装，以及解压出来的目录树——都
+落进同一个「不支持」状态。此前上报这个状态的两处都说这份拷贝来自系统包管理器、请到那里更新，
+对任何不是用 `.deb` 安装的人来说都是错的指引。现在桌面对话框和账户菜单里的那一行都会说明规则
+并给出两条路径：包安装走包管理器，其余手动下载。
+
+## 细节
+
+- Web 侧的字符串在两份词典里都从 `clientUnsupportedPackage` 更名为
+  `clientUnsupportedNonAppImage`，让键名指向它实际渲染的条件。
+- `electron-builder.yml` 中 `extraMetadata` 的注释不再声称 `name` 决定应用数据目录；外壳自己的
+  `app.setName()` 在任何东西读取 `userData` 之前就已执行。

--- a/changelog/unreleased/2026-08-23-update-unavailable-copy.zh.md
+++ b/changelog/unreleased/2026-08-23-update-unavailable-copy.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-23
 - **Type:** fix
 - **Scope:** `desktop`, `web`
+- **PR:** [#413](https://github.com/Prism-Shadow/penguin-harness/pull/413)
 
 [English](2026-08-23-update-unavailable-copy.md)
 

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -47,8 +47,9 @@ files:
     to: web-dist
 # The app's own metadata, which the workspace package.json cannot carry: deb and AppImage
 # derive package and executable names from `name`, where "@prismshadow/…" is invalid, and
-# fpm refuses to build without a homepage. The name also decides the app data directory, so
-# it stays what installed apps already use.
+# fpm refuses to build without a homepage. It does NOT decide the app data directory: the
+# shell calls app.setName() before anything reads userData, so that keeps the name
+# src/app-identity.ts chooses per form.
 extraMetadata:
   name: penguin-harness-desktop
   homepage: https://github.com/Prism-Shadow/penguin-harness

--- a/packages/desktop/src/updater.ts
+++ b/packages/desktop/src/updater.ts
@@ -241,10 +241,12 @@ export async function checkForUpdatesManually(): Promise<void> {
       platform: process.platform,
       env: process.env,
     });
+    // `linux-not-appimage` covers every Linux form that is not an AppImage — a deb install,
+    // but also an unpacked tree — so the wording names the rule rather than assuming dpkg.
     const detail =
       support.supported || support.reason === "dev"
         ? "This build does not update itself."
-        : "This copy was installed from a system package; update it with your package manager.";
+        : "Only the AppImage build updates itself on Linux. Update a package install with your package manager, or download the latest release manually.";
     await dialog.showMessageBox({ type: "info", message: "Updates are unavailable.", detail });
     return;
   }

--- a/packages/web/src/components/account/desktop-update-row.tsx
+++ b/packages/web/src/components/account/desktop-update-row.tsx
@@ -46,7 +46,7 @@ export function DesktopUpdateRow({
   const reason =
     row.labelKind === "unsupported"
       ? row.unsupportedReason === "linux-not-appimage"
-        ? S.update.clientUnsupportedPackage
+        ? S.update.clientUnsupportedNonAppImage
         : S.update.clientUnsupportedDev
       : null;
 

--- a/packages/web/src/lib/strings-en.ts
+++ b/packages/web/src/lib/strings-en.ts
@@ -208,9 +208,9 @@ export const en: Strings = {
     clientInstallConfirmAction: "Restart now",
     /** Tooltip on the disabled row in a dev (unpackaged) run. */
     clientUnsupportedDev: "A dev run does not update itself",
-    /** Tooltip on the disabled row for installs owned by the system package manager (e.g. .deb). */
-    clientUnsupportedPackage:
-      "This install is managed by the system package manager — update it there",
+    /** Tooltip on the disabled row for a Linux install that is not an AppImage (a .deb, or an unpacked tree). */
+    clientUnsupportedNonAppImage:
+      "Only the AppImage build updates itself on Linux — update a package install through your package manager",
   },
 
   /** Desktop task-completion notifications (window unfocused; desktop-shell sessions only). */

--- a/packages/web/src/lib/strings.ts
+++ b/packages/web/src/lib/strings.ts
@@ -208,8 +208,8 @@ export const zh = {
     clientInstallConfirmAction: "立即重启",
     /** Tooltip on the disabled row in a dev (unpackaged) run. */
     clientUnsupportedDev: "开发运行不支持自更新",
-    /** Tooltip on the disabled row for installs owned by the system package manager (e.g. .deb). */
-    clientUnsupportedPackage: "此安装由系统包管理器管理，请通过包管理器更新",
+    /** Tooltip on the disabled row for a Linux install that is not an AppImage (a .deb, or an unpacked tree). */
+    clientUnsupportedNonAppImage: "Linux 上只有 AppImage 版本支持自更新——包安装请通过包管理器更新",
   },
 
   /** Desktop task-completion notifications (window unfocused; desktop-shell sessions only). */

--- a/packages/web/src/lib/use-desktop-update.ts
+++ b/packages/web/src/lib/use-desktop-update.ts
@@ -53,7 +53,7 @@ function settleWatch(): void {
     case "unsupported":
       toastInfo(
         settle.reason === "linux-not-appimage"
-          ? S.update.clientUnsupportedPackage
+          ? S.update.clientUnsupportedNonAppImage
           : S.update.clientUnsupportedDev,
       );
       break;


### PR DESCRIPTION
## What

Two inaccuracies about the same thing, plus a stale build comment.

**1. `linux-not-appimage` copy claims dpkg.** `updateSupport` returns that reason for *every* Linux form that is not an AppImage — a `.deb`, but also an unpacked tree. Both surfaces reporting it said the copy came from a system package manager and to update it there:

- `updater.ts` menu dialog: "This copy was installed from a system package; update it with your package manager."
- web account-menu row (`clientUnsupportedPackage`): "This install is managed by the system package manager — update it there"

Wrong advice for anyone not running a `.deb`. Both now state the rule and give both routes. The web key was renamed `clientUnsupportedPackage` → `clientUnsupportedNonAppImage` in both dictionaries so it names the condition it renders for.

The web string is in scope on purpose: it is the same claim, about the same state, to the same user. Fixing one surface and leaving the other would leave the two disagreeing.

**2. `electron-builder.yml` comment.** The `extraMetadata` block claimed `name` "also decides the app data directory, so it stays what installed apps already use". It does not — `src/main.ts` calls `app.setName()` before anything reads `userData`, so the directory is the per-form name `app-identity.ts` chooses (`PenguinHarness` / `PenguinHarness-Dev`), not `penguin-harness-desktop`. A reader trusting the comment would conclude a dev run and a release run share one profile, which is the split `app-identity.ts` exists to maintain.

## Verification

- `packages/desktop` and `packages/web` typecheck
- `packages/desktop` tests: 100 passed; `packages/web` tests: 1239 passed
- `prettier --check .`

No test asserted the renamed key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)