### PR TITLE
feat: new agents initialize from a snapshot package; exported packages selectable in the import picker

### DIFF
--- a/changelog/unreleased/2026-08-24-agent-snapshot-create.md
+++ b/changelog/unreleased/2026-08-24-agent-snapshot-create.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-24
 - **Type:** feature
 - **Scope:** `server`, `web`, `docs`
+- **PR:** [#441](https://github.com/Prism-Shadow/penguin-harness/pull/441)
 
 [中文版](2026-08-24-agent-snapshot-create.zh.md)
 

--- a/changelog/unreleased/2026-08-24-agent-snapshot-create.md
+++ b/changelog/unreleased/2026-08-24-agent-snapshot-create.md
@@ -1,0 +1,42 @@
+# New agents start from a snapshot package, and exported packages are selectable again
+
+- **Date:** 2026-08-24
+- **Type:** feature
+- **Scope:** `server`, `web`, `docs`
+
+[中文版](2026-08-24-agent-snapshot-create.zh.md)
+
+Two changes to Agent State snapshot transfer. The create dialog can now initialize a new
+agent straight from an exported snapshot package, instead of the round-trip of creating an
+empty agent and then importing into it. And the import file picker no longer grays out the
+very files the export produces.
+
+## Create from a snapshot
+
+The Agents page's create dialog gains an optional **Initialize from a snapshot** field:
+pick an exported package (`<agentId>-v<n>.tar.gz`) and the new agent is created with the
+package's Agent State — its version, prompt, tools, skills, schedules and memory. The id
+field is prefilled from the package name while still empty (editable as usual).
+
+- `POST /api/projects/:projectId/agents` takes an optional `dataBase64` (the same 14MB
+  package the import endpoint takes). Creating from a package needs no version
+  confirmation and takes no pre-import snapshot: both guards protect existing State, and a
+  fresh agent has none.
+- Explicit `name` / `description` override the package's values; left empty they keep the
+  package's own (no id fallback — the package is the identity being copied in).
+- Mutually exclusive with skill seeding (`skills` / `skillsDirectory`): the package
+  carries its own skills, the server rejects the combination (`snapshot_with_skills`),
+  and the dialog hides the skill fields once a package is picked.
+- An invalid package fails the whole creation and leaves no empty agent behind — the id
+  is immediately reusable.
+- Permission follows creation (any project member): the owner-only rule on import guards
+  overwriting an existing agent's State, which creating from a package never does.
+
+## Import picker fix
+
+The settings page's import control declared `accept=".tar.gz,.tgz"` only. macOS pickers
+(Safari, and the desktop shell's native dialog) map accept extensions to UTIs, and the
+double-dot `.tar.gz` maps to nothing — so exported `<agentId>-v<n>.tar.gz` files showed up
+grayed out and unselectable. Both snapshot pickers now also declare
+`application/gzip` / `application/x-gzip` and a bare `.gz`; the server validates package
+structure anyway, so the wider net admits nothing it cannot reject.

--- a/changelog/unreleased/2026-08-24-agent-snapshot-create.zh.md
+++ b/changelog/unreleased/2026-08-24-agent-snapshot-create.zh.md
@@ -1,0 +1,36 @@
+# 新建 Agent 可从快照包直接初始化，导出的包也重新可选了
+
+- **Date:** 2026-08-24
+- **Type:** feature
+- **Scope:** `server`, `web`, `docs`
+
+[English](2026-08-24-agent-snapshot-create.md)
+
+围绕 Agent State 快照搬运的两个改动。创建弹窗现在可以直接从导出的快照包初始化新
+Agent，不必再「先建空 Agent、再导入覆盖」绕一圈；导入的文件选择器也不再把导出产物
+置灰。
+
+## 从快照新建
+
+智能体页的创建弹窗新增可选的「**从快照初始化**」字段：选中导出的包
+（`<agentId>-v<n>.tar.gz`），新 Agent 即以包内 Agent State 创建——版本、提示词、
+工具、技能、定时任务与记忆一并到位。id 字段留空时按包文件名预填（照常可改）。
+
+- `POST /api/projects/:projectId/agents` 接受可选 `dataBase64`（与导入端点同一份
+  14MB 上限的包）。从包新建无需版本确认、也不做导入前补快照：这两道防线守的都是
+  既有 State，新 Agent 没有可保护的状态。
+- 显式填写的 `name` / `description` 覆盖包内值；留空则沿用包内（不再以 id 兜底
+  ——包本身就是被复制进来的身份）。
+- 与技能播种（`skills` / `skillsDirectory`）互斥：包自带技能，服务端对同给拒绝
+  （`snapshot_with_skills`），弹窗侧选中包后隐藏技能字段。
+- 包非法则创建整体失败、不留下空 Agent——该 id 可立即重试。
+- 权限沿用创建（任意项目成员）：导入仅 owner 的约束守的是覆盖既有 Agent State，
+  从包新建不覆盖任何人的工作。
+
+## 导入选择器修复
+
+设置页的导入控件此前只声明 `accept=".tar.gz,.tgz"`。macOS 系选择器（Safari 与桌面
+壳的原生对话框）按 UTI 映射扩展名，双点的 `.tar.gz` 映射不到任何类型——导出的
+`<agentId>-v<n>.tar.gz` 在选择器里被置灰、无法选中。两处快照选择器现在同时声明
+`application/gzip` / `application/x-gzip` 与裸 `.gz`；服务端本就校验包结构，前端
+放宽不会放进任何它拒绝不了的东西。

--- a/changelog/unreleased/2026-08-24-agent-snapshot-create.zh.md
+++ b/changelog/unreleased/2026-08-24-agent-snapshot-create.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-24
 - **Type:** feature
 - **Scope:** `server`, `web`, `docs`
+- **PR:** [#441](https://github.com/Prism-Shadow/penguin-harness/pull/441)
 
 [English](2026-08-24-agent-snapshot-create.md)
 

--- a/packages/docs/content/self-improvement.en.md
+++ b/packages/docs/content/self-improvement.en.md
@@ -66,7 +66,7 @@ The built-in `default_agent` ships with an example Benchmark (`packages/core/src
 
 ## Snapshots and versions
 
-Before each optimization round, the Agent State is packed into `snapshots/v<version>.tar.gz` (excluding the Vault — secrets never enter a snapshot). The `version` in `system_config.yaml` increments on successful optimization. The Web UI supports exporting and importing snapshots; importing a version not higher than the current one requires explicit confirmation.
+Before each optimization round, the Agent State is packed into `snapshots/v<version>.tar.gz` (excluding the Vault — secrets never enter a snapshot). The `version` in `system_config.yaml` increments on successful optimization. The Web UI supports exporting and importing snapshots; importing a version not higher than the current one requires explicit confirmation. A new Agent can also be created straight from an exported package in the Agents page's create dialog: it starts with the package's state and version, no confirmation needed.
 
 ## Auditable end to end
 

--- a/packages/docs/content/self-improvement.zh.md
+++ b/packages/docs/content/self-improvement.zh.md
@@ -66,7 +66,7 @@ benchmarks/<id>/
 
 ## Snapshot 与版本
 
-每轮优化前，Agent State 被打包为 `snapshots/v<version>.tar.gz`（Vault 除外——密钥永不进入快照）。`system_config.yaml` 的 `version` 在优化成功后自增。Web UI 支持导出与导入快照，导入版本不高于当前版本时需要显式确认。
+每轮优化前，Agent State 被打包为 `snapshots/v<version>.tar.gz`（Vault 除外——密钥永不进入快照）。`system_config.yaml` 的 `version` 在优化成功后自增。Web UI 支持导出与导入快照，导入版本不高于当前版本时需要显式确认。也可以在智能体页的创建弹窗里直接从导出的快照包新建 Agent：新 Agent 以包内状态与版本创建，无需确认。
 
 ## 全程可审计
 

--- a/packages/docs/content/web-app.en.md
+++ b/packages/docs/content/web-app.en.md
@@ -84,7 +84,7 @@ The files panel browses the Workspace tree, previews files (Markdown / HTML rend
 
 ## Agent Management (/agents)
 
-The list page creates and deletes Agents; clicking through opens the `/agents/:agentId` settings page, organized into tabs:
+The list page creates and deletes Agents — the create dialog can initialize the new agent from an exported Agent State snapshot package (name and description left empty keep the package's values, and skill picking is unavailable then, since the package carries its own skills) — and clicking through opens the `/agents/:agentId` settings page, organized into tabs:
 
 | Tab | Contents |
 | --- | --- |

--- a/packages/docs/content/web-app.zh.md
+++ b/packages/docs/content/web-app.zh.md
@@ -83,7 +83,7 @@ penguin web
 
 ## Agent 管理（/agents）
 
-列表页支持创建与删除 Agent；点击进入 `/agents/:agentId` 设置页，按标签页组织：
+列表页支持创建与删除 Agent——创建弹窗可选从导出的 Agent State 快照包直接初始化（名称与描述留空沿用包内值；此时技能选择不可用，包自带技能）；点击进入 `/agents/:agentId` 设置页，按标签页组织：
 
 | 标签页 | 内容 |
 | --- | --- |

--- a/packages/server/src/api/types.ts
+++ b/packages/server/src/api/types.ts
@@ -789,6 +789,13 @@ export interface AgentCreateRequest {
    */
   skillsDirectory?: string;
   directorySkills?: string[];
+  /**
+   * Base64 of an exported Agent State snapshot package (`.tar.gz`): the new Agent is
+   * initialized from the package instead of the default template. Mutually exclusive with
+   * skill seeding (`skills` / `skillsDirectory`) — the package carries its own skills.
+   * Explicit `name` / `description` override the package's values; absent ones keep them.
+   */
+  dataBase64?: string;
 }
 
 export interface AgentCreateResponse {

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -550,7 +550,8 @@ export function buildAppDeps(
 
   const projectConfigService = new ProjectConfigService(config.root);
   const agentConfigService = new AgentConfigService(config.root);
-  const agentService = new AgentService(config.root, agentsRepo, agentConfigService);
+  const snapshots = new SnapshotService(config.root);
+  const agentService = new AgentService(config.root, agentsRepo, agentConfigService, snapshots);
   const memoryService = new MemoryService(config.root, agentConfigService);
   // Session-origin registry: session_meta is the single source of truth (no DB column);
   // shared by the manager (subagent registration), the loader (self-heal rebuild),
@@ -572,7 +573,6 @@ export function buildAppDeps(
   // smaller scale: a push invalidates open previews, and a preview is one reload away.)
   const previewTokens = createPreviewTokenSigner();
   const benchmarks = new BenchmarkService(config.root, workspaceFiles);
-  const snapshots = new SnapshotService(config.root);
   const usageService = new UsageService(
     usageRepo,
     errorsRepo,

--- a/packages/server/src/http/routes/agent-transfer.ts
+++ b/packages/server/src/http/routes/agent-transfer.ts
@@ -13,6 +13,24 @@ import { badRequest, readJson, requireString, requireValidId } from "../validate
 /** Import archive size cap: aligned with the global request body limit (stays within 20MB after base64). */
 const MAX_ARCHIVE_BYTES = 14 * 1024 * 1024;
 
+/**
+ * Decodes a request body's `dataBase64` snapshot package into a Buffer, enforcing the
+ * archive cap. Shared by the import route and agent creation's snapshot seed.
+ */
+export function readArchiveBase64(body: Record<string, unknown>): Buffer {
+  const dataBase64 = requireString(body, "dataBase64", { minLen: 1, maxLen: 20 * 1024 * 1024 });
+  let archive: Buffer;
+  try {
+    archive = Buffer.from(dataBase64, "base64");
+  } catch {
+    throw badRequest("dataBase64 is not valid base64.");
+  }
+  if (archive.byteLength === 0) throw badRequest("Import package is empty.");
+  if (archive.byteLength > MAX_ARCHIVE_BYTES)
+    throw badRequest("Import package exceeds the 14MB limit.");
+  return archive;
+}
+
 export function agentTransferRoutes(deps: AppDeps): Hono<AppEnv> {
   const app = new Hono<AppEnv>();
 
@@ -36,18 +54,11 @@ export function agentTransferRoutes(deps: AppDeps): Hono<AppEnv> {
     deps.projectService.requireProjectOwner(c.var.user.userId, projectId);
     await deps.agentConfigService.requireExists(projectId, agentId);
     const body = await readJson(c);
-    const dataBase64 = requireString(body, "dataBase64", { minLen: 1, maxLen: 20 * 1024 * 1024 });
+    const archive = readArchiveBase64(body);
     const confirm = body.confirm === true;
-    let archive: Buffer;
-    try {
-      archive = Buffer.from(dataBase64, "base64");
-    } catch {
-      throw badRequest("dataBase64 is not valid base64.");
-    }
-    if (archive.byteLength === 0) throw badRequest("Import package is empty.");
-    if (archive.byteLength > MAX_ARCHIVE_BYTES)
-      throw badRequest("Import package exceeds the 14MB limit.");
-    const { version } = await deps.snapshots.importArchive(projectId, agentId, archive, confirm);
+    const { version } = await deps.snapshots.importArchive(projectId, agentId, archive, {
+      confirm,
+    });
     const res: AgentImportResponse = { version };
     return c.json(res);
   });

--- a/packages/server/src/http/routes/agents.ts
+++ b/packages/server/src/http/routes/agents.ts
@@ -17,6 +17,7 @@ import {
   requireString,
   requireValidId,
 } from "../validate.js";
+import { readArchiveBase64 } from "./agent-transfer.js";
 import type { AppDeps } from "../../app.js";
 
 /** Window size in days for the card's activity sparkline (last 30 days, including today). */
@@ -79,6 +80,9 @@ export function agentsRoutes(deps: AppDeps): Hono<AppEnv> {
       // process's cwd instead of being rejected.
       directory = { path: await requireProjectDir(skillsDirectory), names: directorySkills };
     }
+    // Optional snapshot seed: the new Agent starts from an exported package instead of the
+    // default template (the service rejects combining it with skill seeding).
+    const archive = body.dataBase64 === undefined ? undefined : readArchiveBase64(body);
     const item = await deps.agentService.createAgent(
       projectId,
       agentId,
@@ -86,6 +90,7 @@ export function agentsRoutes(deps: AppDeps): Hono<AppEnv> {
       description,
       skills,
       directory,
+      archive,
     );
     const agent: AgentSummary = {
       ...item,

--- a/packages/server/src/services/agent-service.ts
+++ b/packages/server/src/services/agent-service.ts
@@ -30,6 +30,7 @@ import {
 import type { AgentsRepo } from "../db/repos/agents.js";
 import { SEMANTIC_ID_PATTERN, SEMANTIC_ID_RULE } from "./ids.js";
 import type { AgentConfigService } from "./agent-config-service.js";
+import type { SnapshotService } from "./snapshot-service.js";
 import { isTopicFileName } from "./memory-service.js";
 import { resolveLibrarySkills } from "./skill-library.js";
 import { resolveDirectorySkills } from "./directory-skills.js";
@@ -62,6 +63,7 @@ export class AgentService {
     private readonly root: string,
     private readonly agents: AgentsRepo,
     private readonly agentConfig: AgentConfigService,
+    private readonly snapshots: SnapshotService,
   ) {}
 
   /** Union of DB index ∪ directory scan; unmanaged directory Agents are backfilled into the DB. */
@@ -239,6 +241,12 @@ export class AgentService {
    * `installSkill` writer the Skills tab uses, inside the same cleanup window as the rest of
    * initialization, so an Agent never survives with only part of its picked set. They are
    * resolved before anything is created, so an unknown name creates no directory at all.
+   *
+   * `archive` is an exported Agent State snapshot package: the fresh Agent is seeded from
+   * it instead of the default template (explicit name/description override the package's
+   * values, absent ones keep them — no id fallback). Mutually exclusive with skill seeding:
+   * the package carries its own skills. An invalid package fails the whole creation inside
+   * the same cleanup window, leaving no empty Agent behind.
    */
   async createAgent(
     projectId: string,
@@ -247,12 +255,20 @@ export class AgentService {
     description?: string,
     skillNames?: readonly string[],
     directory?: { path: string; names: readonly string[] },
+    archive?: Buffer,
   ): Promise<AgentListItem> {
     if (!SEMANTIC_ID_PATTERN.test(agentId)) {
       throw new HttpError(
         400,
         "invalid_agent_id",
         `Agent id must be 2–64 characters: ${SEMANTIC_ID_RULE}.`,
+      );
+    }
+    if (archive !== undefined && (skillNames?.length || directory)) {
+      throw new HttpError(
+        400,
+        "snapshot_with_skills",
+        "Snapshot initialization and skill seeding are mutually exclusive: the package carries its own skills.",
       );
     }
     const taken =
@@ -276,9 +292,29 @@ export class AgentService {
     const seedSkills = [...librarySeed, ...directorySeed];
     await coreCreateAgent({ root: this.root, projectId, agentId });
     try {
-      await this.agentConfig.updateConfig(projectId, agentId, {
-        config: { name: displayName, ...(description !== undefined ? { description } : {}) },
-      });
+      if (archive !== undefined) {
+        // Seed the fresh state from the snapshot package. No pre-import snapshot and no
+        // version confirmation: both guards protect existing State, and this Agent has
+        // none yet — its template state is not worth preserving.
+        await this.snapshots.importArchive(projectId, agentId, archive, {
+          confirm: true,
+          preSnapshot: false,
+        });
+        // Explicit name/description override the package's values; absent ones keep them.
+        // No id fallback here: the package is the identity being copied in.
+        if (name !== undefined || description !== undefined) {
+          await this.agentConfig.updateConfig(projectId, agentId, {
+            config: {
+              ...(name !== undefined ? { name } : {}),
+              ...(description !== undefined ? { description } : {}),
+            },
+          });
+        }
+      } else {
+        await this.agentConfig.updateConfig(projectId, agentId, {
+          config: { name: displayName, ...(description !== undefined ? { description } : {}) },
+        });
+      }
       for (const skill of seedSkills) {
         await installSkill(this.root, projectId, agentId, skill);
       }
@@ -292,22 +328,27 @@ export class AgentService {
     }
     const createdAt = new Date().toISOString();
     this.agents.insertOrIgnore({ projectId, agentId, createdAt });
-    // The init template ships with a default toolset and version number; read back the actual values.
+    // Read back the actual values: the init template ships a default toolset and version
+    // number, and a snapshot seed brings the package's own name, description, version,
+    // skills, schedules and memory.
     const meta = await this.agentConfig.readCardMeta(projectId, agentId);
+    const cardName = archive !== undefined ? (meta.name ?? agentId) : displayName;
+    const cardDescription = archive !== undefined ? meta.description : description;
     return {
       agentId,
-      name: displayName,
-      ...(description !== undefined ? { description } : {}),
+      name: cardName,
+      ...(cardDescription !== undefined ? { description: cardDescription } : {}),
       createdAt,
       updatedAt: createdAt,
       toolCount: meta.toolCount,
       version: meta.version,
       kernelOutdated: meta.kernelOutdated,
+      // The vault never travels in a snapshot, so this is 0 either way; the other counts
+      // are real reads because a package may carry any of them.
       vaultKeyCount: 0,
-      scheduleCount: 0,
-      // Read the real count: coreCreateAgent seeds the default skill set for default_agent.
+      scheduleCount: await this.scheduleCount(projectId, agentId),
       skillCount: await this.skillCount(projectId, agentId),
-      memoryCount: 0,
+      memoryCount: await this.memoryCount(projectId, agentId),
     };
   }
 }

--- a/packages/server/src/services/snapshot-service.ts
+++ b/packages/server/src/services/snapshot-service.ts
@@ -94,12 +94,17 @@ export class SnapshotService {
    * (higher than current imports directly, same version or older requires
    * `confirm`), automatically snapshots the current version before import, then
    * replaces `agent_state/` while keeping the current vault.
+   *
+   * `preSnapshot: false` skips the automatic pre-import snapshot — for seeding a
+   * freshly created Agent, whose template state is not worth preserving (its
+   * caller passes `confirm: true` for the same reason: both guards protect
+   * existing State, and a fresh Agent has none).
    */
   async importArchive(
     projectId: string,
     agentId: string,
     archive: Buffer,
-    confirm: boolean,
+    opts: { confirm: boolean; preSnapshot?: boolean },
   ): Promise<{ version: number }> {
     const current = await this.currentVersion(projectId, agentId);
     const base = agentDir(this.root, projectId, agentId);
@@ -145,7 +150,7 @@ export class SnapshotService {
       const incoming = agentStateVersion({
         version: typeof incomingRaw === "number" ? incomingRaw : undefined,
       });
-      if (incoming <= current && !confirm) {
+      if (incoming <= current && !opts.confirm) {
         throw new HttpError(
           409,
           "version_conflict",
@@ -154,7 +159,7 @@ export class SnapshotService {
       }
 
       // Automatically snapshots the current version before import (reused if one already exists for that version), so a mistaken import can be rolled back.
-      await this.ensureSnapshot(projectId, agentId);
+      if (opts.preSnapshot !== false) await this.ensureSnapshot(projectId, agentId);
 
       // Replace agent_state: first merge the current vault into the staging
       // directory to be swapped in (extraction already filtered out any vault

--- a/packages/server/test/agent-transfer.test.ts
+++ b/packages/server/test/agent-transfer.test.ts
@@ -10,7 +10,9 @@ import * as tar from "tar";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { agentStateDir, snapshotsDir } from "@prismshadow/penguin-core";
 import type {
+  AgentCreateResponse,
   AgentImportResponse,
+  AgentsResponse,
   ProjectCreateResponse,
   VaultResponse,
 } from "../src/api/types.js";
@@ -127,5 +129,83 @@ describe("agent export/import", () => {
 
     const vault = (await (await owner.get(`${base}/vault`)).json()) as VaultResponse;
     expect(vault.entries.map((e) => e.key)).toEqual(["TOKEN"]);
+  });
+
+  it("creates a new agent from an exported package: state, name and version come from it", async () => {
+    // Give the source agent a distinct name/description/version and a state marker, then export.
+    expect(
+      (
+        await owner.put(`${base}/config`, {
+          config: { name: "Tuned Agent", description: "Tuned description" },
+        })
+      ).status,
+    ).toBe(200);
+    const configPath = path.join(
+      agentStateDir(t.root, projectId, "default_agent"),
+      "system_config.yaml",
+    );
+    const yaml = await fs.readFile(configPath, "utf8");
+    await fs.writeFile(configPath, yaml.replace(/^version: .*$/m, "version: 3"), "utf8");
+    const marker = path.join(agentStateDir(t.root, projectId, "default_agent"), "marker.txt");
+    await fs.writeFile(marker, "seeded", "utf8");
+    const archive = Buffer.from(await (await owner.get(`${base}/export`)).arrayBuffer());
+
+    // Members can create from a package: creating overwrites nothing, unlike import.
+    const created = await member.post(`/api/projects/${projectId}/agents`, {
+      agentId: "cloned_agent",
+      dataBase64: archive.toString("base64"),
+    });
+    expect(created.status).toBe(201);
+    const summary = ((await created.json()) as AgentCreateResponse).agent;
+    // Name, description and version come from the package (no id fallback for the name).
+    expect(summary.name).toBe("Tuned Agent");
+    expect(summary.description).toBe("Tuned description");
+    expect(summary.version).toBe(3);
+
+    // The package's state landed, and no pre-import snapshot of the template state was taken.
+    const clonedMarker = path.join(agentStateDir(t.root, projectId, "cloned_agent"), "marker.txt");
+    await expect(fs.readFile(clonedMarker, "utf8")).resolves.toBe("seeded");
+    await expect(fs.access(snapshotsDir(t.root, projectId, "cloned_agent"))).rejects.toThrow();
+  });
+
+  it("explicit name/description override the package's values on create", async () => {
+    const archive = Buffer.from(await (await owner.get(`${base}/export`)).arrayBuffer());
+    const created = await owner.post(`/api/projects/${projectId}/agents`, {
+      agentId: "renamed_agent",
+      name: "Renamed",
+      dataBase64: archive.toString("base64"),
+    });
+    expect(created.status).toBe(201);
+    const summary = ((await created.json()) as AgentCreateResponse).agent;
+    expect(summary.name).toBe("Renamed");
+  });
+
+  it("an invalid package fails the whole creation and leaves no agent behind", async () => {
+    const res = await owner.post(`/api/projects/${projectId}/agents`, {
+      agentId: "broken_agent",
+      dataBase64: Buffer.from("junk").toString("base64"),
+    });
+    expect(res.status).toBe(400);
+    const list = (await (
+      await owner.get(`/api/projects/${projectId}/agents`)
+    ).json()) as AgentsResponse;
+    expect(list.agents.map((a) => a.agentId)).not.toContain("broken_agent");
+    // The id is immediately reusable: the failed creation left no orphaned directory.
+    expect(
+      (await owner.post(`/api/projects/${projectId}/agents`, { agentId: "broken_agent" })).status,
+    ).toBe(201);
+  });
+
+  it("snapshot initialization and skill seeding are mutually exclusive", async () => {
+    const archive = Buffer.from(await (await owner.get(`${base}/export`)).arrayBuffer());
+    const res = await owner.post(`/api/projects/${projectId}/agents`, {
+      agentId: "mixed_agent",
+      skills: ["anything"],
+      dataBase64: archive.toString("base64"),
+    });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      "snapshot_with_skills",
+    );
   });
 });

--- a/packages/web/src/components/ui/hidden-file-input.tsx
+++ b/packages/web/src/components/ui/hidden-file-input.tsx
@@ -9,16 +9,21 @@
  * initial containing block, so a control sitting past the fold added document-level
  * scrollable overflow and a second scrollbar.
  *
- * Hence the wrapper: it is `relative`, so the containing block travels **with the control**
- * instead of depending on whichever ancestor happens to be positioned. The wrapper is
- * `contents`-free on purpose — it is a real box, but an empty inline one with an absolutely
- * positioned child, so it contributes no width and no height to the label around it.
+ * Hence the wrapper: it is positioned (`absolute`), so the containing block travels **with
+ * the control** instead of depending on whichever ancestor happens to be positioned. The
+ * wrapper is `contents`-free on purpose — it must be a real box to be a containing block.
+ *
+ * `absolute` rather than `relative`: with auto offsets and a clipped 0-size child it still
+ * renders at its static position inside the label, but it is **out of flow** — an in-flow
+ * zero-width wrapper counts as a flex item in the `inline-flex gap-*` labels that host every
+ * one of these controls, and the gap slot in front of the text pushed the label text a full
+ * gap off center.
  */
 import type { InputHTMLAttributes } from "react";
 
 export function HiddenFileInput(props: Omit<InputHTMLAttributes<HTMLInputElement>, "type">) {
   return (
-    <span className="relative">
+    <span className="absolute">
       <input type="file" className="sr-only" {...props} />
     </span>
   );

--- a/packages/web/src/features/agents/agent-settings-page.tsx
+++ b/packages/web/src/features/agents/agent-settings-page.tsx
@@ -44,6 +44,7 @@ import { kernelTabLabel } from "./kernel-labels";
 import { VaultTab } from "./vault-tab";
 import { SchedulesTab } from "./schedules-tab";
 import { McpServersSection } from "./mcp-servers-section";
+import { SNAPSHOT_ACCEPT, SNAPSHOT_BUTTON_CLASS, fileToBase64 } from "./snapshot-file";
 import { thinkingLevelOptionsFor } from "../chat/thinking-level";
 import { InfoPopover } from "../../components/ui/info-popover";
 import { ICON_SIZE } from "../../lib/icon-scale";
@@ -280,13 +281,6 @@ export function AgentSettingsPage() {
 
 type SaveFn = (update: AgentConfigUpdateRequest) => Promise<void>;
 
-/** <a download>/<label> version of the button look (matches Button secondary sm; the Button component only renders <button>). */
-const TRANSFER_BUTTON_CLASS =
-  "inline-flex cursor-pointer items-center justify-center gap-1 rounded-md border border-gray-300 " +
-  "bg-white px-2.5 py-1 text-xs font-medium text-gray-800 transition-colors duration-150 " +
-  "hover:bg-gray-50 focus-within:ring-2 focus-within:ring-gray-400/30 " +
-  "dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:hover:bg-gray-800";
-
 /** Kernel-outdated hint icon (rotate-cw, 24×24 line path — the skill library's update glyph). */
 const KERNEL_UPDATE_ICON = "M23 4v6h-6M20.49 15a9 9 0 1 1-2.12-9.36L23 10";
 
@@ -393,13 +387,10 @@ function OverviewTab({
     e.target.value = "";
     if (!file) return;
     setImportError(null);
-    const reader = new FileReader();
-    reader.onload = () => {
-      const url = reader.result as string;
-      void runImport(url.slice(url.indexOf(",") + 1), false); // strip the data:...;base64, prefix
-    };
-    reader.onerror = () => setImportError(S.common.unknownError);
-    reader.readAsDataURL(file);
+    fileToBase64(file).then(
+      (dataBase64) => void runImport(dataBase64, false),
+      () => setImportError(S.common.unknownError),
+    );
   };
 
   return (
@@ -439,16 +430,20 @@ function OverviewTab({
               <a
                 href={api.agentExportUrl(projectId, agentId)}
                 download
-                className={TRANSFER_BUTTON_CLASS}
+                className={SNAPSHOT_BUTTON_CLASS}
               >
                 {S.agent.exportSnapshot}
               </a>
             )}
             {isOwner && (
               <label
-                className={`${TRANSFER_BUTTON_CLASS} ${importing ? "pointer-events-none opacity-60" : ""}`}
+                className={`${SNAPSHOT_BUTTON_CLASS} ${importing ? "pointer-events-none opacity-60" : ""}`}
               >
-                <HiddenFileInput accept=".tar.gz,.tgz" disabled={importing} onChange={onPickFile} />
+                <HiddenFileInput
+                  accept={SNAPSHOT_ACCEPT}
+                  disabled={importing}
+                  onChange={onPickFile}
+                />
                 {importing ? S.agent.importing : S.agent.importSnapshot}
               </label>
             )}

--- a/packages/web/src/features/agents/agents-page.tsx
+++ b/packages/web/src/features/agents/agents-page.tsx
@@ -17,6 +17,7 @@
  * all / select none. A plain new Agent otherwise starts with none.
  */
 import { useEffect, useRef, useState } from "react";
+import type { ChangeEvent } from "react";
 import { useLocation, useNavigate } from "react-router";
 import type { SkillMetadataItem } from "@prismshadow/penguin-server/api";
 import * as api from "../../api/endpoints";
@@ -44,6 +45,14 @@ import { STAT_ICONS } from "../../lib/stat-icons";
 import { DRAFT_SESSION_ID } from "../chat/chat-page";
 import { parkActiveDraft } from "../chat/draft-sessions";
 import { ActivitySparkline } from "./activity-sparkline";
+import {
+  SNAPSHOT_ACCEPT,
+  SNAPSHOT_BUTTON_CLASS,
+  agentIdFromSnapshotName,
+  fileToBase64,
+} from "./snapshot-file";
+import { HiddenFileInput } from "../../components/ui/hidden-file-input";
+import { CloseIcon } from "../../components/ui/icons";
 import { WorkspaceSelect } from "../chat/workspace-select";
 import { SkillPickList } from "../skills/skill-pick-list";
 import { addSkillNames, removeSkillNames, toggleSkillName } from "../skills/skill-selection";
@@ -120,6 +129,12 @@ export function AgentsPage() {
   const [dirSkillsError, setDirSkillsError] = useState<string | null>(null);
   const [createDirSkills, setCreateDirSkills] = useState<string[]>([]);
   const [dirSkillsOpen, setDirSkillsOpen] = useState(false);
+  /**
+   * Snapshot package to initialize the new Agent from (null = default template). Picking one
+   * hides the two skill fields: the package carries its own skills, and the server rejects
+   * the combination.
+   */
+  const [snapshotFile, setSnapshotFile] = useState<File | null>(null);
 
   /** Open the create dialog: don't keep the previous draft, always start from an empty form. */
   const openCreate = () => {
@@ -134,7 +149,25 @@ export function AgentsPage() {
     setDirSkillsError(null);
     setCreateDirSkills([]);
     setDirSkillsOpen(false);
+    setSnapshotFile(null);
     setCreateOpen(true);
+  };
+
+  const onPickSnapshot = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = "";
+    if (!file) return;
+    setSnapshotFile(file);
+    // Skill seeding and the package are mutually exclusive; drop any picks made before.
+    setCreateSkills([]);
+    setSkillsDir("");
+    setCreateDirSkills([]);
+    // Suggest the id from the package name (exported as <agentId>-v<n>.tar.gz) while the
+    // field is still empty; the suggestion stays editable, an unusable derivation is dropped.
+    if (!agentId.trim()) {
+      const derived = agentIdFromSnapshotName(file.name);
+      if (SEMANTIC_ID_PATTERN.test(derived)) setAgentId(derived);
+    }
   };
 
   // The library is fetched the first time the dialog opens, not on page load: the list itself
@@ -236,19 +269,26 @@ export function AgentsPage() {
         skills?: string[];
         skillsDirectory?: string;
         directorySkills?: string[];
+        dataBase64?: string;
       } = {
         agentId: id,
       };
       if (name.trim()) body.name = name.trim();
       if (description.trim()) body.description = description.trim();
-      // Picked Skills are seeded server-side inside the same create call, so a failure leaves no
-      // half-equipped Agent behind.
-      if (createSkills.length > 0) body.skills = createSkills;
-      // The pair only means anything together, so it is sent only when a directory actually
-      // contributed something — picking a directory and then no Skills from it is a plain Agent.
-      if (skillsDir && createDirSkills.length > 0) {
-        body.skillsDirectory = skillsDir;
-        body.directorySkills = createDirSkills;
+      if (snapshotFile !== null) {
+        // Initialize from the picked package; skill seeding is mutually exclusive (the
+        // package carries its own skills), and picking the file already cleared those fields.
+        body.dataBase64 = await fileToBase64(snapshotFile);
+      } else {
+        // Picked Skills are seeded server-side inside the same create call, so a failure leaves no
+        // half-equipped Agent behind.
+        if (createSkills.length > 0) body.skills = createSkills;
+        // The pair only means anything together, so it is sent only when a directory actually
+        // contributed something — picking a directory and then no Skills from it is a plain Agent.
+        if (skillsDir && createDirSkills.length > 0) {
+          body.skillsDirectory = skillsDir;
+          body.directorySkills = createDirSkills;
+        }
       }
       const res = await api.createAgent(projectId, body);
       setCreateOpen(false);
@@ -579,104 +619,147 @@ export function AgentsPage() {
             value={description}
             onChange={(e) => setDescription(e.target.value)}
           />
-          {/* Seed Skills: the form-variant picker (same trigger as the schedule dialog's model
+          {/* Optional snapshot seed: the new Agent starts from an exported package instead of
+              the default template. Picking one hides the two skill fields below — the package
+              carries its own skills, and the server rejects the combination. */}
+          <div>
+            <FieldLabel>{S.agent.createSnapshot}</FieldLabel>
+            {snapshotFile === null ? (
+              <label
+                className={`${SNAPSHOT_BUTTON_CLASS} ${busy ? "pointer-events-none opacity-60" : ""}`}
+              >
+                <HiddenFileInput
+                  accept={SNAPSHOT_ACCEPT}
+                  disabled={busy}
+                  onChange={onPickSnapshot}
+                />
+                {S.agent.createSnapshotPick}
+              </label>
+            ) : (
+              <div className="flex min-w-0 items-center gap-1.5">
+                <span className="min-w-0 truncate rounded-md border border-gray-300 bg-gray-50 px-2.5 py-1 font-mono text-xs dark:border-gray-700 dark:bg-gray-900">
+                  {snapshotFile.name}
+                </span>
+                <button
+                  type="button"
+                  title={S.agent.createSnapshotClear}
+                  aria-label={S.agent.createSnapshotClear}
+                  disabled={busy}
+                  onClick={() => setSnapshotFile(null)}
+                  className="shrink-0 rounded-md p-1 text-gray-400 transition-colors duration-150 hover:text-gray-600 dark:hover:text-gray-300"
+                >
+                  <CloseIcon size={12} />
+                </button>
+              </div>
+            )}
+            <FieldHint>
+              {snapshotFile === null ? S.agent.createSnapshotHint : S.agent.createSnapshotSkillsOff}
+            </FieldHint>
+          </div>
+          {snapshotFile === null && (
+            <>
+              {/* Seed Skills: the form-variant picker (same trigger as the schedule dialog's model
               and workspace pickers) over the shared multi-select panel, so a dialog field and the
               composer's dropdown offer one list with one set of row semantics. */}
-          <div>
-            <FieldLabel>{S.agent.createSkills}</FieldLabel>
-            <FormPicker
-              open={skillsOpen}
-              setOpen={setSkillsOpen}
-              label={
-                createSkills.length === 0
-                  ? S.agent.createSkillsPlaceholder
-                  : S.agent.createSkillsPicked(createSkills.length)
-              }
-              muted={createSkills.length === 0}
-              title={S.agent.createSkills}
-              ariaLabel={S.agent.createSkills}
-              disabled={busy}
-              menuClass="w-[26rem]"
-            >
-              <SkillPickList
-                skills={library ?? []}
-                selected={createSkills}
-                onToggle={(skillName) =>
-                  setCreateSkills((prev) => toggleSkillName(prev, skillName))
-                }
-                onSelectAll={(names) => setCreateSkills((prev) => addSkillNames(prev, names))}
-                onSelectNone={(names) => setCreateSkills((prev) => removeSkillNames(prev, names))}
-                emptyHint={library === null ? S.common.loading : S.agent.createSkillsEmpty}
-              />
-            </FormPicker>
-            {libraryError ? (
-              <FieldError>{libraryError}</FieldError>
-            ) : (
-              <FieldHint>{S.agent.createSkillsHint}</FieldHint>
-            )}
-          </div>
-          {/* Skills a checkout already carries: pick the project directory, then pick from what
-              its .agents/skills / .claude/skills hold. Separate from the library field because a
-              directory Skill may share a library Skill's name and still be the one installed. */}
-          <div>
-            <FieldLabel>{S.agent.createDirSkills}</FieldLabel>
-            <WorkspaceSelect
-              projectId={projectId ?? ""}
-              workspace={skillsDir}
-              onChange={setSkillsDir}
-              variant="form"
-              fieldLabel={S.agent.createDirSkills}
-              emptyLabel={S.agent.createDirSkillsPick}
-              menuHint={S.agent.createDirSkillsHint}
-              clearLabel={S.agent.createDirSkillsClear}
-            />
-            {skillsDir && dirSkills !== null && dirSkills.length > 0 && (
-              <div className="mt-2">
+              <div>
+                <FieldLabel>{S.agent.createSkills}</FieldLabel>
                 <FormPicker
-                  open={dirSkillsOpen}
-                  setOpen={setDirSkillsOpen}
+                  open={skillsOpen}
+                  setOpen={setSkillsOpen}
                   label={
-                    createDirSkills.length === 0
+                    createSkills.length === 0
                       ? S.agent.createSkillsPlaceholder
-                      : S.agent.createSkillsPicked(createDirSkills.length)
+                      : S.agent.createSkillsPicked(createSkills.length)
                   }
-                  muted={createDirSkills.length === 0}
-                  title={S.agent.createDirSkills}
-                  ariaLabel={S.agent.createDirSkills}
+                  muted={createSkills.length === 0}
+                  title={S.agent.createSkills}
+                  ariaLabel={S.agent.createSkills}
                   disabled={busy}
                   menuClass="w-[26rem]"
                 >
                   <SkillPickList
-                    skills={dirSkills}
-                    selected={createDirSkills}
+                    skills={library ?? []}
+                    selected={createSkills}
                     onToggle={(skillName) =>
-                      setCreateDirSkills((prev) => toggleSkillName(prev, skillName))
+                      setCreateSkills((prev) => toggleSkillName(prev, skillName))
                     }
-                    onSelectAll={(names) =>
-                      setCreateDirSkills((prev) => addSkillNames(prev, names))
-                    }
+                    onSelectAll={(names) => setCreateSkills((prev) => addSkillNames(prev, names))}
                     onSelectNone={(names) =>
-                      setCreateDirSkills((prev) => removeSkillNames(prev, names))
+                      setCreateSkills((prev) => removeSkillNames(prev, names))
                     }
-                    emptyHint={S.agent.createDirSkillsEmpty}
+                    emptyHint={library === null ? S.common.loading : S.agent.createSkillsEmpty}
                   />
                 </FormPicker>
+                {libraryError ? (
+                  <FieldError>{libraryError}</FieldError>
+                ) : (
+                  <FieldHint>{S.agent.createSkillsHint}</FieldHint>
+                )}
               </div>
-            )}
-            {dirSkillsError ? (
-              <FieldError>{dirSkillsError}</FieldError>
-            ) : (
-              <FieldHint>
-                {!skillsDir
-                  ? S.agent.createDirSkillsHint
-                  : dirSkills === null
-                    ? S.common.loading
-                    : dirSkills.length === 0
-                      ? S.agent.createDirSkillsEmpty
-                      : S.agent.createDirSkillsFound(dirSkills.length)}
-              </FieldHint>
-            )}
-          </div>
+              {/* Skills a checkout already carries: pick the project directory, then pick from what
+              its .agents/skills / .claude/skills hold. Separate from the library field because a
+              directory Skill may share a library Skill's name and still be the one installed. */}
+              <div>
+                <FieldLabel>{S.agent.createDirSkills}</FieldLabel>
+                <WorkspaceSelect
+                  projectId={projectId ?? ""}
+                  workspace={skillsDir}
+                  onChange={setSkillsDir}
+                  variant="form"
+                  fieldLabel={S.agent.createDirSkills}
+                  emptyLabel={S.agent.createDirSkillsPick}
+                  menuHint={S.agent.createDirSkillsHint}
+                  clearLabel={S.agent.createDirSkillsClear}
+                />
+                {skillsDir && dirSkills !== null && dirSkills.length > 0 && (
+                  <div className="mt-2">
+                    <FormPicker
+                      open={dirSkillsOpen}
+                      setOpen={setDirSkillsOpen}
+                      label={
+                        createDirSkills.length === 0
+                          ? S.agent.createSkillsPlaceholder
+                          : S.agent.createSkillsPicked(createDirSkills.length)
+                      }
+                      muted={createDirSkills.length === 0}
+                      title={S.agent.createDirSkills}
+                      ariaLabel={S.agent.createDirSkills}
+                      disabled={busy}
+                      menuClass="w-[26rem]"
+                    >
+                      <SkillPickList
+                        skills={dirSkills}
+                        selected={createDirSkills}
+                        onToggle={(skillName) =>
+                          setCreateDirSkills((prev) => toggleSkillName(prev, skillName))
+                        }
+                        onSelectAll={(names) =>
+                          setCreateDirSkills((prev) => addSkillNames(prev, names))
+                        }
+                        onSelectNone={(names) =>
+                          setCreateDirSkills((prev) => removeSkillNames(prev, names))
+                        }
+                        emptyHint={S.agent.createDirSkillsEmpty}
+                      />
+                    </FormPicker>
+                  </div>
+                )}
+                {dirSkillsError ? (
+                  <FieldError>{dirSkillsError}</FieldError>
+                ) : (
+                  <FieldHint>
+                    {!skillsDir
+                      ? S.agent.createDirSkillsHint
+                      : dirSkills === null
+                        ? S.common.loading
+                        : dirSkills.length === 0
+                          ? S.agent.createDirSkillsEmpty
+                          : S.agent.createDirSkillsFound(dirSkills.length)}
+                  </FieldHint>
+                )}
+              </div>
+            </>
+          )}
         </div>
       </Modal>
 

--- a/packages/web/src/features/agents/snapshot-file.ts
+++ b/packages/web/src/features/agents/snapshot-file.ts
@@ -1,0 +1,41 @@
+/** Picking and reading Agent State snapshot packages (`<agentId>-v<n>.tar.gz`). */
+
+/**
+ * <a download>/<label> version of the button look (matches Button secondary sm; the Button
+ * component only renders <button>): the settings page's transfer actions and the create
+ * dialog's snapshot picker.
+ */
+export const SNAPSHOT_BUTTON_CLASS =
+  "inline-flex cursor-pointer items-center justify-center gap-1 rounded-md border border-gray-300 " +
+  "bg-white px-2.5 py-1 text-xs font-medium text-gray-800 transition-colors duration-150 " +
+  "hover:bg-gray-50 focus-within:ring-2 focus-within:ring-gray-400/30 " +
+  "dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:hover:bg-gray-800";
+
+/**
+ * Accept list for the snapshot file pickers.
+ *
+ * Extensions alone are not enough: macOS pickers (Safari, and the desktop shell's native
+ * dialog) map accept extensions to UTIs, and the double-dot `.tar.gz` maps to nothing —
+ * exported packages then show up grayed out and unselectable. The MIME types and the bare
+ * `.gz` keep them selectable everywhere; the server validates package structure anyway, so
+ * the wider net admits nothing it cannot reject.
+ */
+export const SNAPSHOT_ACCEPT = ".tar.gz,.tgz,.gz,application/gzip,application/x-gzip";
+
+/** Reads a picked file into the base64 payload the snapshot endpoints take. */
+export function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const url = reader.result as string;
+      resolve(url.slice(url.indexOf(",") + 1)); // strip the data:...;base64, prefix
+    };
+    reader.onerror = () => reject(reader.error ?? new Error("File read failed."));
+    reader.readAsDataURL(file);
+  });
+}
+
+/** Agent-id suggestion from a snapshot file name: `<agentId>-v<n>.tar.gz` → `<agentId>`. */
+export function agentIdFromSnapshotName(fileName: string): string {
+  return fileName.replace(/\.(tar\.gz|tgz|gz)$/i, "").replace(/-v\d+$/, "");
+}

--- a/packages/web/src/lib/strings-en.ts
+++ b/packages/web/src/lib/strings-en.ts
@@ -390,6 +390,13 @@ export const en: Strings = {
     createDirSkillsFound: (n: number): string =>
       `${n} skill${n === 1 ? "" : "s"} found in this directory`,
     createDirSkillsClear: "Clear the selected directory",
+    createSnapshot: "Initialize from a snapshot",
+    createSnapshotPick: "Choose a snapshot package",
+    createSnapshotHint:
+      "Optional: pick an exported Agent State snapshot package (.tar.gz) — the new agent starts from the package's state; name and description left empty keep the package's values.",
+    createSnapshotSkillsOff:
+      "The snapshot package carries its own skills, so skill seeding is unavailable.",
+    createSnapshotClear: "Remove the selected package",
     sessionCount: (n: number): string => `${n} session${n === 1 ? "" : "s"}`,
     toolCount: (n: number): string => `${n} tool${n === 1 ? "" : "s"}`,
     vaultKeyCount: (n: number): string => `${n} vault key${n === 1 ? "" : "s"}`,

--- a/packages/web/src/lib/strings-en.ts
+++ b/packages/web/src/lib/strings-en.ts
@@ -393,7 +393,7 @@ export const en: Strings = {
     createSnapshot: "Initialize from a snapshot",
     createSnapshotPick: "Choose a snapshot package",
     createSnapshotHint:
-      "Optional: pick an exported Agent State snapshot package (.tar.gz) — the new agent starts from the package's state; name and description left empty keep the package's values.",
+      "Pick an exported Agent State snapshot package (.tar.gz) to start the new agent from its state; name and description left empty keep the package's values.",
     createSnapshotSkillsOff:
       "The snapshot package carries its own skills, so skill seeding is unavailable.",
     createSnapshotClear: "Remove the selected package",

--- a/packages/web/src/lib/strings.ts
+++ b/packages/web/src/lib/strings.ts
@@ -376,6 +376,13 @@ export const zh = {
     createDirSkillsEmpty: "该目录下没有可安装的技能",
     createDirSkillsFound: (n: number): string => `该目录下找到 ${n} 个技能`,
     createDirSkillsClear: "清除已选目录",
+    /** Create dialog's optional snapshot seed: the new Agent starts from an exported package. */
+    createSnapshot: "从快照初始化",
+    createSnapshotPick: "选择快照包",
+    createSnapshotHint:
+      "可选：选择导出的 Agent State 快照包（.tar.gz），新 Agent 以包内状态创建；名称与描述留空则沿用包内值",
+    createSnapshotSkillsOff: "快照包自带技能，与技能选择互斥",
+    createSnapshotClear: "移除已选快照包",
     sessionCount: (n: number): string => `${n} 个 Session`,
     toolCount: (n: number): string => `${n} 个工具`,
     vaultKeyCount: (n: number): string => `${n} 个密钥`,

--- a/packages/web/src/lib/strings.ts
+++ b/packages/web/src/lib/strings.ts
@@ -380,7 +380,7 @@ export const zh = {
     createSnapshot: "从快照初始化",
     createSnapshotPick: "选择快照包",
     createSnapshotHint:
-      "可选：选择导出的 Agent State 快照包（.tar.gz），新 Agent 以包内状态创建；名称与描述留空则沿用包内值",
+      "选择导出的 Agent State 快照包（.tar.gz），新 Agent 以包内状态创建；名称与描述留空则沿用包内值",
     createSnapshotSkillsOff: "快照包自带技能，与技能选择互斥",
     createSnapshotClear: "移除已选快照包",
     sessionCount: (n: number): string => `${n} 个 Session`,


### PR DESCRIPTION
Fixes two user-reported problems in Agent State snapshot transfer.

## Import picker couldn't select exported packages
The import control declared `accept=".tar.gz,.tgz"` only. macOS pickers (Safari, and the desktop shell's native dialog) map accept extensions to UTIs, and the double-dot `.tar.gz` maps to nothing — the very files export produces (`<agentId>-v<n>.tar.gz`) showed up grayed out. Both snapshot pickers (settings import + the new create-dialog field) now share one accept list adding `application/gzip` / `application/x-gzip` and bare `.gz` (`snapshot-file.ts`). The server validates package structure anyway, so the wider net admits nothing it cannot reject.

## Create a new agent from a snapshot
`POST /api/projects/:projectId/agents` takes an optional `dataBase64` (same 14MB cap as import, shared `readArchiveBase64` helper). The service seeds the fresh agent via `importArchive` with `confirm: true, preSnapshot: false` — both guards protect existing State, and a fresh agent has none. Semantics:

- version/name/description/skills/schedules/memory come from the package; explicit `name`/`description` override, absent ones keep the package's (no id fallback).
- Mutually exclusive with skill seeding (`snapshot_with_skills` 400): the package carries its own skills. The dialog hides the skill fields once a package is picked.
- An invalid package fails the whole creation inside the existing cleanup window — no empty agent left, the id immediately reusable.
- Permission follows creation (any member): owner-only import guards overwriting an existing agent's State, which creating never does.

The create dialog gains an optional "Initialize from a snapshot" field; the id is prefilled from the package filename while empty. The returned card reads real counts (schedules/memory) since a package may carry them.

Design: Prism-Shadow/penguin-harness-design [#56](https://github.com/Prism-Shadow/penguin-harness-design/pull/56)

## Verification
- `packages/server`: full suite (935+) incl. 4 new agent-transfer tests (create-from-package state/name/version, explicit override, invalid-package rollback + id reuse, mutual exclusion) — green
- `packages/web`: full suite + typecheck — green; `packages/docs` suite — green
- `pnpm build`, per-package `tsc --noEmit`, `pnpm format:check`, `git diff --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HY3k3oyazaJhvc6gRwLXAL