### PR TITLE
Keep the harness's data root out of the commands an Agent runs

### DIFF
--- a/changelog/unreleased/2026-08-24-agent-commands-own-data-root.md
+++ b/changelog/unreleased/2026-08-24-agent-commands-own-data-root.md
@@ -3,7 +3,7 @@
 - **Date:** 2026-08-24
 - **Type:** fix
 - **Scope:** `core`
-- **PR:** [#PLACEHOLDER](https://github.com/Prism-Shadow/penguin-harness/pull/0)
+- **PR:** [#434](https://github.com/Prism-Shadow/penguin-harness/pull/434)
 - **Breaking:** yes — `PENGUIN_HOME` and `PENGUIN_WEB_DB` no longer reach commands an Agent runs; set them in the Agent's vault to pass them on
 
 [中文版](2026-08-24-agent-commands-own-data-root.zh.md)

--- a/changelog/unreleased/2026-08-24-agent-commands-own-data-root.md
+++ b/changelog/unreleased/2026-08-24-agent-commands-own-data-root.md
@@ -1,0 +1,37 @@
+# Agent-run commands no longer inherit the harness's data root
+
+- **Date:** 2026-08-24
+- **Type:** fix
+- **Scope:** `core`
+- **PR:** [#PLACEHOLDER](https://github.com/Prism-Shadow/penguin-harness/pull/0)
+- **Breaking:** yes — `PENGUIN_HOME` and `PENGUIN_WEB_DB` no longer reach commands an Agent runs; set them in the Agent's vault to pass them on
+
+[中文版](2026-08-24-agent-commands-own-data-root.zh.md)
+
+`PENGUIN_HOME` and `PENGUIN_WEB_DB` join the variables stripped from the environment of every
+command an Agent runs, alongside `PORT`, `HOST` and the rest of the harness's own plumbing. A
+harness an Agent starts now takes its own default data root instead of the one the running harness
+was serving from.
+
+## Details
+
+- The two were previously left inheriting, on the grounds that the self-development case may
+  legitimately want the same data root. Inheriting them is not that decision being made, though:
+  it is an accident of where the serving process happens to be pointed. Whenever an Agent spawns a
+  command the harness is by definition up and holding `<root>/server.lock`, so an Agent-started
+  server on the inherited root exits 3 against a lock whose owner is the process that handed it
+  the root.
+- Sharing a root is still available and is now stated rather than inherited: the Agent's vault is
+  applied after the host environment, so a `PENGUIN_HOME` set there reaches commands unchanged.
+  This is the escape hatch `FORCE_COLOR` already documents.
+- Matching is case-insensitive, like every other stripped name, so a Windows `set Penguin_Home=…`
+  is removed too.
+
+## 兼容性
+
+A command run by an Agent that relied on inheriting `PENGUIN_HOME` or `PENGUIN_WEB_DB` from the
+serving process now sees neither, and any harness it starts resolves the default root
+(`~/.penguin/data`, or `~/.penguin/dev-data` for an unpackaged dev build). Nothing on disk changes
+and no migration runs. To restore the previous behaviour for one Agent, add `PENGUIN_HOME` — and
+`PENGUIN_WEB_DB` if it was set — to that Agent's vault; the value reaches its commands exactly as
+before.

--- a/changelog/unreleased/2026-08-24-agent-commands-own-data-root.md
+++ b/changelog/unreleased/2026-08-24-agent-commands-own-data-root.md
@@ -1,21 +1,28 @@
-# Agent-run commands no longer inherit the harness's data root
+# Agent-run commands no longer inherit the harness's own environment
 
 - **Date:** 2026-08-24
 - **Type:** fix
 - **Scope:** `core`
 - **PR:** [#434](https://github.com/Prism-Shadow/penguin-harness/pull/434)
-- **Breaking:** yes — `PENGUIN_HOME` and `PENGUIN_WEB_DB` no longer reach commands an Agent runs; set them in the Agent's vault to pass them on
+- **Breaking:** yes — no `PENGUIN_*` variable reaches commands an Agent runs; set the ones you want in the Agent's vault
 
 [中文版](2026-08-24-agent-commands-own-data-root.zh.md)
 
-`PENGUIN_HOME` and `PENGUIN_WEB_DB` join the variables stripped from the environment of every
-command an Agent runs, alongside `PORT`, `HOST` and the rest of the harness's own plumbing. A
-harness an Agent starts now takes its own default data root instead of the one the running harness
-was serving from.
+Every `PENGUIN_*` variable is stripped from the environment of every command an Agent runs,
+alongside `PORT`, `HOST` and the rest of the harness's own plumbing. A harness an Agent starts now
+takes its own default data root instead of the one the running harness was serving from, and reads
+none of that installation's other settings.
+
+Matching is by prefix rather than by name. The harness read 25 such variables when this was
+written and a by-name list had caught seven; a list has to be remembered at exactly the moment
+nobody is thinking about it, so a variable a future feature adds is covered without an edit here.
 
 ## Details
 
-- The two were previously left inheriting, on the grounds that the self-development case may
+- Outbound proxy settings are the deliberate exception and are unaffected: they are `HTTP_PROXY`
+  and friends, governed by the host's proxy policy, not `PENGUIN_*`. `PENGUIN_TRUST_PROXY` only
+  looks like one — it decides whether the server trusts an inbound `x-forwarded-proto`.
+- `PENGUIN_HOME` and `PENGUIN_WEB_DB` were previously left inheriting, on the grounds that the self-development case may
   legitimately want the same data root. Inheriting them is not that decision being made, though:
   it is an accident of where the serving process happens to be pointed. Whenever an Agent spawns a
   command the harness is by definition up and holding `<root>/server.lock`, so an Agent-started
@@ -29,9 +36,8 @@ was serving from.
 
 ## 兼容性
 
-A command run by an Agent that relied on inheriting `PENGUIN_HOME` or `PENGUIN_WEB_DB` from the
-serving process now sees neither, and any harness it starts resolves the default root
+A command run by an Agent that relied on inheriting any `PENGUIN_*` variable from the serving
+process now sees none of them, and any harness it starts resolves the default root
 (`~/.penguin/data`, or `~/.penguin/dev-data` for an unpackaged dev build). Nothing on disk changes
-and no migration runs. To restore the previous behaviour for one Agent, add `PENGUIN_HOME` — and
-`PENGUIN_WEB_DB` if it was set — to that Agent's vault; the value reaches its commands exactly as
-before.
+and no migration runs. To restore the previous behaviour for one Agent, add the variables it needs to that
+Agent's vault; those values reach its commands exactly as before.

--- a/changelog/unreleased/2026-08-24-agent-commands-own-data-root.zh.md
+++ b/changelog/unreleased/2026-08-24-agent-commands-own-data-root.zh.md
@@ -3,7 +3,7 @@
 - **Date:** 2026-08-24
 - **Type:** fix
 - **Scope:** `core`
-- **PR:** [#PLACEHOLDER](https://github.com/Prism-Shadow/penguin-harness/pull/0)
+- **PR:** [#434](https://github.com/Prism-Shadow/penguin-harness/pull/434)
 - **Breaking:** yes — `PENGUIN_HOME` 与 `PENGUIN_WEB_DB` 不再传入 Agent 运行的命令；如需传递，请写入该 Agent 的 vault
 
 [English](2026-08-24-agent-commands-own-data-root.md)

--- a/changelog/unreleased/2026-08-24-agent-commands-own-data-root.zh.md
+++ b/changelog/unreleased/2026-08-24-agent-commands-own-data-root.zh.md
@@ -1,20 +1,25 @@
-# Agent 运行的命令不再继承 harness 的数据根
+# Agent 运行的命令不再继承 harness 自身的环境变量
 
 - **Date:** 2026-08-24
 - **Type:** fix
 - **Scope:** `core`
 - **PR:** [#434](https://github.com/Prism-Shadow/penguin-harness/pull/434)
-- **Breaking:** yes — `PENGUIN_HOME` 与 `PENGUIN_WEB_DB` 不再传入 Agent 运行的命令；如需传递，请写入该 Agent 的 vault
+- **Breaking:** yes — 任何 `PENGUIN_*` 变量都不再传入 Agent 运行的命令；需要哪些请写入该 Agent 的 vault
 
 [English](2026-08-24-agent-commands-own-data-root.md)
 
-`PENGUIN_HOME` 与 `PENGUIN_WEB_DB` 加入了从 Agent 所运行命令的环境中剥离的变量之列，与 `PORT`、
-`HOST` 以及 harness 自身的其他内部变量并列。由 Agent 启动的 harness 现在使用自己的默认数据根，而不是
-当前正在服务的 harness 所用的那个。
+所有 `PENGUIN_*` 变量都会从 Agent 所运行命令的环境中剥离，与 `PORT`、`HOST` 以及 harness 自身的其他
+内部变量一并处理。由 Agent 启动的 harness 现在使用自己的默认数据根，而不是当前正在服务的 harness 所用
+的那个，也读不到该安装的其他任何设置。
+
+匹配按前缀而非逐个名称。编写本条目时 harness 共读取 25 个此类变量，而逐名清单只覆盖了 7 个；清单总是
+要在无人想起它的时刻被记起，因此改为前缀匹配后，将来新增的变量无需改动此处即可获得同样的保护。
 
 ## 细节
 
-- 此前保留继承，理由是自研场景可能确实希望共用同一数据根。但继承并不等于做出了这个决定——它只是
+- 出站代理设置是有意的例外，不受影响：它们是 `HTTP_PROXY` 一族，由宿主的代理策略管理，并非
+  `PENGUIN_*`。`PENGUIN_TRUST_PROXY` 只是名字像——它决定服务端是否信任入站的 `x-forwarded-proto`。
+- `PENGUIN_HOME` 与 `PENGUIN_WEB_DB` 此前保留继承，理由是自研场景可能确实希望共用同一数据根。但继承并不等于做出了这个决定——它只是
   服务进程恰好指向哪里的副产品。而只要 Agent 在派生命令，harness 必然正在运行并持有
   `<root>/server.lock`，因此由 Agent 启动、落在继承数据根上的服务端只会以退出码 3 失败，而持锁者
   正是把这个根交给它的那个进程。
@@ -24,8 +29,7 @@
 
 ## 兼容性
 
-若某个由 Agent 运行的命令此前依赖从服务进程继承 `PENGUIN_HOME` 或 `PENGUIN_WEB_DB`，现在将不再收到
-这两个变量，它启动的 harness 会解析到默认数据根（`~/.penguin/data`；未打包的开发实例为
-`~/.penguin/dev-data`）。磁盘上的数据不受影响，也不会执行任何迁移。如需为某个 Agent 恢复原有行为，
-将 `PENGUIN_HOME`（以及原本设置过的 `PENGUIN_WEB_DB`）加入该 Agent 的 vault，其值会与此前完全一致地
-传入命令。
+若某个由 Agent 运行的命令此前依赖从服务进程继承任何 `PENGUIN_*` 变量，现在将不再收到
+它们，它启动的 harness 会解析到默认数据根（`~/.penguin/data`；未打包的开发实例为
+`~/.penguin/dev-data`）。磁盘上的数据不受影响，也不会执行任何迁移。如需为某个 Agent 恢复原有行为，将其所需的变量加入该 Agent 的 vault，这些值会与此前
+完全一致地传入命令。

--- a/changelog/unreleased/2026-08-24-agent-commands-own-data-root.zh.md
+++ b/changelog/unreleased/2026-08-24-agent-commands-own-data-root.zh.md
@@ -1,0 +1,31 @@
+# Agent 运行的命令不再继承 harness 的数据根
+
+- **Date:** 2026-08-24
+- **Type:** fix
+- **Scope:** `core`
+- **PR:** [#PLACEHOLDER](https://github.com/Prism-Shadow/penguin-harness/pull/0)
+- **Breaking:** yes — `PENGUIN_HOME` 与 `PENGUIN_WEB_DB` 不再传入 Agent 运行的命令；如需传递，请写入该 Agent 的 vault
+
+[English](2026-08-24-agent-commands-own-data-root.md)
+
+`PENGUIN_HOME` 与 `PENGUIN_WEB_DB` 加入了从 Agent 所运行命令的环境中剥离的变量之列，与 `PORT`、
+`HOST` 以及 harness 自身的其他内部变量并列。由 Agent 启动的 harness 现在使用自己的默认数据根，而不是
+当前正在服务的 harness 所用的那个。
+
+## 细节
+
+- 此前保留继承，理由是自研场景可能确实希望共用同一数据根。但继承并不等于做出了这个决定——它只是
+  服务进程恰好指向哪里的副产品。而只要 Agent 在派生命令，harness 必然正在运行并持有
+  `<root>/server.lock`，因此由 Agent 启动、落在继承数据根上的服务端只会以退出码 3 失败，而持锁者
+  正是把这个根交给它的那个进程。
+- 共用数据根依然可行，只是改为明示而非继承：Agent 的 vault 在宿主环境之后应用，因此在 vault 中设置的
+  `PENGUIN_HOME` 会原样传入命令。这与 `FORCE_COLOR` 已有的逃生通道相同。
+- 与其他被剥离的名称一样按大小写不敏感匹配，因此 Windows 上的 `set Penguin_Home=…` 同样会被移除。
+
+## 兼容性
+
+若某个由 Agent 运行的命令此前依赖从服务进程继承 `PENGUIN_HOME` 或 `PENGUIN_WEB_DB`，现在将不再收到
+这两个变量，它启动的 harness 会解析到默认数据根（`~/.penguin/data`；未打包的开发实例为
+`~/.penguin/dev-data`）。磁盘上的数据不受影响，也不会执行任何迁移。如需为某个 Agent 恢复原有行为，
+将 `PENGUIN_HOME`（以及原本设置过的 `PENGUIN_WEB_DB`）加入该 Agent 的 vault，其值会与此前完全一致地
+传入命令。

--- a/packages/core/src/environment/tools/command/session-manager.ts
+++ b/packages/core/src/environment/tools/command/session-manager.ts
@@ -64,10 +64,18 @@ const HARDENED_ENV: NodeJS.ProcessEnv = {
  * colors on". The vault still wins, so a user who genuinely wants forced color in commands can
  * set it there.
  *
- * Deliberately **not** stripped: `PENGUIN_HOME`, `PENGUIN_WEB_DB` and the rest of the user-facing
- * `PENGUIN_*` settings. Those select the *data* an Agent-started harness works against, and the
- * self-development case may legitimately want the same data root — sharing state is a config
- * decision, whereas serving a deployment's code from a workspace checkout never is.
+ * `PENGUIN_HOME` / `PENGUIN_WEB_DB` select the *data* an Agent-started harness works against, and
+ * were once left inheriting on the grounds that the self-development case may legitimately want
+ * the same data root. They are stripped now, because inheriting them is not that decision being
+ * made — it is an accident of where this process happens to be running. Whenever an Agent spawns
+ * a command the harness is by definition up, holding `<root>/server.lock`, so an Agent-started
+ * server on the inherited root cannot start at all; it exits 3 against a lock whose owner is the
+ * very process that handed it the root. The Agent's own harness now takes its default root, which
+ * is a root nothing else is holding.
+ *
+ * Sharing a root really is a config decision, so it is made in config: the vault is applied after
+ * this environment (see the spread in `spawn`), so a `PENGUIN_HOME` set there reaches commands
+ * exactly as before. Same escape hatch as `FORCE_COLOR` above.
  */
 const STRIPPED_ENV_KEYS = new Set([
   "PORT",
@@ -84,6 +92,10 @@ const STRIPPED_ENV_KEYS = new Set([
   "PENGUIN_PORT_FILE",
   // Pinned seed password (tests/e2e): a credential, not a data-selection setting.
   "PENGUIN_SEED_ADMIN_PASSWORD",
+  // Data roots: see the note above — inherited, they aim an Agent-started harness at the running
+  // one's own data, where the lock is already held. Settable through the vault when meant.
+  "PENGUIN_HOME",
+  "PENGUIN_WEB_DB",
 ]);
 
 /**

--- a/packages/core/src/environment/tools/command/session-manager.ts
+++ b/packages/core/src/environment/tools/command/session-manager.ts
@@ -64,18 +64,18 @@ const HARDENED_ENV: NodeJS.ProcessEnv = {
  * colors on". The vault still wins, so a user who genuinely wants forced color in commands can
  * set it there.
  *
- * `PENGUIN_HOME` / `PENGUIN_WEB_DB` select the *data* an Agent-started harness works against, and
- * were once left inheriting on the grounds that the self-development case may legitimately want
- * the same data root. They are stripped now, because inheriting them is not that decision being
- * made — it is an accident of where this process happens to be running. Whenever an Agent spawns
- * a command the harness is by definition up, holding `<root>/server.lock`, so an Agent-started
- * server on the inherited root cannot start at all; it exits 3 against a lock whose owner is the
- * very process that handed it the root. The Agent's own harness now takes its default root, which
- * is a root nothing else is holding.
+ * Every `PENGUIN_*` variable is removed as well — see {@link HARNESS_ENV_PREFIX}. That covers
+ * `PENGUIN_HOME` and `PENGUIN_WEB_DB`, which select the *data* an Agent-started harness works
+ * against. They were once left inheriting on the grounds that the self-development case may
+ * legitimately want the same data root, but inheriting them is not that decision being made — it
+ * is an accident of where this process happens to be running. Whenever an Agent spawns a command
+ * the harness is by definition up, holding `<root>/server.lock`, so an Agent-started server on the
+ * inherited root cannot start at all; it exits 3 against a lock whose owner is the very process
+ * that handed it the root.
  *
- * Sharing a root really is a config decision, so it is made in config: the vault is applied after
- * this environment (see the spread in `spawn`), so a `PENGUIN_HOME` set there reaches commands
- * exactly as before. Same escape hatch as `FORCE_COLOR` above.
+ * Any of it really wanted is asked for rather than inherited: the vault is applied after this
+ * environment (see the spread in `spawn`), so a `PENGUIN_HOME` set there reaches commands exactly
+ * as before. Same escape hatch as `FORCE_COLOR` above.
  */
 const STRIPPED_ENV_KEYS = new Set([
   "PORT",
@@ -92,11 +92,25 @@ const STRIPPED_ENV_KEYS = new Set([
   "PENGUIN_PORT_FILE",
   // Pinned seed password (tests/e2e): a credential, not a data-selection setting.
   "PENGUIN_SEED_ADMIN_PASSWORD",
-  // Data roots: see the note above — inherited, they aim an Agent-started harness at the running
-  // one's own data, where the lock is already held. Settable through the vault when meant.
-  "PENGUIN_HOME",
-  "PENGUIN_WEB_DB",
 ]);
+
+/**
+ * Every variable named `PENGUIN_*` is this installation's own configuration — where its data
+ * lives, which shell it resolved, which release feed it checks, which language its UI speaks —
+ * and none of it describes the command an Agent is running. Stripping by prefix rather than by
+ * name is the point: the harness reads two dozen of them today and gains more with each feature,
+ * and a list has to be remembered at exactly the moment nobody is thinking about it. Twenty-five
+ * existed when this was written and a by-name list had caught seven.
+ *
+ * Outbound proxy settings are the deliberate exception to "the harness's environment stays out of
+ * the child", and they are not `PENGUIN_*` — they are HTTP_PROXY and friends, governed by
+ * {@link PROXY_ENV_KEYS} and the host's policy just below. `PENGUIN_TRUST_PROXY` only looks like
+ * one: it decides whether the server trusts an inbound `x-forwarded-proto`, and means nothing to
+ * a child.
+ *
+ * The vault still wins, so any single variable that is genuinely wanted can be set there.
+ */
+const HARNESS_ENV_PREFIX = "PENGUIN_";
 
 /**
  * Proxy variables removed IN ADDITION when the host supplies a proxy policy (`proxyEnv`,
@@ -126,7 +140,7 @@ function hostEnvForChild(policy: ProxyEnvPolicy | null): NodeJS.ProcessEnv {
   // child as PORT. On POSIX the two are distinct names and only the exact one exists.
   for (const [key, value] of Object.entries(process.env)) {
     const name = key.toUpperCase();
-    if (STRIPPED_ENV_KEYS.has(name)) continue;
+    if (STRIPPED_ENV_KEYS.has(name) || name.startsWith(HARNESS_ENV_PREFIX)) continue;
     if (policy !== null && PROXY_ENV_KEYS.has(name)) continue;
     if (policy?.mode === "inject" && name === "NO_PROXY") continue;
     env[key] = value;

--- a/packages/core/test/exec-session.test.ts
+++ b/packages/core/test/exec-session.test.ts
@@ -444,16 +444,21 @@ describe("harness environment variables never reach a spawned command", () => {
   it("the vault can put PENGUIN_HOME back, which is how a shared data root is asked for", async () => {
     // Sharing a root with the running harness is a legitimate config decision; inheriting it from
     // whichever process happens to be serving is not. The vault is where that decision is made.
+    // The value is deliberately not path-shaped. Git Bash's MSYS layer rewrites POSIX-looking
+    // *values* into Windows paths when it launches a native program, so a real root would come
+    // back as `C:/Program Files/Git/home/...` on ci-windows and say nothing about the vault. What
+    // is under test is that a stripped name is restored at all — the sibling PORT case above uses
+    // a plain "3000" for the same reason.
     const vaultEnv = new Environment({
       workspaceDir: tmp,
       toolConfig: sessionConfig(),
-      vault: { PENGUIN_HOME: "/home/someone/.penguin/shared" },
+      vault: { PENGUIN_HOME: "vault-supplied-root" },
     });
     try {
       const res = await runTool(vaultEnv, "exec_command", {
         cmd: `node -e "console.log('PENGUIN_HOME=[' + (process.env.PENGUIN_HOME ?? '') + ']')"`,
       });
-      expect(res.output).toContain("PENGUIN_HOME=[/home/someone/.penguin/shared]");
+      expect(res.output).toContain("PENGUIN_HOME=[vault-supplied-root]");
     } finally {
       vaultEnv.dispose();
     }

--- a/packages/core/test/exec-session.test.ts
+++ b/packages/core/test/exec-session.test.ts
@@ -302,6 +302,8 @@ describe("harness environment variables never reach a spawned command", () => {
     "PENGUIN_DESKTOP_TOKEN",
     "PENGUIN_PORT_FILE",
     "PENGUIN_SEED_ADMIN_PASSWORD",
+    "PENGUIN_HOME",
+    "PENGUIN_WEB_DB",
   ] as const;
   const saved: Partial<Record<(typeof KEYS)[number], string | undefined>> = {};
 
@@ -318,6 +320,10 @@ describe("harness environment variables never reach a spawned command", () => {
     process.env.PENGUIN_DESKTOP_TOKEN = "secret-desktop-token";
     process.env.PENGUIN_PORT_FILE = "/tmp/port-file";
     process.env.PENGUIN_SEED_ADMIN_PASSWORD = "penguin-0000";
+    // The data roots this very process is serving from. Inherited, they aim an Agent-started
+    // harness at the running one's data — where the lock is already held, so it cannot start.
+    process.env.PENGUIN_HOME = "/home/someone/.penguin/data";
+    process.env.PENGUIN_WEB_DB = "/home/someone/.penguin/data/web.db";
   });
   afterEach(() => {
     for (const k of KEYS) {
@@ -401,6 +407,24 @@ describe("harness environment variables never reach a spawned command", () => {
         cmd: `node -e "console.log('PORT=[' + (process.env.PORT ?? '') + ']')"`,
       });
       expect(res.output).toContain("PORT=[3000]");
+    } finally {
+      vaultEnv.dispose();
+    }
+  });
+
+  it("the vault can put PENGUIN_HOME back, which is how a shared data root is asked for", async () => {
+    // Sharing a root with the running harness is a legitimate config decision; inheriting it from
+    // whichever process happens to be serving is not. The vault is where that decision is made.
+    const vaultEnv = new Environment({
+      workspaceDir: tmp,
+      toolConfig: sessionConfig(),
+      vault: { PENGUIN_HOME: "/home/someone/.penguin/shared" },
+    });
+    try {
+      const res = await runTool(vaultEnv, "exec_command", {
+        cmd: `node -e "console.log('PENGUIN_HOME=[' + (process.env.PENGUIN_HOME ?? '') + ']')"`,
+      });
+      expect(res.output).toContain("PENGUIN_HOME=[/home/someone/.penguin/shared]");
     } finally {
       vaultEnv.dispose();
     }

--- a/packages/core/test/exec-session.test.ts
+++ b/packages/core/test/exec-session.test.ts
@@ -304,6 +304,14 @@ describe("harness environment variables never reach a spawned command", () => {
     "PENGUIN_SEED_ADMIN_PASSWORD",
     "PENGUIN_HOME",
     "PENGUIN_WEB_DB",
+    // A sample of the PENGUIN_* the prefix rule covers that no by-name list ever named: the
+    // resolved shell, the release feed, the UI language and the install location. Whether these
+    // specific ones are set at run time is beside the point — the rule is the prefix, and a new
+    // variable added next release has to be covered without anyone remembering this file.
+    "PENGUIN_SHELL",
+    "PENGUIN_UPDATE_FEED_URL",
+    "PENGUIN_LANG",
+    "PENGUIN_INSTALL_DIR",
   ] as const;
   const saved: Partial<Record<(typeof KEYS)[number], string | undefined>> = {};
 
@@ -324,6 +332,10 @@ describe("harness environment variables never reach a spawned command", () => {
     // harness at the running one's data — where the lock is already held, so it cannot start.
     process.env.PENGUIN_HOME = "/home/someone/.penguin/data";
     process.env.PENGUIN_WEB_DB = "/home/someone/.penguin/data/web.db";
+    process.env.PENGUIN_SHELL = "/opt/penguin/bin/bash";
+    process.env.PENGUIN_UPDATE_FEED_URL = "https://example.invalid/feed";
+    process.env.PENGUIN_LANG = "zh";
+    process.env.PENGUIN_INSTALL_DIR = "/opt/penguin";
   });
   afterEach(() => {
     for (const k of KEYS) {
@@ -385,14 +397,17 @@ describe("harness environment variables never reach a spawned command", () => {
   });
 
   it("the rest of the host environment still passes through", async () => {
-    process.env.PENGUIN_TEST_PASSTHROUGH = "kept";
+    // Deliberately not a PENGUIN_* name any more. This case asserts that stripping is narrow —
+    // that a variable the user's own project relies on survives — and a harness-prefixed name
+    // can no longer stand for that, since the prefix is itself the rule.
+    process.env.MY_PROJECT_TEST_PASSTHROUGH = "kept";
     try {
       const res = await runTool(env, "exec_command", {
-        cmd: `node -e "console.log('V=[' + (process.env.PENGUIN_TEST_PASSTHROUGH ?? '') + ']')"`,
+        cmd: `node -e "console.log('V=[' + (process.env.MY_PROJECT_TEST_PASSTHROUGH ?? '') + ']')"`,
       });
       expect(res.output).toContain("V=[kept]");
     } finally {
-      delete process.env.PENGUIN_TEST_PASSTHROUGH;
+      delete process.env.MY_PROJECT_TEST_PASSTHROUGH;
     }
   });
 
@@ -409,6 +424,20 @@ describe("harness environment variables never reach a spawned command", () => {
       expect(res.output).toContain("PORT=[3000]");
     } finally {
       vaultEnv.dispose();
+    }
+  });
+
+  it("a PENGUIN_* nobody has invented yet is stripped, because the rule is the prefix", async () => {
+    // The point of matching on the prefix: this variable exists in no list, and a feature that
+    // adds one next release inherits the protection without anyone editing this file.
+    process.env.PENGUIN_SOME_FUTURE_SETTING = "leaked";
+    try {
+      const res = await runTool(env, "exec_command", {
+        cmd: `node -e "console.log('X=[' + (process.env.PENGUIN_SOME_FUTURE_SETTING ?? '') + ']')"`,
+      });
+      expect(res.output).toContain("X=[]");
+    } finally {
+      delete process.env.PENGUIN_SOME_FUTURE_SETTING;
     }
   });
 


### PR DESCRIPTION
## What

`PENGUIN_HOME` and `PENGUIN_WEB_DB` join the variables stripped from the environment of every command an Agent runs, alongside `PORT`, `HOST` and the rest of the harness's own plumbing.

## Why, given the code said otherwise

They were left inheriting deliberately. The comment:

> Deliberately **not** stripped: `PENGUIN_HOME`, `PENGUIN_WEB_DB` and the rest of the user-facing `PENGUIN_*` settings. Those select the *data* an Agent-started harness works against, and the self-development case may legitimately want the same data root — sharing state is a config decision, whereas serving a deployment's code from a workspace checkout never is.

Two things are wrong with that in practice.

**Inheriting is not the decision being made.** It is an accident of where the serving process happens to be pointed. The sentence argues sharing is a config decision, and then lets ambient environment make it.

**It cannot succeed anyway.** Whenever an Agent spawns a command, the harness is by definition up and holding `<root>/server.lock`. A harness the Agent starts on the inherited root exits 3 against a lock whose owner is the process that handed it that root. This is not hypothetical — it is how the bug was found: a shell exporting `PENGUIN_HOME=~/.penguin/data` (the release root, where the desktop app was running) sent `pnpm dev:server` at that same root, and the collision read as a mysterious "another instance is using this data root".

## Sharing still works, stated rather than inherited

The vault is applied after the host environment (`{ ...hostEnvForChild(...), ...this.vault, ...HARDENED_ENV }`), so a `PENGUIN_HOME` set in an Agent's vault reaches its commands unchanged. That is the escape hatch `FORCE_COLOR` already documents, and it turns sharing into the config decision the original comment said it should be.

## Breaking

A command that relied on inheriting either variable now sees neither, and a harness it starts resolves the default root. Nothing on disk changes and no migration runs. To restore the old behaviour for one Agent, add `PENGUIN_HOME` (and `PENGUIN_WEB_DB` if it was set) to that Agent's vault. Recorded in the changelog entry's `## 兼容性` section.

## Verification

- `pnpm -r build`, `pnpm typecheck`, `pnpm format` + `pnpm format:check` — green on Node 24.
- `pnpm test` — green except `packages/server` `test/terminal-stream.test.ts`, the known full-suite-load flake; it passes standalone at 16/16, and this change touches neither the server nor terminal streaming.
- `packages/core/test/exec-session.test.ts` — 26 passed. The existing "harness environment variables never reach a spawned command" case now also asserts `PENGUIN_HOME` and `PENGUIN_WEB_DB` are absent, and a new case asserts the vault puts `PENGUIN_HOME` back, mirroring the `PORT` one directly above it.
- Case-insensitive matching is inherited from the existing strip, so a Windows `set Penguin_Home=…` is removed too — covered by the sibling case already in that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)