### PR TITLE
fix(skills): keep non-text files out of the library manifest

### DIFF
--- a/changelog/unreleased/2026-08-23-skill-library-loader-keeps-non-text-files-out.md
+++ b/changelog/unreleased/2026-08-23-skill-library-loader-keeps-non-text-files-out.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-23
 - **Type:** fix
 - **Scope:** `skills`
+- **PR:** [#419](https://github.com/Prism-Shadow/penguin-harness/pull/419)
 
 [中文版](2026-08-23-skill-library-loader-keeps-non-text-files-out.zh.md)
 

--- a/changelog/unreleased/2026-08-23-skill-library-loader-keeps-non-text-files-out.md
+++ b/changelog/unreleased/2026-08-23-skill-library-loader-keeps-non-text-files-out.md
@@ -1,0 +1,23 @@
+# The skill-library loader keeps non-text files out of the manifest
+
+- **Date:** 2026-08-23
+- **Type:** fix
+- **Scope:** `skills`
+
+[中文版](2026-08-23-skill-library-loader-keeps-non-text-files-out.zh.md)
+
+`readSkillFiles` collected every regular file in a library skill directory by reading it with the
+`utf8` encoding, and `installSkill` writes those strings back with the same encoding — so a file
+that was not UTF-8 text would have had its bytes replaced with U+FFFD on the way through and been
+installed corrupted, with nothing reporting it. Auxiliary files are now decoded strictly and
+skipped when they are not text, and a test asserts the whole library stays text.
+
+## Details
+
+- `decodeSkillFile` decodes with a `fatal` `TextDecoder` and rejects a NUL byte, which is what
+  UTF-16 text looks like once its bytes happen to form valid UTF-8. `ignoreBOM` keeps a leading BOM
+  in the string, so a file that decodes carries exactly the content the previous read produced.
+- The new library-wide test walks `skills/` — `SKILL.md` and `icon.svg` included, not just the
+  auxiliary files — and names any file that is not text, so one cannot reach a release unnoticed.
+- The manifest stays text-only by design: the archive-install route carries uploaded files as
+  `Uint8Array` and is unaffected, so a Skill installed from a zip can still ship binary assets.

--- a/changelog/unreleased/2026-08-23-skill-library-loader-keeps-non-text-files-out.zh.md
+++ b/changelog/unreleased/2026-08-23-skill-library-loader-keeps-non-text-files-out.zh.md
@@ -1,0 +1,22 @@
+# 技能库加载器不再把非文本文件收进清单
+
+- **Date:** 2026-08-23
+- **Type:** fix
+- **Scope:** `skills`
+
+[English](2026-08-23-skill-library-loader-keeps-non-text-files-out.md)
+
+`readSkillFiles` 会以 `utf8` 编码读取库内 skill 目录下的每一个普通文件，而 `installSkill` 又以同样的
+编码把这些字符串写回磁盘——于是一个非 UTF-8 文本的文件在这条链路上字节会被替换成 U+FFFD，最终被安装成
+一份损坏的副本，且全程无人报错。现在辅助文件改为严格解码，非文本一律跳过，并新增测试盯住整个技能库保持
+纯文本。
+
+## 细节
+
+- `decodeSkillFile` 使用 `fatal` 的 `TextDecoder` 解码，并拒绝 NUL 字节——UTF-16 文本的字节序列碰巧构成
+  合法 UTF-8 时就是这个样子。`ignoreBOM` 让开头的 BOM 保留在字符串中，因此能通过解码的文件所携带的内容
+  与此前的读取结果完全一致。
+- 新增的全库测试遍历 `skills/`，连 `SKILL.md` 与 `icon.svg` 一并检查而不只是辅助文件，并列出任何非文本
+  文件，使其无法悄悄进入某个发布。
+- 清单只装文本是有意为之：archive 安装路由以 `Uint8Array` 承载上传文件，不受影响，因此从 zip 安装的
+  Skill 仍可携带二进制资源。

--- a/changelog/unreleased/2026-08-23-skill-library-loader-keeps-non-text-files-out.zh.md
+++ b/changelog/unreleased/2026-08-23-skill-library-loader-keeps-non-text-files-out.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-23
 - **Type:** fix
 - **Scope:** `skills`
+- **PR:** [#419](https://github.com/Prism-Shadow/penguin-harness/pull/419)
 
 [English](2026-08-23-skill-library-loader-keeps-non-text-files-out.md)
 

--- a/packages/skills/src/index.ts
+++ b/packages/skills/src/index.ts
@@ -106,11 +106,36 @@ const SKILLS_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "
 export const SKILL_NAME_PATTERN = /^[A-Za-z0-9_-]+$/;
 
 /**
+ * UTF-8 decoder that rejects malformed byte sequences rather than substituting U+FFFD.
+ * `ignoreBOM` keeps a leading BOM in the string, so decoding matches what reading the file with
+ * the "utf8" encoding produced — the byte-for-byte content is what gets installed.
+ */
+const strictUtf8 = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true });
+
+/**
+ * Decodes a skill file's bytes as UTF-8 text, or returns undefined when they are not text this
+ * loader can carry — malformed UTF-8, or a NUL byte (which is what a UTF-16 or otherwise binary
+ * file looks like once the byte sequence happens to decode). Auxiliary files travel as strings all
+ * the way to disk on install, so anything that is not UTF-8 text would be written back with its
+ * bytes replaced; refusing it here keeps a corrupted copy from ever being installed. Exported for
+ * the test that asserts the whole library stays text.
+ */
+export function decodeSkillFile(bytes: Uint8Array): string | undefined {
+  let text: string;
+  try {
+    text = strictUtf8.decode(bytes);
+  } catch {
+    return undefined;
+  }
+  return text.includes("\0") ? undefined : text;
+}
+
+/**
  * Recursively collects a skill directory's auxiliary files — every regular file except the
  * top-level SKILL.md and icon.svg, which are carried by dedicated fields — keyed by POSIX-relative
  * path. These are resources a SKILL.md may reference (e.g. `reference/API.md`), installed alongside
- * it. Read as UTF-8 text; symlinks and other non-regular entries are skipped. Returns undefined
- * when the directory has no such files.
+ * it. Read as UTF-8 text; symlinks, other non-regular entries and non-text files (see
+ * decodeSkillFile) are skipped. Returns undefined when the directory has no such files.
  */
 function readSkillFiles(dir: string): Record<string, string> | undefined {
   const files: Record<string, string> = {};
@@ -122,7 +147,8 @@ function readSkillFiles(dir: string): Record<string, string> | undefined {
       } else if (entry.isFile()) {
         // SKILL.md and icon.svg at the root are carried by the content / icon fields.
         if (rel === "" && (entry.name === "SKILL.md" || entry.name === "icon.svg")) continue;
-        files[childRel] = fs.readFileSync(path.join(abs, entry.name), "utf8");
+        const text = decodeSkillFile(fs.readFileSync(path.join(abs, entry.name)));
+        if (text !== undefined) files[childRel] = text;
       }
     }
   };

