### PR TITLE
End a bare URL at the URL, not at the end of the sentence

### DIFF
--- a/changelog/unreleased/2026-08-24-autolink-ends-at-ascii.md
+++ b/changelog/unreleased/2026-08-24-autolink-ends-at-ascii.md
@@ -1,0 +1,29 @@
+# A bare URL ends where the URL ends, not where the sentence does
+
+- **Date:** 2026-08-24
+- **Type:** fix
+- **Scope:** `web`
+- **PR:** [#PLACEHOLDER](https://github.com/Prism-Shadow/penguin-harness/pull/0)
+
+[中文版](2026-08-24-autolink-ends-at-ascii.zh.md)
+
+A URL typed into Chinese prose swallowed whatever followed it. `见 https://penguin.ooo，然后继续`
+linked the comma and the rest of the clause along with the address, so the link 404ed and the
+sentence lost its punctuation to link styling. Markdown surfaces in the Web App now end a bare URL
+at its last ASCII character.
+
+## Details
+
+- GFM's autolink literal ends a bare URL at whitespace, then trims a short list of trailing ASCII
+  punctuation. Neither rule sees CJK, so `，`, `。`, `（）` and plain Chinese text run up against
+  the host were all inside the href. English was never affected — `see https://penguin.ooo, then`
+  already ended correctly.
+- The boundary is the last ASCII character, because a URL is ASCII by RFC 3986; a trailing
+  non-ASCII run is handed back to the paragraph as text.
+- Explicit `[文档](https://…)` links are untouched: the trim applies only to autolinks, where the
+  link text is the URL itself.
+- One shared plugin list now backs all five Markdown renderers — chat messages, both Trace event
+  views, the benchmark case browser and the workspace file preview — so a URL ends in the same
+  place on every surface.
+- A URL carrying *unencoded* CJK in its path is trimmed at the last ASCII character. That form is
+  invalid per the RFC; the same link percent-encoded is untouched.

--- a/changelog/unreleased/2026-08-24-autolink-ends-at-ascii.md
+++ b/changelog/unreleased/2026-08-24-autolink-ends-at-ascii.md
@@ -3,7 +3,7 @@
 - **Date:** 2026-08-24
 - **Type:** fix
 - **Scope:** `web`
-- **PR:** [#PLACEHOLDER](https://github.com/Prism-Shadow/penguin-harness/pull/0)
+- **PR:** [#437](https://github.com/Prism-Shadow/penguin-harness/pull/437)
 
 [中文版](2026-08-24-autolink-ends-at-ascii.zh.md)
 

--- a/changelog/unreleased/2026-08-24-autolink-ends-at-ascii.zh.md
+++ b/changelog/unreleased/2026-08-24-autolink-ends-at-ascii.zh.md
@@ -3,7 +3,7 @@
 - **Date:** 2026-08-24
 - **Type:** fix
 - **Scope:** `web`
-- **PR:** [#PLACEHOLDER](https://github.com/Prism-Shadow/penguin-harness/pull/0)
+- **PR:** [#437](https://github.com/Prism-Shadow/penguin-harness/pull/437)
 
 [English](2026-08-24-autolink-ends-at-ascii.md)
 

--- a/changelog/unreleased/2026-08-24-autolink-ends-at-ascii.zh.md
+++ b/changelog/unreleased/2026-08-24-autolink-ends-at-ascii.zh.md
@@ -1,0 +1,24 @@
+# 裸链接在 URL 结束处终止，而不是在句子结束处
+
+- **Date:** 2026-08-24
+- **Type:** fix
+- **Scope:** `web`
+- **PR:** [#PLACEHOLDER](https://github.com/Prism-Shadow/penguin-harness/pull/0)
+
+[English](2026-08-24-autolink-ends-at-ascii.md)
+
+写在中文行文里的 URL 会把后面的内容一并吞掉：`见 https://penguin.ooo，然后继续` 会把逗号及其后的
+半句话一起链接进去，于是链接 404，句子的标点也被套上了链接样式。Web App 的 Markdown 渲染现在让裸
+链接在最后一个 ASCII 字符处终止。
+
+## 细节
+
+- GFM 的 autolink literal 以空白作为裸链接的终止，再裁掉少量结尾的 ASCII 标点。两条规则都不认识
+  CJK，因此 `，`、`。`、`（）` 以及紧贴主机名的中文文字都留在了 href 里。英文从来不受影响——
+  `see https://penguin.ooo, then` 本就正确终止。
+- 边界取最后一个 ASCII 字符：按 RFC 3986，URL 本就是 ASCII；结尾的非 ASCII 片段会作为文本交还给段落。
+- 显式的 `[文档](https://…)` 链接不受影响：裁剪只作用于链接文字即 URL 本身的 autolink。
+- 五个 Markdown 渲染入口——对话消息、两处 Trace 事件视图、Benchmark 用例浏览器与工作区文件预览——
+  现在共用同一份插件列表，因此裸链接在每个界面上的终止位置一致。
+- 路径中携带**未编码** CJK 的 URL 会在最后一个 ASCII 字符处被截断。该写法本就不符合 RFC；同一链接
+  经百分号编码后不受影响。

--- a/packages/web/src/features/benchmark/benchmark-case-browser.tsx
+++ b/packages/web/src/features/benchmark/benchmark-case-browser.tsx
@@ -7,7 +7,7 @@ import type {
 } from "@prismshadow/penguin-server/api";
 import ReactMarkdown from "react-markdown";
 import type { Components } from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { REMARK_PLUGINS } from "../../lib/remark-autolink-boundary";
 import * as api from "../../api/endpoints";
 import { apiErrorText } from "../../lib/api-error";
 import { joinWorkspacePath } from "../../lib/file-path";
@@ -455,7 +455,7 @@ export function BenchmarkCaseBrowser({ projectId, agentId, benchmarkId, caseSumm
           ) : preview.kind === "md" ? (
             <>
               <div className="md-body text-sm text-gray-800 dark:text-gray-100">
-                <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+                <ReactMarkdown remarkPlugins={REMARK_PLUGINS} components={markdownComponents}>
                   {preview.content ?? ""}
                 </ReactMarkdown>
               </div>

--- a/packages/web/src/features/chat/md.tsx
+++ b/packages/web/src/features/chat/md.tsx
@@ -16,7 +16,7 @@ import { isValidElement, memo } from "react";
 import type { ComponentPropsWithoutRef, ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
 import type { Components, ExtraProps } from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { REMARK_PLUGINS } from "../../lib/remark-autolink-boundary";
 import { CodeBlock } from "./code-block";
 
 /** Flatten a react-markdown code element's children to plain text (string or string array in practice). */
@@ -91,7 +91,7 @@ export const Md = memo(function Md({
 }) {
   return (
     <ReactMarkdown
-      remarkPlugins={[remarkGfm]}
+      remarkPlugins={REMARK_PLUGINS}
       components={streaming ? STREAMING_COMPONENTS : SETTLED_COMPONENTS}
     >
       {text}

--- a/packages/web/src/features/chat/workspace-browser.tsx
+++ b/packages/web/src/features/chat/workspace-browser.tsx
@@ -15,7 +15,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { ChangeEvent } from "react";
 import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { REMARK_PLUGINS } from "../../lib/remark-autolink-boundary";
 import type { SessionInfo, WorkspaceFilesResponse } from "@prismshadow/penguin-server/api";
 import * as api from "../../api/endpoints";
 import { ApiError } from "../../api/client";
@@ -566,7 +566,7 @@ export function WorkspaceBrowser({
             <>
               <div className="md-body text-base leading-relaxed text-gray-800 dark:text-gray-100">
                 <ReactMarkdown
-                  remarkPlugins={[remarkGfm]}
+                  remarkPlugins={REMARK_PLUGINS}
                   components={{
                     // Relative images are resolved against the md file's directory into the file API (otherwise resolving against the app's origin would always 404).
                     img: ({ src, alt }) => (

--- a/packages/web/src/features/traces/trace-event-row.tsx
+++ b/packages/web/src/features/traces/trace-event-row.tsx
@@ -13,7 +13,7 @@
  */
 import { Fragment, useState } from "react";
 import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { REMARK_PLUGINS } from "../../lib/remark-autolink-boundary";
 import { S } from "../../lib/strings";
 import type { OmniMessage } from "@prismshadow/penguin-core/omnimessage";
 import { formatTime, humanizeTokens } from "../../lib/format";
@@ -213,7 +213,7 @@ function SessionMetaBody({ p }: { p: Record<string, unknown> }) {
         <details>
           <summary className={summaryClass}>{S.traces.systemPrompt}</summary>
           <div className="md-body mt-1.5 max-h-96 overflow-auto rounded bg-gray-100 px-2.5 py-2 text-sm leading-relaxed text-gray-700 dark:bg-gray-800/70 dark:text-gray-300">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{prompt}</ReactMarkdown>
+            <ReactMarkdown remarkPlugins={REMARK_PLUGINS}>{prompt}</ReactMarkdown>
           </div>
         </details>
       )}
@@ -316,7 +316,7 @@ function EventBody({ msg }: { msg: OmniMessage }) {
       if (!md.trim()) return <p className="text-xs text-gray-400">—</p>;
       return (
         <div className="md-body text-sm leading-relaxed text-gray-700 dark:text-gray-300">
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>{md}</ReactMarkdown>
+          <ReactMarkdown remarkPlugins={REMARK_PLUGINS}>{md}</ReactMarkdown>
         </div>
       );
     }

--- a/packages/web/src/lib/remark-autolink-boundary.ts
+++ b/packages/web/src/lib/remark-autolink-boundary.ts
@@ -1,0 +1,88 @@
+/**
+ * Ends a bare URL at the last ASCII character.
+ *
+ * GFM's autolink-literal extension ends a bare URL at whitespace, then trims a short list of
+ * trailing ASCII punctuation. Neither rule sees CJK: `见 https://penguin.ooo，然后继续` is not
+ * whitespace-separated after the host, so the comma and the clause after it are swallowed into the
+ * href, which then 404s, and the sentence loses its punctuation to link styling. English is
+ * unaffected — `see https://penguin.ooo, then` already trims correctly — so this only ever fires on
+ * text GFM was not written for.
+ *
+ * A URL is ASCII by RFC 3986; anything outside it belongs percent-encoded. So the boundary is the
+ * last ASCII character, and a trailing non-ASCII run is handed back to the paragraph as text.
+ *
+ * The trade this makes: a URL carrying *unencoded* CJK in its path — `…/wiki/中文` pasted raw
+ * rather than percent-encoded — is trimmed at the last ASCII character. That form is invalid per
+ * the RFC and browsers only accept it by encoding it for you; the same link pasted in its encoded
+ * form is untouched. Explicit `[text](url)` links are never touched at all.
+ */
+import remarkGfm from "remark-gfm";
+
+/**
+ * The mdast shapes this touches, declared structurally rather than pulling `@types/mdast` in as a
+ * dependency for three of them. Anything else on a node passes through untouched.
+ */
+interface TextNode {
+  type: "text";
+  value: string;
+}
+interface LinkNode {
+  type: "link";
+  url: string;
+  children: Node[];
+}
+type Node = TextNode | LinkNode | { type: string; children?: Node[] };
+interface Parent {
+  children: Node[];
+}
+
+/** Trailing characters outside ASCII: never part of a well-formed URL. */
+const TRAILING_NON_ASCII = /[^\x00-\x7F]+$/;
+
+/** True when this link came from autolinking rather than `[text](url)` syntax. */
+function isAutolinkLiteral(node: LinkNode): boolean {
+  if (node.children.length !== 1) return false;
+  const child = node.children[0];
+  if (!child || child.type !== "text") return false;
+  const { value } = child as TextNode;
+  // GFM sets url to the matched text, prefixing `http://` for a bare `www.` match.
+  return node.url === value || node.url === `http://${value}`;
+}
+
+function trimNode(node: LinkNode): TextNode | null {
+  if (!isAutolinkLiteral(node)) return null;
+  const child = node.children[0] as TextNode;
+  const match = TRAILING_NON_ASCII.exec(child.value);
+  if (!match) return null;
+  const kept = child.value.slice(0, match.index);
+  // A "URL" that is non-ASCII all the way to its scheme is not one this should be splitting.
+  if (!kept.includes("://") && !kept.startsWith("www.")) return null;
+  child.value = kept;
+  node.url = node.url.startsWith("http://") && !kept.startsWith("http") ? `http://${kept}` : kept;
+  return { type: "text", value: match[0] };
+}
+
+/** Walks every parent, so a link nested in emphasis or a list item is covered too. */
+function walk(parent: Parent): void {
+  for (let i = 0; i < parent.children.length; i += 1) {
+    const node = parent.children[i]!;
+    if (node.type === "link") {
+      const spill = trimNode(node as LinkNode);
+      if (spill) parent.children.splice(i + 1, 0, spill);
+    }
+    const children = (node as { children?: Node[] }).children;
+    if (Array.isArray(children)) walk(node as Parent);
+  }
+}
+
+/** Runs after remark-gfm, on the tree it produced. */
+export function remarkAutolinkBoundary() {
+  return (tree: Parent): void => walk(tree);
+}
+
+/**
+ * The remark plugin list every Markdown surface uses. Shared so the five renderers cannot drift:
+ * a bare URL has to end at the same place in a chat message, a Trace event, a benchmark case and
+ * a workspace file preview.
+ */
+export const REMARK_PLUGINS = [remarkGfm, remarkAutolinkBoundary];

--- a/packages/web/test/remark-autolink-boundary.test.ts
+++ b/packages/web/test/remark-autolink-boundary.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Where a bare URL ends. GFM's autolink literal stops at whitespace and trims a little ASCII
+ * punctuation, which leaves CJK — the comma, the clause after it, or plain text run up against the
+ * host — inside the href. These pin the boundary at the last ASCII character, and pin the two
+ * things that must not change: explicit links, and URLs that are already fine.
+ */
+import { describe, expect, it } from "vitest";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import ReactMarkdown from "react-markdown";
+import { REMARK_PLUGINS } from "../src/lib/remark-autolink-boundary";
+
+/** The rendered `[href, text]` of the first link, or null. */
+function firstLink(markdown: string): [string, string] | null {
+  const html = renderToStaticMarkup(
+    React.createElement(ReactMarkdown, { remarkPlugins: REMARK_PLUGINS }, markdown),
+  );
+  const m = /<a href="([^"]*)"[^>]*>([^<]*)<\/a>/.exec(html);
+  return m ? [m[1]!, m[2]!] : null;
+}
+
+/** The rendered text of the whole thing, tags stripped — what the reader actually sees. */
+function plainText(markdown: string): string {
+  return renderToStaticMarkup(
+    React.createElement(ReactMarkdown, { remarkPlugins: REMARK_PLUGINS }, markdown),
+  ).replace(/<[^>]*>/g, "");
+}
+
+describe("a bare URL ends at the last ASCII character", () => {
+  it("stops before CJK punctuation, and the punctuation stays in the sentence", () => {
+    expect(firstLink("见 https://penguin.ooo，然后继续")).toEqual([
+      "https://penguin.ooo",
+      "https://penguin.ooo",
+    ]);
+    expect(plainText("见 https://penguin.ooo，然后继续")).toContain("，然后继续");
+  });
+
+  it("stops before CJK text with no punctuation between", () => {
+    expect(firstLink("中文https://penguin.ooo英文")).toEqual([
+      "https://penguin.ooo",
+      "https://penguin.ooo",
+    ]);
+    expect(plainText("中文https://penguin.ooo英文")).toContain("英文");
+  });
+
+  it("stops before a full-width bracket after a path with a query", () => {
+    expect(firstLink("参考 https://penguin.ooo/a/b?c=1（备注）")).toEqual([
+      "https://penguin.ooo/a/b?c=1",
+      "https://penguin.ooo/a/b?c=1",
+    ]);
+  });
+
+  it("stops before a full stop at the end of a sentence", () => {
+    expect(firstLink("见 https://penguin.ooo。")).toEqual([
+      "https://penguin.ooo",
+      "https://penguin.ooo",
+    ]);
+  });
+});
+
+describe("what must not change", () => {
+  it("leaves English alone — GFM already ends those correctly", () => {
+    expect(firstLink("see https://penguin.ooo, then")).toEqual([
+      "https://penguin.ooo",
+      "https://penguin.ooo",
+    ]);
+    expect(firstLink("docs at https://penguin.ooo/docs work")).toEqual([
+      "https://penguin.ooo/docs",
+      "https://penguin.ooo/docs",
+    ]);
+  });
+
+  it("leaves an explicit link's CJK text alone", () => {
+    // The trim applies to autolinks only; here the CJK *is* the link text the author wrote.
+    expect(firstLink("[中文文档](https://penguin.ooo/docs)")).toEqual([
+      "https://penguin.ooo/docs",
+      "中文文档",
+    ]);
+  });
+
+  it("leaves a percent-encoded path alone, CJK or not", () => {
+    expect(firstLink("见 https://penguin.ooo/wiki/%E4%B8%AD%E6%96%87 完")).toEqual([
+      "https://penguin.ooo/wiki/%E4%B8%AD%E6%96%87",
+      "https://penguin.ooo/wiki/%E4%B8%AD%E6%96%87",
+    ]);
+  });
+
+  it("keeps a bare www. autolink working, prefix and all", () => {
+    expect(firstLink("见 www.penguin.ooo，好")).toEqual([
+      "http://www.penguin.ooo",
+      "www.penguin.ooo",
+    ]);
+  });
+});


### PR DESCRIPTION
## The bug

A URL typed into Chinese prose swallows whatever follows it. Rendered through the app's Markdown pipeline before this change:

| input | resulting `href` |
| --- | --- |
| `见 https://penguin.ooo，然后继续` | `https://penguin.ooo%EF%BC%8C%E7%84%B6%E5%90%8E%E7%BB%A7%E7%BB%AD` |
| `见 https://penguin.ooo。` | `https://penguin.ooo%E3%80%82` |
| `中文https://penguin.ooo英文` | `https://penguin.ooo%E8%8B%B1%E6%96%87` |
| `see https://penguin.ooo, then` | `https://penguin.ooo` ✓ |

Two things break at once: the link 404s, and the sentence loses its punctuation and following words to link styling.

GFM's autolink literal ends a bare URL at whitespace, then trims a short list of trailing ASCII punctuation. Neither rule sees CJK, so a comma that is not whitespace-separated from the host stays inside the URL. English was never affected, which is why this survived.

## The fix

A small remark plugin running after `remark-gfm` ends a bare URL at its **last ASCII character** and hands the trailing non-ASCII run back to the paragraph as text. A URL is ASCII by RFC 3986; anything outside it belongs percent-encoded.

Only autolink literals are touched — recognised by the link having a single text child equal to its own URL (with GFM's `http://` prefix allowed for bare `www.` matches). An explicit `[中文文档](https://…)` keeps its Chinese link text.

The five Markdown renderers now share one plugin list, so a URL cannot end in one place in a chat message and somewhere else in a Trace event: `md.tsx`, both `trace-event-row.tsx` sites, `benchmark-case-browser.tsx`, `workspace-browser.tsx`.

## The trade

A URL carrying **unencoded** CJK in its path — `…/wiki/中文` pasted raw rather than percent-encoded — is now trimmed at the last ASCII character. That form is invalid per RFC 3986 and browsers only accept it by encoding it for you; the same link in its encoded form is untouched, and there is a test pinning that. If unencoded-CJK URLs turn out to matter more than the reported bug, the rule can be narrowed to CJK punctuation only, at the cost of leaving `https://penguin.ooo英文` broken.

## Scope

`packages/web` only. `packages/landing` and `packages/docs` render Markdown with the same GFM behaviour and have the same latent issue, but their content is authored and reviewed rather than written by users and models, and a scan of both content trees found no live instances. Left out deliberately rather than missed.

## Verification

- `pnpm -r build`, `pnpm typecheck`, `pnpm test`, `pnpm format` + `pnpm format:check` — green on Node 24. 938 core / 911 server / 292 cli / 1249 web / 100 desktop.
- New `packages/web/test/remark-autolink-boundary.test.ts` — 8 cases rendered through the real `react-markdown` + plugin pipeline, asserting both the `href` and the visible text: CJK comma, CJK text with no separator, full-width brackets after a query string, sentence-final `。`, and four that must not change — English (already correct), an explicit link's Chinese text, a percent-encoded path, and a bare `www.` autolink keeping its `http://` prefix.
- The before-table above was produced by rendering those same inputs on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)