### PR TITLE
docs(skills): document the updated frontmatter as the ISO 8601 UTC it is

### DIFF
--- a/changelog/unreleased/2026-08-23-skill-updated-frontmatter-format.md
+++ b/changelog/unreleased/2026-08-23-skill-updated-frontmatter-format.md
@@ -1,0 +1,22 @@
+# One documented format for a Skill's `updated` frontmatter
+
+- **Date:** 2026-08-23
+- **Type:** process
+- **Scope:** `docs`, `skills`, `server`
+
+[中文版](2026-08-23-skill-updated-frontmatter-format.zh.md)
+
+The Skills doc pages described `updated` as a date and showed `updated: 2026-07-17`, while every
+Skill in the built-in library, the `skill-porting` and `agent-initialization` recipes for writing
+one, and the library test's assertion all use an ISO 8601 UTC timestamp. The documentation and the
+two DTO comments were moved onto the format the library actually ships.
+
+## Details
+
+- `skills.en.md` / `skills.zh.md`: the frontmatter table entry and the example both name an ISO 8601
+  UTC timestamp, and the tolerant-parsing paragraph states that the value is stored as written and
+  never parsed, with the library's convention alongside it.
+- The field comments in `packages/skills/src/index.ts` and the `SkillMetadataItem` DTO in
+  `packages/server/src/api/types.ts` say the same.
+- Parsing is unchanged: `updated` remains an opaque string with an empty-string default, and the
+  Web App keeps rendering it as a relative date.

--- a/changelog/unreleased/2026-08-23-skill-updated-frontmatter-format.md
+++ b/changelog/unreleased/2026-08-23-skill-updated-frontmatter-format.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-23
 - **Type:** process
 - **Scope:** `docs`, `skills`, `server`