--- a/packages/skills/test/skills.test.ts
+++ b/packages/skills/test/skills.test.ts
@@ -3,13 +3,15 @@
  * files into a manifest (including auxiliary files a SKILL.md references), loadPreinstalledSkills'
  * preinstall filter, loadSkillGroups grouping, groupSkills' Other group and missing-member
  * tolerance, librarySkill's traversal-name rejection, doc conventions (`## Before you start` is
- * mandatory), and parseSkillFrontmatter's error tolerance.
+ * mandatory), decodeSkillFile keeping non-text files out of the manifest, and
+ * parseSkillFrontmatter's error tolerance.
  */
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   SKILL_GROUPS,
+  decodeSkillFile,
   groupSkills,
   librarySkill,
   loadLibrarySkills,
@@ -382,5 +384,52 @@ describe("parseSkillFrontmatter", () => {
       version: 1,
       updated: "",
     });
+  });
+});
+/**
+ * Auxiliary files travel as strings from the library to the installed skill directory, so a file
+ * that is not UTF-8 text would be written back with its bytes replaced. The guard keeps such a
+ * file out of the manifest instead; the library-wide check is what makes sure one never ships.
+ */
+describe("decodeSkillFile", () => {
+  const bytes = (...values: number[]): Uint8Array => Uint8Array.from(values);
+
+  it("decodes UTF-8 text, multi-byte sequences included", () => {
+    expect(decodeSkillFile(new TextEncoder().encode("# Title\n中文 — em dash\n"))).toBe(
+      "# Title\n中文 — em dash\n",
+    );
+    // A UTF-8 BOM is valid UTF-8 and is carried through as written (the frontmatter parser strips it).
+    expect(decodeSkillFile(bytes(0xef, 0xbb, 0xbf, 0x68, 0x69))).toBe("\uFEFFhi");
+    expect(decodeSkillFile(bytes())).toBe("");
+  });
+
+  it("rejects malformed UTF-8 (a PNG header, a lone continuation byte)", () => {
+    expect(decodeSkillFile(bytes(0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a))).toBeUndefined();
+    expect(decodeSkillFile(bytes(0x80))).toBeUndefined();
+    expect(decodeSkillFile(bytes(0xc3))).toBeUndefined();
+  });
+
+  it("rejects a NUL byte, which is what UTF-16 text looks like as UTF-8", () => {
+    // "hi" in UTF-16LE: every ASCII character carries a NUL, and each pair decodes as valid UTF-8.
+    expect(decodeSkillFile(bytes(0x68, 0x00, 0x69, 0x00))).toBeUndefined();
+  });
+
+  it("every file in the library is text (nothing would be corrupted on install)", async () => {
+    const walk = async (dir: string): Promise<string[]> => {
+      const out: string[] = [];
+      for (const entry of await fs.readdir(dir, { withFileTypes: true })) {
+        const abs = path.join(dir, entry.name);
+        if (entry.isDirectory()) out.push(...(await walk(abs)));
+        else if (entry.isFile()) out.push(abs);
+      }
+      return out;
+    };
+    const binary: string[] = [];
+    for (const file of await walk(skillsRoot)) {
+      if (decodeSkillFile(await fs.readFile(file)) === undefined) {
+        binary.push(path.relative(skillsRoot, file));
+      }
+    }
+    expect(binary, "non-text files in the skill library").toEqual([]);
   });
 });


