### PR TITLE
docs(skills): penguin-cli skill catches up with the CLI it documents

### DIFF
--- a/changelog/unreleased/2026-08-23-penguin-cli-skill-covers-recent-commands.md
+++ b/changelog/unreleased/2026-08-23-penguin-cli-skill-covers-recent-commands.md
@@ -1,0 +1,25 @@
+# The penguin-cli skill covers the commands the CLI has grown
+
+- **Date:** 2026-08-23
+- **Type:** process
+- **Scope:** `skills`
+
+[中文版](2026-08-23-penguin-cli-skill-covers-recent-commands.zh.md)
+
+The `penguin-cli` library skill documented the CLI as it stood in late July, so four
+command surfaces shipped since then were invisible to any agent following it. All four were
+added (skill `v9`): `penguin config model remove`, the `--fast-mode` / `--no-fast-mode` pair
+on `model add`, and `--thinking` and `--goal` on `run` / `chat`.
+
+## Details
+
+- `model remove` joined the other model commands, with its exact `(provider, model_id)`
+  matching, its non-zero exit on an unconfigured pair, and the default / vision pointer
+  clearing that follows a removal.
+- `--fast-mode` / `--no-fast-mode` joined the `model add` synopsis and its option list as a
+  tri-state alongside `--vision`, including the stderr warning for a model whose AgentHub
+  client has no fast tier.
+- The "Running agents" section gained `--thinking <level>` — its fallback chain, the
+  session-creation pinning that subagents inherit, and its per-turn meaning under `--resume`
+  — and `--goal [budget]`, with the token-budget value and the `/goal` form inside
+  `penguin chat`.

--- a/changelog/unreleased/2026-08-23-penguin-cli-skill-covers-recent-commands.md
+++ b/changelog/unreleased/2026-08-23-penguin-cli-skill-covers-recent-commands.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-23
 - **Type:** process
 - **Scope:** `skills`
