### PR TITLE
docs(server): make the hot-update runtime's comments match the code

### DIFF
--- a/changelog/unreleased/2026-08-23-hmr-comments-match-the-code.md
+++ b/changelog/unreleased/2026-08-23-hmr-comments-match-the-code.md
@@ -20,8 +20,11 @@ sent that reader the wrong way.
   is why the terminal WebSocket handshake reaches the App through in-process members. Both
   passages now say that.
 - `app.ts` described the hot APIs as authenticating with "a local-agent Bearer token OR admin
-  cookie session", pointing at `hot/routes.ts`. That token was removed for being a plaintext
-  admin-equivalent secret on disk, and the path named no file.
+  cookie session", pointing at `hot/routes.ts` — a path that names no file, and a token that
+  had been removed for being a plaintext admin-equivalent secret on disk. The gate is the
+  network check, then the ordinary auth middleware with an admin check on top; the Bearer
+  credential it accepts today is the boot's local API token at `<root>/api-token`, which
+  reinstated that equivalence deliberately, not the per-boot token the old comment meant.
 - Three JSDoc blocks documented the declaration below their neighbour rather than their own:
   `UpgradeAllTarget`'s sat above `UpgradeAssets`, `persistVersion`'s above
   `materializeAssets`, and `isSafeRelPath`'s above `sameFileContent` — leaving three

--- a/changelog/unreleased/2026-08-23-hmr-comments-match-the-code.md
+++ b/changelog/unreleased/2026-08-23-hmr-comments-match-the-code.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-23
 - **Type:** process
 - **Scope:** `server`