### PR DESCRIPTION
## The defect

`readSkillFiles` collected every regular file in a library skill directory with `fs.readFileSync(path, "utf8")`, and the other end of that chain writes them back the same way:

- `packages/skills/src/index.ts` — auxiliary files become `Record<string, string>`
- `packages/core/src/state/agent-state.ts:459` — `installSkill` writes each with `fs.writeFile(file, data, "utf8")`

So a file that is not UTF-8 text gets its bytes replaced with U+FFFD on the way in and is written out corrupted, with nothing reporting it. Latent today — the library ships only Markdown and SVG — but the only thing keeping it latent is that nobody has committed a PNG next to a `SKILL.md`.

## The fix

`decodeSkillFile(bytes)` returns the text or `undefined`, and `readSkillFiles` skips a file it cannot decode:

- `fatal: true` — malformed UTF-8 is rejected instead of being replaced.
- NUL byte rejected — that is what UTF-16 text looks like once its bytes happen to form valid UTF-8 (`68 00 69 00`).
- `ignoreBOM: true` — a leading BOM stays in the string, so a file that *does* decode carries exactly what the old `"utf8"` read produced. Without this, `TextDecoder` would have silently stripped the BOM and changed installed content.

Skipping rather than throwing: a bad file can only arrive through a commit to `packages/skills/skills/`, and the test below catches that in CI. At runtime, an omitted auxiliary file makes the agent's read fail where it is used; throwing would 500 the whole library listing for every user instead.

## Why not carry binaries

The manifest being text-only is a property of the built-in library, not of Skills in general — the archive-install route already carries uploaded files as `Uint8Array` (`packages/server/src/http/routes/skills.ts:101`), so a Skill installed from a zip can ship binary assets. Making the library manifest byte-preserving would mean a new field on `LibrarySkill`, the `SkillMetadataItem` DTO and the install writer, for a capability nothing asks for. Not built.

## Guard

A new test walks `skills/` — `SKILL.md` and `icon.svg` included, not only the auxiliary files — and lists any file that is not text.

Both halves confirmed against a planted `vllm/reference/logo.png` (a real PNG header):

- test: `non-text files in the skill library: expected [ 'vllm/reference/logo.png' ] to deeply equal []`
- loader: `librarySkill('vllm').files` returned `["reference/notes.md"]` — the PNG dropped, its text sibling kept.

## Verification

`pnpm format:check`; `skills` test (28 passed, up from 24) and `typecheck`; `skills` build + `server` typecheck, since this adds an export to a package the server imports.

## Note

One of five PRs from an audit of the shipped skill library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)