### PR TITLE
修复切换项目时会话串入问题

### DIFF
--- a/changelog/unreleased/2026-08-24-project-session-isolation.md
+++ b/changelog/unreleased/2026-08-24-project-session-isolation.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-24
 - **Type:** fix
 - **Scope:** `web`
+- **PR:** [#435](https://github.com/Prism-Shadow/penguin-harness/pull/435)
 
 [中文版](2026-08-24-project-session-isolation.zh.md)
 

--- a/changelog/unreleased/2026-08-24-project-session-isolation.md
+++ b/changelog/unreleased/2026-08-24-project-session-isolation.md
@@ -1,0 +1,14 @@
+# Keep deep-linked Sessions inside their Project
+
+- **Date:** 2026-08-24
+- **Type:** fix
+- **Scope:** `web`
+
+[中文版](2026-08-24-project-session-isolation.zh.md)
+
+The Web App rejected a deep-linked Session when it belonged to a different Project instead of inserting it into the current Project's conversation list.
+
+## Details
+
+- Scoped direct Session lookup results to the currently selected Project.
+- Scoped failed deep-link probes by both Project and Session so a Project switch could not reuse stale probe state.

--- a/changelog/unreleased/2026-08-24-project-session-isolation.zh.md
+++ b/changelog/unreleased/2026-08-24-project-session-isolation.zh.md
@@ -1,0 +1,14 @@
+# 将深链接 Session 限制在所属 Project 内
+
+- **Date:** 2026-08-24
+- **Type:** fix
+- **Scope:** `web`
+
+[English](2026-08-24-project-session-isolation.md)
+
+Web App 在深链接 Session 属于其他 Project 时拒绝载入，而不会再将其插入当前 Project 的对话列表。
+
+## 细节
+
+- 将 Session 直接查询结果限制在当前选择的 Project 内。
+- 以 Project 和 Session 共同标识深链接查询失败状态，避免切换 Project 后复用过期状态。

--- a/changelog/unreleased/2026-08-24-project-session-isolation.zh.md
+++ b/changelog/unreleased/2026-08-24-project-session-isolation.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-24
 - **Type:** fix
 - **Scope:** `web`
+- **PR:** [#435](https://github.com/Prism-Shadow/penguin-harness/pull/435)
 
 [English](2026-08-24-project-session-isolation.md)
 

--- a/packages/web/src/features/chat/chat-page.tsx
+++ b/packages/web/src/features/chat/chat-page.tsx
@@ -90,6 +90,7 @@ import { ChatDropRegion } from "./drop-zone";
 import { ConversationOutline, OutlineMenuButton, useOutlineRailFit } from "./conversation-outline";
 import { DraftView } from "./draft-view";
 import { parkActiveDraft } from "./draft-sessions";
+import { sessionForProject, sessionProbeKey } from "./session-project";
 import { CHAT_DEFAULTS_CHANGED_EVENT, chatDefaultsChangedDetail } from "./chat-defaults-event";
 import { advanceCostStat, applyUsageFetch, createCostStatHold } from "./header-stats";
 import type { CostStatDisplay } from "./header-stats";
@@ -584,9 +585,10 @@ export function ChatPage() {
   // The Session list is paged: a deep-linked Session (old bookmark, cross-page jump) may sit
   // beyond the loaded pages. Look it up directly and insert it before the auto-select effect
   // below concludes it doesn't exist; only a failed probe releases that redirect.
-  const [probeFailedId, setProbeFailedId] = useState<string | null>(null);
+  const probeKey = projectId && routeSessionId ? sessionProbeKey(projectId, routeSessionId) : null;
+  const [probeFailedKey, setProbeFailedKey] = useState<string | null>(null);
   useEffect(() => {
-    if (draft || !routeSessionId || sessionsLoading) return;
+    if (draft || !projectId || !routeSessionId || !probeKey || sessionsLoading) return;
     if (sessions.some((s) => s.sessionId === routeSessionId)) return;
     // We deleted this Session ourselves: the row is gone from the list on purpose, so the
     // lookup below could only 404 (and the server would record that as an error). Deleting
@@ -594,22 +596,34 @@ export function ChatPage() {
     // this path runs on every such delete. Treat it as an already-failed probe, which
     // releases the redirect effect below to move on to another conversation.
     if (isSessionDeleted(routeSessionId)) {
-      setProbeFailedId(routeSessionId);
+      setProbeFailedKey(probeKey);
       return;
     }
     let cancelled = false;
     api.getSession(routeSessionId).then(
       (res) => {
-        if (!cancelled) addSession(res.session);
+        if (cancelled) return;
+        const session = sessionForProject(res.session, projectId);
+        if (session) addSession(session);
+        else setProbeFailedKey(probeKey);
       },
       () => {
-        if (!cancelled) setProbeFailedId(routeSessionId);
+        if (!cancelled) setProbeFailedKey(probeKey);
       },
     );
     return () => {
       cancelled = true;
     };
-  }, [draft, routeSessionId, sessionsLoading, sessions, addSession, isSessionDeleted]);
+  }, [
+    draft,
+    projectId,
+    routeSessionId,
+    probeKey,
+    sessionsLoading,
+    sessions,
+    addSession,
+    isSessionDeleted,
+  ]);
 
   // Auto-select the most recent conversation when the route doesn't select one (newest loaded
   // active/schedule Session — archived rows are hidden by choice and subagent Sessions belong
@@ -619,10 +633,10 @@ export function ChatPage() {
     if (sessionsLoading || draft) return;
     if (routeSessionId && sessions.some((s) => s.sessionId === routeSessionId)) return;
     // A routed id missing from the paged list isn't gone until the direct lookup fails.
-    if (routeSessionId && probeFailedId !== routeSessionId) return;
+    if (routeSessionId && probeFailedKey !== probeKey) return;
     const last = latestConversation(sessions);
     navigate(last ? `/chat/${last.sessionId}` : `/chat/${DRAFT_SESSION_ID}`, { replace: true });
-  }, [sessionsLoading, draft, routeSessionId, probeFailedId, sessions, navigate]);
+  }, [sessionsLoading, draft, routeSessionId, probeKey, probeFailedKey, sessions, navigate]);
 
   // Sync task_state to the sidebar list badge.
   //