+- **PR:** [#415](https://github.com/Prism-Shadow/penguin-harness/pull/415)
 
 [中文版](2026-08-23-penguin-cli-skill-covers-recent-commands.zh.md)
 

--- a/changelog/unreleased/2026-08-23-penguin-cli-skill-covers-recent-commands.md
+++ b/changelog/unreleased/2026-08-23-penguin-cli-skill-covers-recent-commands.md
@@ -20,6 +20,9 @@ on `model add`, and `--thinking` and `--goal` on `run` / `chat`.
 - `--fast-mode` / `--no-fast-mode` joined the `model add` synopsis and its option list as a
   tri-state alongside `--vision`, including the stderr warning for a model whose AgentHub
   client has no fast tier.
+- The OpenAI-compatible endpoint recipe now spells the client type `openai-chat`, the
+  canonical name since AgentHub 0.4.2, and names the bare `openai` form as the deprecated
+  alias it is normalized from.
 - The "Running agents" section gained `--thinking <level>` — its fallback chain, the
   session-creation pinning that subagents inherit, and its per-turn meaning under `--resume`
   — and `--goal [budget]`, with the token-budget value and the `/goal` form inside

--- a/changelog/unreleased/2026-08-23-penguin-cli-skill-covers-recent-commands.zh.md
+++ b/changelog/unreleased/2026-08-23-penguin-cli-skill-covers-recent-commands.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-23
 - **Type:** process
 - **Scope:** `skills`
+- **PR:** [#415](https://github.com/Prism-Shadow/penguin-harness/pull/415)
 
 [English](2026-08-23-penguin-cli-skill-covers-recent-commands.md)
 

--- a/changelog/unreleased/2026-08-23-penguin-cli-skill-covers-recent-commands.zh.md
+++ b/changelog/unreleased/2026-08-23-penguin-cli-skill-covers-recent-commands.zh.md
@@ -1,0 +1,21 @@
+# penguin-cli skill 补齐 CLI 新增的命令
+
+- **Date:** 2026-08-23
+- **Type:** process
+- **Scope:** `skills`
+
+[English](2026-08-23-penguin-cli-skill-covers-recent-commands.md)
+
+`penguin-cli` 库内 skill 记录的还是 7 月下旬的 CLI，此后新增的四处命令界面对照着它工作的
+Agent 完全看不见。这次一并补上（skill `v9`）：`penguin config model remove`、`model add` 上的
+`--fast-mode` / `--no-fast-mode`，以及 `run` / `chat` 上的 `--thinking` 与 `--goal`。
+
+## 细节
+
+- `model remove` 加入其余 model 命令，连同它对 `(provider, model_id)` 的精确匹配、未配置该组合时
+  的非零退出，以及删除后随之清空的默认模型 / 视觉模型指针。
+- `--fast-mode` / `--no-fast-mode` 进入 `model add` 的命令行摘要与选项列表，和 `--vision` 一样是
+  三态；也写明了对没有 fast 档位的 AgentHub 客户端会在 stderr 给出告警。
+- "Running agents" 一节补上 `--thinking <level>`——它的回退链、在会话创建时定档因而被子 Agent
+  继承、以及 `--resume` 下转为按轮覆盖的含义——和 `--goal [budget]`，包括 token 预算取值与
+  `penguin chat` 里的 `/goal` 写法。

--- a/changelog/unreleased/2026-08-23-penguin-cli-skill-covers-recent-commands.zh.md
+++ b/changelog/unreleased/2026-08-23-penguin-cli-skill-covers-recent-commands.zh.md
@@ -17,6 +17,8 @@ Agent 完全看不见。这次一并补上（skill `v9`）：`penguin config mod
   的非零退出，以及删除后随之清空的默认模型 / 视觉模型指针。
 - `--fast-mode` / `--no-fast-mode` 进入 `model add` 的命令行摘要与选项列表，和 `--vision` 一样是
   三态；也写明了对没有 fast 档位的 AgentHub 客户端会在 stderr 给出告警。
+- OpenAI 兼容端点的写法改用 `openai-chat`——AgentHub 0.4.2 起的正式名称——并点明 bare `openai`
+  只是会被归一化过去的废弃别名。
 - "Running agents" 一节补上 `--thinking <level>`——它的回退链、在会话创建时定档因而被子 Agent
   继承、以及 `--resume` 下转为按轮覆盖的含义——和 `--goal [budget]`，包括 token 预算取值与
   `penguin chat` 里的 `/goal` 写法。

--- a/packages/skills/skills/penguin-cli/SKILL.md
+++ b/packages/skills/skills/penguin-cli/SKILL.md
@@ -3,8 +3,8 @@ name: penguin-cli
 description: Manage model API keys, default models and per-agent vault secrets with the penguin CLI.
 short_description: Manage models and secrets with the penguin CLI.
 short_description_zh: 用 penguin CLI 管理模型与密钥。
-version: 8
-updated: 2026-07-25T00:00:00Z
+version: 9
+updated: 2026-08-23T15:42:44Z
 ---
 
 # Penguin CLI
@@ -22,6 +22,7 @@ Add or update a model (upsert by the `(provider, model_id)` pair; re-run with mo
 ```bash
 penguin config model add --provider <group> --model-id <upstream_id> [--api-key <key>] [--base-url <url>] \
   [--client-type <type>] [--context-window <n>] [--max-tokens <n>] [--vision | --no-vision] \
+  [--fast-mode | --no-fast-mode] \
   [--price-cache-read <n>] [--price-cache-write <n>] [--price-output <n>] \
   [--project-id <id>] [--root <dir>] [--set-default]
 ```
@@ -30,6 +31,7 @@ penguin config model add --provider <group> --model-id <upstream_id> [--api-key 
 - For any OpenAI chat-completion compatible endpoint use `--client-type openai --base-url <endpoint>`; omit `--client-type` to auto-route by model id.
 - Prices are USD per million tokens (cache read / cache write / output).
 - `--vision` / `--no-vision` mark whether the model accepts images; omitting both keeps the current value (default is vision-capable).
+- `--fast-mode` / `--no-fast-mode` turn on faster output at premium pricing (off by default); omitting both keeps the current value. Enabling it on a model whose AgentHub client has no fast tier still writes the entry but warns on stderr — the parameter would be rejected at request time.
 - `--max-tokens <n>` pins a per-model output cap (positive integer), overriding the Agent's `model.max_tokens`; omit to inherit. Lower it for small-context models — the per-Agent default (32000) cannot fit into e.g. a 32k context window together with any prompt.
 - All `penguin config model ...` and `penguin config vault ...` commands accept `--root <dir>` to target another data root (default `PENGUIN_HOME`, then `~/.penguin/data`). Two configuration targets — treat the difference as a hard rule:
   - **Penguin's own model** (self-configuration: the model Penguin itself runs on): the default root without `--root` is correct.
@@ -42,7 +44,10 @@ Other model commands:
 penguin config model default --model-id <upstream_id> --provider <group> [--root <dir>]   # set the project default model
 penguin config model vision --model-id <upstream_id> --provider <group> [--root <dir>]    # set the project vision model (reads images for text-only sessions)
 penguin config model list [--root <dir>]                      # list models; api_key is shown masked
+penguin config model remove --model-id <upstream_id> --provider <group> [--root <dir>]    # delete a model entry and its inline credential
 ```
+
+`model remove` matches the `(provider, model_id)` pair exactly, so the same upstream id under another group is left alone, and it exits non-zero when the pair is not configured. Removing the entry the default model or the vision model pointed at clears that pointer as well — a pointer naming a model that is no longer configured would fail the next session outright.
 
 ## Vault (per-agent secrets)
 
@@ -65,7 +70,10 @@ penguin config lang <en|zh>   # persist the CLI language via PENGUIN_LANG in you
 
 ## Running agents
 
-`penguin run -m "<task>" [--provider <group> --model-id <id>] [--agent-id <id>] [--workspace <path>] [--approve <mode>]` runs one task; `penguin chat [--resume [session_id]]` starts or resumes an interactive chat with the same options. The model reference stays a pair here too: pass `--provider` and `--model-id` together, or neither to run on the project's default model — one without the other is rejected.
+`penguin run -m "<task>" [--provider <group> --model-id <id>] [--agent-id <id>] [--workspace <path>] [--approve <mode>] [--thinking <level>] [--goal [budget]]` runs one task; `penguin chat [--resume [session_id]]` starts or resumes an interactive chat with the same options (minus `-m`, plus `--verbose`). The model reference stays a pair here too: pass `--provider` and `--model-id` together, or neither to run on the project's default model — one without the other is rejected.
+
+- `--thinking <level>` (`low` / `medium` / `high` / `xhigh` / `max`) sets the session's thinking level; omit it to take the configured chain (the agent's `model.thinking_level`, else the project's `default_chat.thinking_level`, else `medium`). It is pinned at session creation, so spawned subagent sessions follow it. With `--resume` it becomes the initial per-turn override instead.
+- `--goal [budget]` runs the task in goal mode: rounds repeat on one session until the objective completes, and the exit code is 0 only then. The optional value is a token budget (`--goal 500k`); a bare `--goal` runs unbudgeted. Inside `penguin chat` the same mode is `/goal[:<budget>] <objective>`.
 
 ## Storage
 

--- a/packages/skills/skills/penguin-cli/SKILL.md
+++ b/packages/skills/skills/penguin-cli/SKILL.md
@@ -28,7 +28,7 @@ penguin config model add --provider <group> --model-id <upstream_id> [--api-key 
 ```
 
 - A model is identified by the `(provider, model_id)` pair, so `--provider` and `--model-id` are **both required** — the group is never inferred from the model id, because gateways resell vendor models under their upstream ids and a wrong guess would send the key to another vendor's endpoint. `--model-id` takes the provider's upstream model id (what the API expects) and is persisted as the entry's request id, so it reaches the API unchanged; `--provider` names the group (`deepseek`, `openai`, `anthropic`, `google`, `openrouter`, `siliconflow`, … — `custom` for any other endpoint).
-- For any OpenAI chat-completion compatible endpoint use `--client-type openai --base-url <endpoint>`; omit `--client-type` to auto-route by model id.
+- For any OpenAI chat-completion compatible endpoint use `--client-type openai-chat --base-url <endpoint>`; omit `--client-type` to auto-route by model id. (The bare `openai` spelling still works as a deprecated alias and is normalized to `openai-chat` when the entry is written.)
 - Prices are USD per million tokens (cache read / cache write / output).
 - `--vision` / `--no-vision` mark whether the model accepts images; omitting both keeps the current value (default is vision-capable).
 - `--fast-mode` / `--no-fast-mode` turn on faster output at premium pricing (off by default); omitting both keeps the current value. Enabling it on a model whose AgentHub client has no fast tier still writes the entry but warns on stderr — the parameter would be rejected at request time.


### PR DESCRIPTION
## What

The `penguin-cli` library skill was last touched on 2026-07-25 (`v8`). Four CLI surfaces shipped after that date and none of them reached the skill, so an agent following it could not discover them:

| Missing | Shipped in |
| --- | --- |
| `penguin config model remove` | #273 (2026-08-14) |
| `--fast-mode` / `--no-fast-mode` on `model add` | #326 (2026-08-19) |
| `--thinking <level>` on `run` / `chat` | #322 (2026-08-19) |
| `--goal [budget]` on `run` | #66 (2026-07-27) |

All four are now documented, and the skill is bumped to `v9`.

The same file also carried the deprecated `--client-type openai` spelling. Since AgentHub 0.4.2 the canonical name is `openai-chat` and the bare form is an alias that core normalizes on write (`packages/core/src/state/project-config.ts:493`) — the `agenthub-models` skill already documents it as deprecated, so the library was teaching in one place what it deprecates in another. Fixed here for `penguin-cli`; the other three skills carrying it (`ollama`, `vllm`, `penguin-sdk`) are a separate PR, so no two PRs touch the same file.

## Why it matters

The docs site kept up each time — `packages/docs/content/cli.en.md` documents `model remove`, `--thinking` and `--fast-mode` — so the gap was in the shipped skill library alone. That library is what installs into users' agents and is the only CLI reference an agent has in context, so a skill that lags the CLI is a capability the agent silently does not have.

## Source of each claim

Written against the implementation, not the docs prose: `packages/cli/src/commands/config.ts:279` (`model remove` and its pair-exact match / non-zero exit / pointer clearing), `config.ts:134` (`--fast-mode` tri-state), `packages/cli/src/commands/run.ts:43-44` (`--thinking`, `--goal`), and the `--goal` budget parsing just below it.

## Verification

`pnpm format:check`, the `skills` package test (24 passed) and `docs`'s `skills-sync.test.ts` (3 passed) — the narrow set for a `packages/skills/skills/**` change.

## Note

One of five PRs from an audit of the shipped skill library; the others cover the README group table (#416), the deprecated `--client-type openai` spelling elsewhere, the `updated` frontmatter format, and the loader's UTF-8 handling of auxiliary files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)