### PR TITLE
docs(skills): README group table lists the whole library, guarded by a test

### DIFF
--- a/changelog/unreleased/2026-08-23-skills-readme-group-table.md
+++ b/changelog/unreleased/2026-08-23-skills-readme-group-table.md
@@ -1,0 +1,20 @@
+# The skills package README lists the whole library again
+
+- **Date:** 2026-08-23
+- **Type:** process
+- **Scope:** `skills`
+
+[中文版](2026-08-23-skills-readme-group-table.zh.md)
+
+The group table in `packages/skills/README.md` named 14 of the 18 shipped Skills: `bento-slides`,
+`humanizer`, `remote-claude-code` and `skill-porting` were added to `SKILL_GROUPS` and to the
+docs pages, but not to the README. The four were added, and a test now derives the check from
+the library so the table cannot fall behind again.
+
+## Details
+
+- The table follows `SKILL_GROUPS` order, and a line below it names the two `preinstall: false`
+  Skills — `humanizer` and `remote-claude-code` — as install-on-demand.
+- The new test reads `README.md` and asserts every name from `loadLibrarySkills()` appears in it,
+  mirroring the docs package's `skills-sync.test.ts`. The existing group assertions catch a Skill
+  missing from the manifest; nothing had covered the README.

--- a/changelog/unreleased/2026-08-23-skills-readme-group-table.md
+++ b/changelog/unreleased/2026-08-23-skills-readme-group-table.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-23
 - **Type:** process
 - **Scope:** `skills`
+- **PR:** [#416](https://github.com/Prism-Shadow/penguin-harness/pull/416)
 
 [中文版](2026-08-23-skills-readme-group-table.zh.md)
 

--- a/changelog/unreleased/2026-08-23-skills-readme-group-table.zh.md
+++ b/changelog/unreleased/2026-08-23-skills-readme-group-table.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-23
 - **Type:** process
 - **Scope:** `skills`
+- **PR:** [#416](https://github.com/Prism-Shadow/penguin-harness/pull/416)
 
 [English](2026-08-23-skills-readme-group-table.md)
 

--- a/changelog/unreleased/2026-08-23-skills-readme-group-table.zh.md
+++ b/changelog/unreleased/2026-08-23-skills-readme-group-table.zh.md
@@ -1,0 +1,18 @@
+# skills 包 README 重新列全整个库
+
+- **Date:** 2026-08-23
+- **Type:** process
+- **Scope:** `skills`
+
+[English](2026-08-23-skills-readme-group-table.md)
+
+`packages/skills/README.md` 的分组表只列了 18 个 Skill 中的 14 个：`bento-slides`、`humanizer`、
+`remote-claude-code`、`skill-porting` 进了 `SKILL_GROUPS`，也进了文档站，唯独没进 README。这次补上
+四个，并新增一个从库里推导的测试，让这张表不会再落下。
+
+## 细节
+
+- 表格按 `SKILL_GROUPS` 的顺序排列，表下一行点明两个 `preinstall: false` 的 Skill——`humanizer` 与
+  `remote-claude-code`——按需从库中安装。
+- 新测试读取 `README.md`，断言 `loadLibrarySkills()` 返回的每个名字都出现在其中，与 docs 包的
+  `skills-sync.test.ts` 同构。原有的分组断言只能抓到"漏进 manifest"，README 此前无人看守。

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -8,10 +8,12 @@ Included skills, in the order of the `SKILL_GROUPS` manifest in `src/index.ts` (
 
 | Group | Skills |
 | --- | --- |
-| Office Productivity | `data-analysis`, `firecrawl` |
-| Software Development | `web-design`, `software-engineering` |
-| AI App Development | `penguin-sdk`, `penguin-cli`, `agenthub-models`, `vllm`, `ollama`, `llamafactory` |
+| Office Productivity | `data-analysis`, `firecrawl`, `bento-slides`, `humanizer` |
+| Software Development | `web-design`, `software-engineering`, `remote-claude-code` |
+| AI App Development | `penguin-sdk`, `penguin-cli`, `agenthub-models`, `vllm`, `ollama`, `llamafactory`, `skill-porting` |
 | Agent Tuning | `agent-initialization`, `benchmark-design`, `agent-evaluation`, `agent-optimization` |
+
+`humanizer` and `remote-claude-code` carry `preinstall: false`, so `default_agent` does not get them at initialization — they are installed from the library on demand.
 
 Agent Tuning powers the self-improvement loop: create the Target Agent, design a Benchmark, evaluate it, optimize it to version N+1 with a snapshot before every round.
 

--- a/packages/skills/test/skills.test.ts
+++ b/packages/skills/test/skills.test.ts
@@ -239,6 +239,19 @@ describe("loadSkillGroups / groupSkills", () => {
       },
     ]);
   });
+
+  /**
+   * The package README repeats the manifest as a table for human readers. Derived from the
+   * library rather than pinned, so adding a Skill fails here instead of leaving the table
+   * quietly short — the same guard the docs pages get from docs' skills-sync test.
+   */
+  it("the package README's group table names every library Skill", async () => {
+    const readme = await fs.readFile(path.resolve(import.meta.dirname, "../README.md"), "utf8");
+    const missing = loadLibrarySkills()
+      .map((skill) => skill.name)
+      .filter((name) => !readme.includes(`\`${name}\``));
+    expect(missing, "skills missing from README.md").toEqual([]);
+  });
 });
 
 describe("librarySkill", () => {


### PR DESCRIPTION
## What

`packages/skills/README.md`'s group table named 14 of the 18 shipped Skills. Four were missing: `bento-slides`, `humanizer`, `remote-claude-code`, `skill-porting`. All four are in `SKILL_GROUPS` and in the bilingual docs pages — only the README drifted.

Added the four, plus a line naming the two `preinstall: false` Skills (`humanizer`, `remote-claude-code`) as install-on-demand, since the table alone does not convey that.

## The guard

The reason it drifted is that nothing checked it. Existing coverage:

- `loadSkillGroups` test — fails if a Skill is missing from `SKILL_GROUPS` (it would land in an `Other` group and break the pinned group list).
- docs' `skills-sync.test.ts` — fails if a Skill is missing from `skills.{en,zh}.md`.
- the README — nothing.

So this adds the third, derived the same way rather than pinned:

```ts
const missing = loadLibrarySkills()
  .map((skill) => skill.name)
  .filter((name) => !readme.includes(`\`${name}\``));
expect(missing, "skills missing from README.md").toEqual([]);
```

Confirmed it actually bites: deleting `` `bento-slides` `` from the table fails with `skills missing from README.md: expected [ 'bento-slides' ] to deeply equal []`.

## Verification

`pnpm format:check`, `skills` package test (25 passed, up from 24) and `typecheck`.

## Note

One of five PRs from an audit of the shipped skill library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)