--- a/packages/web/src/features/chat/session-project.ts
+++ b/packages/web/src/features/chat/session-project.ts
@@ -1,0 +1,11 @@
+import type { SessionInfo } from "@prismshadow/penguin-server/api";
+
+/** Return a probed Session only when it belongs to the Project currently shown by the UI. */
+export function sessionForProject(session: SessionInfo, projectId: string): SessionInfo | null {
+  return session.projectId === projectId ? session : null;
+}
+
+/** Scope probe failures to a Project as well as a Session so switching Projects cannot reuse one. */
+export function sessionProbeKey(projectId: string, sessionId: string): string {
+  return `${projectId}:${sessionId}`;
+}

--- a/packages/web/test/session-project.test.ts
+++ b/packages/web/test/session-project.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import type { SessionInfo } from "@prismshadow/penguin-server/api";
+import { sessionForProject, sessionProbeKey } from "../src/features/chat/session-project";
+
+const SESSION: SessionInfo = {
+  sessionId: "session-a",
+  projectId: "project-a",
+  agentId: "default_agent",
+  provider: "anthropic",
+  modelId: "claude-sonnet-4",
+  workspace: "/workspace",
+  approvalMode: "allow-all",
+  createdAt: "2026-08-24T00:00:00.000Z",
+  lastActiveAt: "2026-08-24T00:00:00.000Z",
+  status: "idle",
+  pendingApprovalCount: 0,
+  pendingFollowUpCount: 0,
+  hasTrace: true,
+  archived: false,
+};
+
+describe("Session Project isolation", () => {
+  it("accepts a deep-linked Session from the current Project", () => {
+    expect(sessionForProject(SESSION, "project-a")).toBe(SESSION);
+  });
+
+  it("rejects a deep-linked Session from another Project", () => {
+    expect(sessionForProject(SESSION, "project-b")).toBeNull();
+  });
+
+  it("does not reuse a probe failure after switching Projects", () => {
+    expect(sessionProbeKey("project-a", SESSION.sessionId)).not.toBe(
+      sessionProbeKey("project-b", SESSION.sessionId),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Prevent a Session from another Project from being inserted into the currently selected Project's conversation list when switching Projects with an existing `/chat/:sessionId` route.

## Root cause

The Session store is correctly cleared and reloaded by `projectId` when the user switches Projects. However, the browser route can still reference the Session that was open in the previous Project.

The chat page supports deep links to Sessions that are not present in the currently loaded sidebar page. It resolves the routed Session through the global Session endpoint and previously inserted the result into the current Session store without verifying its `projectId`.

This produced the following sequence:

1. Open a Session in Project A.
2. Switch to Project B while the old `/chat/:sessionId` route remains active.
3. Project B correctly loads its own Session list.
4. The deep-link fallback fetches Project A's Session by ID.
5. The fetched Session is inserted into Project B's frontend list.

The database records and workspace files remain Project-scoped, but the UI can display and continue operating on a Session from another Project.

## Changes

- Validate that a directly fetched Session belongs to the currently selected Project before adding it to the Session store.
- Treat a cross-Project Session result as a failed deep-link probe.
- Let the existing navigation logic redirect to the target Project's latest conversation or new-chat page.
- Scope probe failure state by both `projectId` and `sessionId`, preventing stale failure state from being reused after another Project switch.
- Add regression tests covering matching Projects, cross-Project rejection, and Project-scoped probe keys.

## Expected behavior

After switching Projects:

- only Sessions belonging to the selected Project appear in the sidebar;
- a route pointing to another Project's Session is rejected;
- the user is redirected to a valid Session in the selected Project, or to the new-chat page;
- valid deep links within the same Project continue to work.

## Compatibility

No database schema, stored Session data, workspace files, or API contracts are changed. This is a Web App routing and state-isolation fix.

## Verification

- `pnpm --filter @prismshadow/penguin-web test`
  - 94 test files passed
  - 1,241 tests passed
- `pnpm --filter @prismshadow/penguin-web typecheck`
- `pnpm format:check`
- `git diff --check`