+- **PR:** [#427](https://github.com/Prism-Shadow/penguin-harness/pull/427)
 
 [中文版](2026-08-23-hmr-comments-match-the-code.zh.md)
 

--- a/changelog/unreleased/2026-08-23-hmr-comments-match-the-code.md
+++ b/changelog/unreleased/2026-08-23-hmr-comments-match-the-code.md
@@ -1,0 +1,31 @@
+# The runtime's comments say what the runtime does
+
+- **Date:** 2026-08-23
+- **Type:** process
+- **Scope:** `server`
+
+[中文版](2026-08-23-hmr-comments-match-the-code.zh.md)
+
+Four passages in the hot-update runtime described something other than the code around them.
+A reader with no session transcript could not have resolved them, and two of them would have
+sent that reader the wrong way.
+
+## Details
+
+- The HTTP seam's module doc, and `hmr/README.md` with it, stated that streaming responses
+  stay runtime-side. The platform's own SSE endpoints go through the seam and always have —
+  a handler returns its `Response` as soon as the stream exists and keeps writing to it. What
+  the seam cannot carry is a live socket, there being no `Response` to return for one, which
+  is why the terminal WebSocket handshake reaches the App through in-process members. Both
+  passages now say that.
+- `app.ts` described the hot APIs as authenticating with "a local-agent Bearer token OR admin
+  cookie session", pointing at `hot/routes.ts`. That token was removed for being a plaintext
+  admin-equivalent secret on disk, and the path named no file.
+- Three JSDoc blocks documented the declaration below their neighbour rather than their own:
+  `UpgradeAllTarget`'s sat above `UpgradeAssets`, `persistVersion`'s above
+  `materializeAssets`, and `isSafeRelPath`'s above `sameFileContent` — leaving three
+  declarations undocumented and three carrying two blocks each. Each is back on the
+  declaration it describes.
+- The store's keep rule read "at most `STORE_KEEP` versions"; the referenced version is kept
+  on top of the newest `STORE_KEEP`, so a store holds three entries whenever the committed
+  version is not among the two most recently written.

--- a/changelog/unreleased/2026-08-23-hmr-comments-match-the-code.zh.md
+++ b/changelog/unreleased/2026-08-23-hmr-comments-match-the-code.zh.md
@@ -17,8 +17,10 @@
   真正带不了的是活的 socket，因为没有 `Response` 可以为它返回，这也正是终端 WebSocket 握手要通过
   进程内成员去够到 App 的原因。现在两处文字说的都是这件事。
 - `app.ts` 把热更新 API 的鉴权描述成「local-agent Bearer token 或管理员 cookie 会话」，并指向
-  `hot/routes.ts`。那个 token 因为是磁盘上一份等同管理员权限的明文密钥而被移除，那个路径也不指向
-  任何文件。
+  `hot/routes.ts`——那个路径不指向任何文件，而它说的那个 token 也早已因为是磁盘上一份等同管理员
+  权限的明文密钥而被移除。这道门实际是：先过网络闸门，再走普通的 auth 中间件并额外要求管理员。
+  它今天接受的 Bearer 凭据是本次启动的本机 API token（`<root>/api-token`）——那份等价关系是后来
+  被有意重新确立的，与旧注释指的那个 per-boot token 不是一回事。
 - 三处 JSDoc 记录的是它邻居下面的那个声明，而不是自己下面的：`UpgradeAllTarget` 的挂在
   `UpgradeAssets` 上、`persistVersion` 的挂在 `materializeAssets` 上、`isSafeRelPath` 的挂在
   `sameFileContent` 上——于是三个声明没有文档，另外三个各顶着两块。每一块都回到了它描述的声明上。

--- a/changelog/unreleased/2026-08-23-hmr-comments-match-the-code.zh.md
+++ b/changelog/unreleased/2026-08-23-hmr-comments-match-the-code.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-23
 - **Type:** process
 - **Scope:** `server`
+- **PR:** [#427](https://github.com/Prism-Shadow/penguin-harness/pull/427)
 
 [English](2026-08-23-hmr-comments-match-the-code.md)
 

--- a/changelog/unreleased/2026-08-23-hmr-comments-match-the-code.zh.md
+++ b/changelog/unreleased/2026-08-23-hmr-comments-match-the-code.zh.md
@@ -1,0 +1,25 @@
+# runtime 的注释现在说的是 runtime 做的事
+
+- **Date:** 2026-08-23
+- **Type:** process
+- **Scope:** `server`
+
+[English](2026-08-23-hmr-comments-match-the-code.md)
+
+热更新 runtime 里有四处文字描述的不是它周围的代码。没有会话记录的读者无从核实它们，其中两处还会
+把读者引向错误的方向。
+
+## 细节
+
+- HTTP seam 的模块文档，以及跟着它的 `hmr/README.md`，都写着流式响应留在 runtime 一侧。platform
+  自己的 SSE 端点一直都是走 seam 的——处理函数在流建立时就交回 `Response`，之后继续往里写。seam
+  真正带不了的是活的 socket，因为没有 `Response` 可以为它返回，这也正是终端 WebSocket 握手要通过
+  进程内成员去够到 App 的原因。现在两处文字说的都是这件事。
+- `app.ts` 把热更新 API 的鉴权描述成「local-agent Bearer token 或管理员 cookie 会话」，并指向
+  `hot/routes.ts`。那个 token 因为是磁盘上一份等同管理员权限的明文密钥而被移除，那个路径也不指向
+  任何文件。
+- 三处 JSDoc 记录的是它邻居下面的那个声明，而不是自己下面的：`UpgradeAllTarget` 的挂在
+  `UpgradeAssets` 上、`persistVersion` 的挂在 `materializeAssets` 上、`isSafeRelPath` 的挂在
+  `sameFileContent` 上——于是三个声明没有文档，另外三个各顶着两块。每一块都回到了它描述的声明上。
+- store 的保留规则写的是「最多 `STORE_KEEP` 个版本」；被引用的版本是在最新的 `STORE_KEEP` 个之外
+  额外保留的，所以只要已提交的版本不在最近写入的两个之内，store 里就有三份。

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -448,8 +448,10 @@ export function createRuntimeApp(deps: AppDeps): Hono<AppEnv> {
     app.use("/api/desktop/update/*", authMiddleware(deps.authService, deps.config.trustProxy));
     app.route("/api/desktop/update", desktopUpdateRoutes(deps));
   }
-  // Hot platform APIs run their own gate (the network gate, then an admin cookie session
-  // — see hmr/routes.ts), so they mount outside the cookie-only authMiddleware below.
+  // Hot platform APIs run their own gate — the network gate, then the SAME auth middleware
+  // the routes below use (the boot's local API token as `Authorization: Bearer`, or an admin
+  // cookie session) with an admin check on top; see hmr/routes.ts. That is why they mount
+  // above the blanket /api/* middleware rather than under it.
   app.route("/api/hmr", hmrRoutes(deps));
 
   // THE seam: from here down, every route is one the platform may take over by push. Mounted

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -448,9 +448,8 @@ export function createRuntimeApp(deps: AppDeps): Hono<AppEnv> {
     app.use("/api/desktop/update/*", authMiddleware(deps.authService, deps.config.trustProxy));
     app.route("/api/desktop/update", desktopUpdateRoutes(deps));
   }
-  // Hot platform APIs authenticate themselves (local-agent Bearer token OR
-  // admin cookie session, see hot/routes.ts), so they mount outside the
-  // cookie-only authMiddleware below.
+  // Hot platform APIs run their own gate (the network gate, then an admin cookie session
+  // — see hmr/routes.ts), so they mount outside the cookie-only authMiddleware below.
   app.route("/api/hmr", hmrRoutes(deps));
 
   // THE seam: from here down, every route is one the platform may take over by push. Mounted

--- a/packages/server/src/hmr/README.md
+++ b/packages/server/src/hmr/README.md
@@ -79,8 +79,11 @@ Two boundaries keep it safe, and both are load-bearing:
   runtime's older handler instead would answer with semantics the caller was not promised. The
   error surfaces as a 500.
 
-Streaming responses (SSE, long downloads) stay runtime-side: the handler returns a whole
-Response. That is a limit of today's seam, not a layer boundary.
+A streaming response rides the seam unchanged — the handler returns a whole `Response` as
+soon as the stream exists and keeps writing to it, which is what the platform's SSE endpoints
+do. A live **socket** is what the seam cannot carry, there being no `Response` to return for
+one, so the terminal WebSocket handshake reaches the App through in-process members instead.
+That is a property of the contract, not a layer boundary.
 
 ## Worked examples (all real, all from review)
 

--- a/packages/server/src/hmr/host.ts
+++ b/packages/server/src/hmr/host.ts
@@ -643,10 +643,10 @@ export class HmrHost {
 
   /**
    * Store GC: keep the STORE_KEEP most recently written of each artifact, plus the one
-   * harness.json references, which is kept whether or not recency would have. Best-effort; ordered after the manifest flip so
-   * nothing referenced can be pruned. `platform`, `cli`, and `web` are three
-   * independent subtrees now (no shared file to piggyback a sweep on), so each
-   * gets its own pass.
+   * harness.json references, which is kept whether or not recency would have. Best-effort;
+   * ordered after the manifest flip so nothing referenced can be pruned. `platform`, `cli`,
+   * `web` and the assets directories are independent subtrees (no shared file to piggyback a
+   * sweep on), so each gets its own pass.
    */
   private async pruneStore(manifest: Manifest): Promise<void> {
     const keepNewest = async (

--- a/packages/server/src/hmr/host.ts
+++ b/packages/server/src/hmr/host.ts
@@ -98,12 +98,6 @@ export interface GitSource {
 }
 
 /**
- * One atomic push: the platform bundle and the cli bundle (each inline ESM source,
- * independent single-file artifacts) plus the web dist as a { relPath: base64 }
- * manifest. All three travel in the SAME request — there is no partial-target
- * upgrade.
- */
-/**
  * Files a push needs on DISK rather than in memory. The web dist is only ever served as
  * bytes, so it stays in RAM; an asset is something the platform hands to the OS — a
  * native `.node` whose loader resolves it by path, a helper binary it execs — and a
@@ -118,6 +112,12 @@ export interface UpgradeAssets {
   exec?: string[];
 }
 
+/**
+ * One atomic push: the platform bundle and the cli bundle (each inline ESM source,
+ * independent single-file artifacts) plus the web dist as a { relPath: base64 }
+ * manifest. All three travel in the SAME request — there is no partial-target
+ * upgrade.
+ */
 export interface UpgradeAllTarget {
   platform: string;
   cli: string;
@@ -152,7 +152,12 @@ export type UpgradeOutcome =
     }
   | { status: "blocked"; dropped: string[]; missing: string[]; invalid: string[] };
 
-/** How many past versions (platform bundle / cli bundle / web dist, each independently) the store keeps (current + one rollback). */
+/**
+ * How many versions of each artifact (platform bundle / cli bundle / web dist / assets
+ * dir, each independently) the store keeps by recency — a rollback copy behind the newest.
+ * The version harness.json references is kept on top of these, so a store holds three
+ * entries whenever the committed version is not among the two most recently written.
+ */
 const STORE_KEEP = 2;
 
 export class HmrHost {
@@ -519,20 +524,6 @@ export class HmrHost {
   // -- Persistence ----------------------------------------------------------
 
   /**
-   * Content-addresses the cli bundle (never imported — just stored, for packages/cli's
-   * own loader to pick up) and the web gzip artifact next to the platform bundle the
-   * boot already stored (its CODE only — see the module doc: state is never
-   * persisted), then flips harness.json ONCE — `platform`, `cli`, and `web` all land in the SAME atomic
-   * rename, never three separate commits that could leave one pointer ahead of the
-   * others. `platform.bundle` and `cli.bundle` are genuinely independent files
-   * (distinct content, distinct sha) rather than the same physical bundle under two
-   * manifest keys.
-   *
-   * Returns whether the commit succeeded — the caller surfaces this to clients
-   * (`persisted` in UpgradeOutcome) so a live swap that could not be written to disk
-   * is visibly at risk of reverting on the next restart, rather than silently ok.
-   */
-  /**
    * Unpacks a push's assets under store/assets/<sha>/, content-addressed like every other
    * artifact so an unchanged set reuses its directory. Modes are restored from the push's
    * `exec` list: an asset arrives as base64 with no mode of its own, and a helper binary
@@ -583,6 +574,20 @@ export class HmrHost {
     return this.assets;
   }
 
+  /**
+   * Content-addresses the cli bundle (never imported — just stored, for packages/cli's
+   * own loader to pick up) and the web gzip artifact next to the platform bundle the
+   * boot already stored (its CODE only — see the module doc: state is never
+   * persisted), then flips harness.json ONCE — `platform`, `cli`, and `web` all land in the SAME atomic
+   * rename, never three separate commits that could leave one pointer ahead of the
+   * others. `platform.bundle` and `cli.bundle` are genuinely independent files
+   * (distinct content, distinct sha) rather than the same physical bundle under two
+   * manifest keys.
+   *
+   * Returns whether the commit succeeded — the caller surfaces this to clients
+   * (`persisted` in UpgradeOutcome) so a live swap that could not be written to disk
+   * is visibly at risk of reverting on the next restart, rather than silently ok.
+   */
   private async persistVersion(
     platformSha: string,
     cliContent: string,
@@ -637,8 +642,8 @@ export class HmrHost {
   }
 
   /**
-   * Store GC: keep at most STORE_KEEP versions — the committed one is always
-   * kept, the rest by recency. Best-effort; ordered after the manifest flip so
+   * Store GC: keep the STORE_KEEP most recently written of each artifact, plus the one
+   * harness.json references, which is kept whether or not recency would have. Best-effort; ordered after the manifest flip so
    * nothing referenced can be pruned. `platform`, `cli`, and `web` are three
    * independent subtrees now (no shared file to piggyback a sweep on), so each
    * gets its own pass.
@@ -765,7 +770,6 @@ async function writeStoreFile(file: string, content: Buffer): Promise<void> {
   }
 }
 
-/** No absolute paths, no `..` segments — the map is looked up by exact key, but a malformed key must never be stored. */
 /** Whether `file` already holds exactly these bytes (missing/unreadable counts as no). */
 async function sameFileContent(file: string, content: Buffer): Promise<boolean> {
   try {
@@ -777,6 +781,7 @@ async function sameFileContent(file: string, content: Buffer): Promise<boolean> 
   }
 }
 
+/** No absolute paths, no `..` segments — the map is looked up by exact key, but a malformed key must never be stored. */
 function isSafeRelPath(rel: string): boolean {
   if (rel === "" || rel.startsWith("/") || rel.includes("\\")) return false;
   return rel.split("/").every((seg) => seg !== "" && seg !== "." && seg !== "..");

--- a/packages/server/src/hmr/http-seam.ts
+++ b/packages/server/src/hmr/http-seam.ts
@@ -20,9 +20,12 @@
  *   than declining, and quietly running the runtime's older handler instead would answer with
  *   different semantics than the caller was promised. The error surfaces as a 500.
  *
- * Streaming responses (SSE, long downloads) stay runtime-side for now: the handler returns a
- * whole Response, which is enough for the request/response API surface and keeps the contract
- * one function wide.
+ * The contract is one function wide — Request in, whole Response out — and a streaming body
+ * rides it unchanged: the platform's SSE endpoints (`/api/events`, a session's event stream)
+ * hand back a Response as soon as the stream exists and go on writing to it afterwards. What
+ * the seam cannot carry is a live SOCKET, because there is no Response to return for one;
+ * that is why the terminal WebSocket handshake reaches the App through in-process members
+ * (`terminals()`, `attachStream()`) instead.
  */
 import type { MiddlewareHandler } from "hono";
 import type { HmrHost } from "./host.js";


### PR DESCRIPTION
Comments only — no behavior change, no test change.

Applied the test `hmr/README.md`'s own prose rule states: *could a reader at HEAD, with no session transcript, resolve every reference and verify every claim?* Four passages failed it, two of them by pointing the reader the wrong way.

## 1. "Streaming responses stay runtime-side" — not true at HEAD

`http-seam.ts`, and `hmr/README.md` repeating it:

> Streaming responses (SSE, long downloads) stay runtime-side for now: the handler returns a whole Response […] That is a limit of today's seam, not a layer boundary.

`sseEndpoint` is used by `http/routes/events.ts` and `http/routes/sessions.ts`, both mounted inside `createApp` (`app.ts:789`, `app.ts:809`) — i.e. the platform's own Hono app, served through `seamHttp`. SSE has been going through the seam since the business surface moved onto the platform. It works because "a whole `Response`" is not a limitation for streaming: `streamSSE` returns its `Response` as soon as the stream exists and writes to it afterwards.

The real limit is a live **socket** — there is no `Response` to return for one — which is exactly why `PlatformApi` exposes `terminals()` and `attachStream()` as in-process members. Both passages now say that instead, which also explains a design choice a reader would otherwise have to rediscover.

## 2. A stale credential and a path that names no file

`app.ts`:

> Hot platform APIs authenticate themselves (local-agent Bearer token OR admin cookie session, see `hot/routes.ts`)

The Bearer token was removed — `hmr/routes.ts` documents why at length (a plaintext admin-equivalent secret on disk, readable by anything running as the same user, agent shells included). And there is no `hot/routes.ts`. A reader following that comment looks for a second auth path that does not exist, in a file that does not exist.

## 3. Three JSDoc blocks attached to the wrong declaration

Each of these documents its *neighbour's* neighbour, leaving one declaration undocumented and one carrying two blocks:

| Block | Was attached to | Describes |
| --- | --- | --- |
| "One atomic push: the platform bundle and the cli bundle…" | `UpgradeAssets` | `UpgradeAllTarget` |
| "Content-addresses the platform bundle…, then flips harness.json ONCE" | `materializeAssets` | `persistVersion` |
| "No absolute paths, no `..` segments…" | `sameFileContent` | `isSafeRelPath` |

Moved, text unchanged.

## 4. An off-by-one in the store's keep rule

`STORE_KEEP`'s doc said "at most `STORE_KEEP` versions … the committed one is always kept, the rest by recency". `pruneStore` does `kept = new Set(ranked.slice(0, STORE_KEEP))` and *then* `kept.add(referenced)`, so the referenced version is kept **on top of** the newest two — three entries whenever the committed version is not among the two most recently written. The doc now says what the code does; the code is unchanged.

`pnpm --filter @prismshadow/penguin-server test` — 900 passed. `typecheck` and `format:check` clean.

## Overlap

`host.ts` is also touched by #421, #422 and #424, and `http-seam.ts` by #424 — different regions in each case, except that #422 rewrites the first sentence of the `persistVersion` block this PR relocates. Whichever lands second needs a trivial resolution.

Deliberately left alone: the "there used to be a Bearer token" note in `hmr/routes.ts` and the "the RPC dispatch route that used to stand in for this" note in `http-seam.ts`. Both are change narration by the letter of the rule, but each records why an obvious-looking affordance is absent, which is the kind of note that stops it being re-added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)