+- **PR:** [#418](https://github.com/Prism-Shadow/penguin-harness/pull/418)
 
 [中文版](2026-08-23-skill-updated-frontmatter-format.zh.md)
 

--- a/changelog/unreleased/2026-08-23-skill-updated-frontmatter-format.zh.md
+++ b/changelog/unreleased/2026-08-23-skill-updated-frontmatter-format.zh.md
@@ -1,0 +1,19 @@
+# Skill 的 `updated` frontmatter 只留一种成文格式
+
+- **Date:** 2026-08-23
+- **Type:** process
+- **Scope:** `docs`, `skills`, `server`
+
+[English](2026-08-23-skill-updated-frontmatter-format.md)
+
+Skills 文档页把 `updated` 说成"更新日期"并给出 `updated: 2026-07-17`，而内置技能库里的每个 Skill、
+`skill-porting` 与 `agent-initialization` 中"如何写一个 Skill"的规范、以及库测试里的断言，用的都是
+ISO 8601 UTC 时间戳。这次把文档和两处 DTO 注释统一到技能库实际采用的格式上。
+
+## 细节
+
+- `skills.en.md` / `skills.zh.md`：frontmatter 表格条目与示例都改为 ISO 8601 UTC 时间戳，容错解析那段
+  补上"该值按原样存储、从不解析"，并在旁边说明技能库的约定。
+- `packages/skills/src/index.ts` 的字段注释与 `packages/server/src/api/types.ts` 中的
+  `SkillMetadataItem` DTO 同步改写。
+- 解析行为未变：`updated` 仍是不透明字符串、缺省为空串，Web App 仍将其渲染为相对日期。

--- a/changelog/unreleased/2026-08-23-skill-updated-frontmatter-format.zh.md
+++ b/changelog/unreleased/2026-08-23-skill-updated-frontmatter-format.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-23
 - **Type:** process
 - **Scope:** `docs`, `skills`, `server`
+- **PR:** [#418](https://github.com/Prism-Shadow/penguin-harness/pull/418)
 
 [English](2026-08-23-skill-updated-frontmatter-format.md)
 

--- a/packages/docs/content/skills.en.md
+++ b/packages/docs/content/skills.en.md
@@ -16,7 +16,7 @@ Frontmatter fields:
 | `short_description` / `short_description_zh` | UI labels for compact spots such as cards; not injected into the prompt |
 | `preinstall` | Optional; `false` keeps the Skill out of default_agent's preinstalled set — install it manually from the library |
 | `version` | Natural-number version, default 1 |
-| `updated` | Update date |
+| `updated` | Update timestamp, ISO 8601 UTC (`2026-07-17T09:00:00Z`) |
 
 ```md
 ---
@@ -25,7 +25,7 @@ description: One-line English description injected into the system prompt.
 short_description: Short UI label.
 short_description_zh: 简短的中文标签。
 version: 1
-updated: 2026-07-17
+updated: 2026-07-17T09:00:00Z
 ---
 
 # My Skill
@@ -33,7 +33,7 @@ updated: 2026-07-17
 Concrete steps, boundaries and acceptance criteria...
 ```
 
-Parsing is tolerant: only `key: value` scalar lines inside the first `---` block are recognized; a `version` that is not a natural number falls back to 1, and a missing `updated` defaults to empty. For `preinstall`, only the literal `false` is recognized.
+Parsing is tolerant: only `key: value` scalar lines inside the first `---` block are recognized; a `version` that is not a natural number falls back to 1, and a missing `updated` defaults to empty. For `preinstall`, only the literal `false` is recognized. `updated` is stored as written and never parsed — the UI renders it as a relative date — but the built-in library writes ISO 8601 UTC throughout, so a Skill written for it should too.
 
 ## Progressive loading
 

--- a/packages/docs/content/skills.zh.md
+++ b/packages/docs/content/skills.zh.md
@@ -16,7 +16,7 @@ frontmatter 字段：
 | `short_description` / `short_description_zh` | UI 短标签(卡片等紧凑位置用)，不注入 Prompt |
 | `preinstall` | 可选；`false` 表示不进入 default_agent 的预装集合，仅可从技能库手动安装 |
 | `version` | 自然数版本号，默认 1 |
-| `updated` | 更新日期 |
+| `updated` | 更新时间戳，ISO 8601 UTC(`2026-07-17T09:00:00Z`) |
 
 ```md
 ---
@@ -25,7 +25,7 @@ description: One-line English description injected into the system prompt.
 short_description: Short UI label.
 short_description_zh: 简短的中文标签。
 version: 1
-updated: 2026-07-17
+updated: 2026-07-17T09:00:00Z
 ---
 
 # My Skill
@@ -33,7 +33,7 @@ updated: 2026-07-17
 具体的步骤、边界与验收标准……
 ```
 
-解析是容错的：只识别首个 `---` 块内的 `key: value` 标量行；`version` 不是自然数时回退为 1,`updated` 缺省为空；`preinstall` 仅识别字面量 `false`。
+解析是容错的：只识别首个 `---` 块内的 `key: value` 标量行；`version` 不是自然数时回退为 1,`updated` 缺省为空；`preinstall` 仅识别字面量 `false`。`updated` 按原样存储、从不解析——UI 将其渲染为相对日期——但内置技能库通篇写 ISO 8601 UTC，为它编写的 Skill 也应如此。
 
 ## 渐进式加载
 

--- a/packages/server/src/api/types.ts
+++ b/packages/server/src/api/types.ts
@@ -2228,7 +2228,7 @@ export interface SkillMetadataItem {
   icon?: string;
   /** Version number (natural number, frontmatter version; falls back to 1 if invalid). */
   version: number;
-  /** Update date (YYYY-MM-DD, frontmatter updated; defaults to an empty string). */
+  /** Update timestamp (frontmatter updated, ISO 8601 UTC by convention; defaults to an empty string). */
   updated: string;
 }
 

--- a/packages/skills/src/index.ts
+++ b/packages/skills/src/index.ts
@@ -28,7 +28,7 @@ export interface SkillMetadata {
   preinstall?: boolean;
   /** Version number (natural number); falls back to 1 on parse failure. */
   version: number;
-  /** Update date (YYYY-MM-DD); defaults to "". */
+  /** Update timestamp, ISO 8601 UTC by convention (stored as written, never parsed); defaults to "". */
   updated: string;
 }
 


### PR DESCRIPTION
## What

Three sources described a Skill's `updated` frontmatter field, two ways:

| Source | Said |
| --- | --- |
| `packages/docs/content/skills.{en,zh}.md` | "Update date", example `updated: 2026-07-17` |
| `packages/skills/src/index.ts:31` | `Update date (YYYY-MM-DD)` |
| `packages/server/src/api/types.ts:2231` | `Update date (YYYY-MM-DD, …)` |
| all 18 library skills | `2026-08-21T00:00:00Z` — full ISO 8601 UTC |
| `skill-porting` (how to normalize a ported skill) | `ISO 8601 UTC; move it together with version` |
| `agent-initialization` (how to write one) | `<ISO 8601 timestamp — move it together with version>` |
| `packages/skills/test/skills.test.ts:47` | asserts `/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/` |

The library, its two authoring recipes and its test agree on ISO 8601 UTC; only the user-facing docs and the two field comments say otherwise. Those four now say ISO 8601 UTC too — the docs example included, so someone copying it lands on the format the test would demand of a library skill.

## Not a behavior change

`parseSkillFrontmatter` stores `updated` as an opaque string with an empty-string default and never parses it; the Web App renders it through `formatRelativeDate`, which accepts both spellings. A hand-written date-only value keeps working exactly as before. The docs paragraph now says this explicitly instead of leaving the reader to infer a validated format that does not exist.

## Verification

`pnpm format:check`; `docs` package tests (53 passed, covers the search index over the edited pages), `landing` (65 passed), `skills` (24 passed); `pnpm --filter @prismshadow/penguin-server typecheck` clean after building `core` — the `types.ts` edit is inside a JSDoc comment.

## Note

One of five PRs from an audit of the shipped skill library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)