### PR TITLE
feat(web): one Session list across machines

### DIFF
--- a/packages/server/src/machines/service.ts
+++ b/packages/server/src/machines/service.ts
@@ -1066,10 +1066,23 @@ export class MachinesService {
     if (resolved === null) {
       return { kind: "failed", detail: "ssh could not resolve that host." };
     }
-    return await this.#effects.signIn({
-      target: { alias: machine.alias, user: resolved.settings.user },
-      assets: this.#assets,
-    });
+    const target = { alias: machine.alias, user: resolved.settings.user };
+    // The machine's own CLI first, for the same reason the model sync prefers it: it needs no
+    // password, so it still works on a machine whose admin password a person has set — which
+    // is precisely the machine a browser could not otherwise be signed in to from here.
+    const minted = await mintTokenOnRemote(target, (t, command) => this.#effects.runOn(t, command));
+    if (minted.kind === "minted") {
+      // Synthesized as the Set-Cookie that machine's own login would have sent: the caller's
+      // job is to rename one into the machine's namespace, and it should not have to know
+      // this one was minted rather than issued. No Secure — the browser is talking to THIS
+      // origin through the proxy, not to the machine.
+      return {
+        kind: "signed-in",
+        setCookie: [`${SESSION_COOKIE}=${minted.token}; Path=/; HttpOnly; SameSite=Lax`],
+      };
+    }
+    if (minted.kind === "failed") return { kind: "failed", detail: minted.detail };
+    return await this.#effects.signIn({ target, assets: this.#assets });
   }
 
   /** Runs `work` with this machine's slot held, or returns null when it is already busy. */

--- a/packages/web/src/api/endpoints.ts
+++ b/packages/web/src/api/endpoints.ts
@@ -453,6 +453,12 @@ export const listSessions = (
     /** Also list CLI-created Sessions (Trace discovery + adoption); default = web rows straight from the DB. */
     cli?: boolean;
   },
+  /**
+   * Which machine to ask. This path is NOT session-scoped, so nothing about it can be routed
+   * from the id — it asks a server which Sessions IT has, and only the caller knows which
+   * servers are worth asking. Omitted (or null) means this one.
+   */
+  machineId?: string | null,
 ) => {
   const qs = opts
     ? `?limit=${opts.limit}&offset=${opts.offset}` +
@@ -463,6 +469,7 @@ export const listSessions = (
     : "";
   return apiFetch<SessionsResponse>(
     `/api/projects/${encodeURIComponent(projectId)}/agents/${encodeURIComponent(agentId)}/sessions${qs}`,
+    { server: machineId ?? null },
   );
 };
 

--- a/packages/web/src/features/chat/draft-view.tsx
+++ b/packages/web/src/features/chat/draft-view.tsx
@@ -51,6 +51,7 @@ import * as api from "../../api/endpoints";
 import { S } from "../../lib/strings";
 import { formatMonthDay } from "../../lib/format";
 import { apiErrorText } from "../../lib/api-error";
+import { rememberSessionMachine } from "../../lib/session-machines";
 import { useAuth } from "../../state/auth";
 import { useLocale } from "../../state/locale";
 import { agentDisplayName, useProject } from "../../state/project";
@@ -693,12 +694,22 @@ export function DraftView({
         const created = await api.createSession(projectId, agentId, body, workspaceMachine);
         createdId = created.session.sessionId;
         const res = await api.postTask(createdId, { input, ...(goal ? { goal } : {}) });
+        // postTask answers with the CURRENT id: a Session with no Trace whose process
+        // restarted in between self-heals into a new one. Everything recorded a moment ago
+        // under the id we created is then about a Session that no longer answers to it, and
+        // the routing map is the half that fails silently — a remote Session left mapped
+        // under the old id would be asked of THIS server, which does not have it. Re-recorded
+        // BEFORE the lookup below, which is itself one of those calls.
+        if (res.sessionId !== createdId) rememberSessionMachine(res.sessionId, workspaceMachine);
         // Re-fetch the row before listing it: the server persisted the fallback title at
         // Task start (inside the postTask call), and its session_title push may have gone
         // out before this row existed in the list, where it patched nothing. The fresh row
         // also carries the post-self-heal id, matching where we navigate.
         const fresh = await api.getSession(res.sessionId).catch(() => null);
-        add(fresh?.session ?? created.session);
+        // Listed under the id we are about to navigate to. Falling back to the created row
+        // verbatim would list the OLD id — a stale row, and a route naming a Session the
+        // list does not contain, which is the flash this page had to guess its way out of.
+        add(fresh?.session ?? { ...created.session, sessionId: res.sessionId });
         discardDraft();
         // The draft now has an id of its own, so its docks move with it: anything left
         // behind under the draft's scope would surface in the NEXT new conversation

--- a/packages/web/src/lib/session-merge.ts
+++ b/packages/web/src/lib/session-merge.ts
@@ -1,0 +1,76 @@
+/**
+ * Merging one page of Sessions from several machines into the one list the sidebar shows.
+ *
+ * Each machine answers about itself — its own Sessions, its own pagination — so the merge
+ * happens here. Two things it must get right, because both fail quietly:
+ *
+ * - **Order.** Every source is already sorted newest-first, and the merged page has to stay
+ *   that way or the sidebar's "recent" reads as arbitrary. Ties keep source order, which
+ *   makes the result stable between refreshes instead of shuffling equal timestamps.
+ * - **"There is more".** A page is `hasMore` if ANY source had more, or if the sources
+ *   together overflowed the page. Losing that flag hides Sessions behind a button that
+ *   never appears — the failure looks like the Sessions do not exist.
+ *
+ * Deduped by session id: the same Session cannot be on two machines, but a machine reached
+ * through two routes could answer twice, and a duplicate row is worse than a missing one.
+ */
+import type { SessionInfo } from "@prismshadow/penguin-server/api";
+
+/** One machine's answer: its page, and whether it had more beyond it. */
+export interface SessionSource {
+  /** The machine these came from; null is this one. */
+  machineId: string | null;
+  items: SessionInfo[];
+  hasMore: boolean;
+}
+
+/** A merged page, plus where each Session came from. */
+export interface MergedSessions {
+  items: SessionInfo[];
+  hasMore: boolean;
+  /** sessionId → machine, for the routing map every later call about it uses. */
+  owners: Array<{ sessionId: string; machineId: string | null }>;
+}
+
+/** Newest first, by the field the server's own index orders on. */
+const newestFirst = (a: SessionInfo, b: SessionInfo): number =>
+  b.createdAt.localeCompare(a.createdAt);
+
+export function mergeSessionPages(sources: SessionSource[], pageSize: number): MergedSessions {
+  const owners: Array<{ sessionId: string; machineId: string | null }> = [];
+  const seen = new Set<string>();
+  const all: SessionInfo[] = [];
+  for (const source of sources) {
+    for (const session of source.items) {
+      if (seen.has(session.sessionId)) continue;
+      seen.add(session.sessionId);
+      all.push(session);
+      owners.push({ sessionId: session.sessionId, machineId: source.machineId });
+    }
+  }
+  // Stable sort: equal timestamps keep the order the sources were read in, so the list does
+  // not reshuffle between refreshes.
+  all.sort(newestFirst);
+  const overflowed = all.length > pageSize;
+  return {
+    items: overflowed ? all.slice(0, pageSize) : all,
+    hasMore: overflowed || sources.some((source) => source.hasMore),
+    owners,
+  };
+}
+
+/**
+ * Sums the per-category counts each machine reported. Counts drive the folder badges, and a
+ * badge that only counted this machine would contradict the rows right under it.
+ */
+export function mergeCounts<T extends Record<string, number>>(
+  counts: Array<T | undefined>,
+): T | undefined {
+  const present = counts.filter((entry): entry is T => entry !== undefined);
+  if (present.length === 0) return undefined;
+  const out = {} as Record<string, number>;
+  for (const entry of present) {
+    for (const [key, value] of Object.entries(entry)) out[key] = (out[key] ?? 0) + value;
+  }
+  return out as T;
+}

--- a/packages/web/src/state/sessions.tsx
+++ b/packages/web/src/state/sessions.tsx
@@ -35,6 +35,13 @@ import type {
 import { useStore } from "zustand/react";
 import { createStore } from "zustand/vanilla";
 import * as api from "../api/endpoints";
+import { mergeCounts } from "../lib/session-merge";
+import {
+  forgetSessionMachines,
+  machineForSession,
+  rememberSessionMachine,
+} from "../lib/session-machines";
+import { workspaceMachines } from "../lib/workspace-machines";
 import { openUserEvents } from "../api/sse";
 import {
   FOLDER_CATEGORIES,
@@ -111,27 +118,33 @@ export interface LiveRowFields {
 const SessionsContext = createContext<SessionsContextValue | null>(null);
 
 /**
- * Page-state key of one (Agent, category, Workspace-group) triple. The scope is the
- * server's query form of a group (workspaceGroupQuery) — a path or the temp sentinel —
- * and "" means the Agent's whole stream, which is what Agent and time grouping page down.
- * "\0" appears in none of the three (the merged temp group's own key does contain one,
- * which is exactly why the query form is what gets stored).
+ * Page-state key of one (Agent, category, Workspace-group, source) run. The scope is the
+ * server's query form of a group (workspaceGroupQuery) — a path or the temp sentinel — and
+ * "" means the Agent's whole stream. The source is the machine whose Sessions that stream is
+ * walked on (`null` = this server): each server pages its own rows with its own offsets, so
+ * one shared cursor would ask machine B for rows only machine A had reached. "\0" appears in
+ * none of the four (the merged temp group's own key does contain one, which is exactly why
+ * the query form is what gets stored).
  */
-const pageKey = (agentId: string, category: SessionCategory, scope = "") =>
-  `${agentId}\0${category}\0${scope}`;
+const pageKey = (
+  agentId: string,
+  category: SessionCategory,
+  scope = "",
+  source: string | null = null,
+) => `${agentId}\0${category}\0${scope}\0${source ?? ""}`;
 
 /** Every list category, in the order the store loads them (active eagerly, the folders on demand). */
 const ALL_CATEGORIES: readonly string[] = ["active", ...FOLDER_CATEGORIES];
 
-/** The triple a page key names, or null if it is not one (never, in practice — a guard for the reload scan). */
+/** The run a page key names, or null if it is not one (never, in practice — a guard for the reload scan). */
 function parsePageKey(
   key: string,
-): { agentId: string; category: SessionCategory; scope: string } | null {
+): { agentId: string; category: SessionCategory; scope: string; source: string | null } | null {
   const parts = key.split("\0");
-  if (parts.length !== 3) return null;
-  const [agentId, category, scope] = parts as [string, string, string];
+  if (parts.length !== 4) return null;
+  const [agentId, category, scope, source] = parts as [string, string, string, string];
   return ALL_CATEGORIES.includes(category)
-    ? { agentId, category: category as SessionCategory, scope }
+    ? { agentId, category: category as SessionCategory, scope, source: source === "" ? null : source }
     : null;
 }
 
@@ -157,6 +170,12 @@ interface SessionsStoreState {
   /** Provider-synced fetch context: the current Project and its Agent set (what reload() targets). */
   projectId: string | null;
   agentIds: string[];
+  /**
+   * Machines whose Sessions are merged into this list, alongside this server's. A Session
+   * lives on the server whose filesystem its workspace is on, so a Project's list is not one
+   * server's answer — it is every one of them, ordered together (lib/session-merge.ts).
+   */
+  machineIds: string[];
 
   sessions: SessionInfo[];
   /**
@@ -234,6 +253,7 @@ export function createSessionsStore() {
     return {
       projectId: null,
       agentIds: [],
+      machineIds: [],
 
       sessions: [],
       deletedSessionIds: new Set(),
@@ -244,52 +264,66 @@ export function createSessionsStore() {
       showCliSessions: false,
 
       reload: async () => {
-        const { projectId, agentIds, showCliSessions } = get();
+        const { projectId, agentIds, machineIds, showCliSessions } = get();
         if (!projectId || agentIds.length === 0) return;
         const g = ++gen;
         set({ loading: true });
+        // This server first, then every machine of the Project. Order matters only as a
+        // tie-break — mergeSessionPages sorts by time and keeps source order for equal
+        // stamps, so the list stays stable between refreshes instead of shuffling.
+        const sources: (string | null)[] = [null, ...machineIds];
         try {
           const results = await Promise.all(
-            agentIds.map(async (agentId) => {
-              // The Agent's whole-stream active first page (with per-category totals)
-              // always; plus the first page of every other pair already on screen — an open
-              // folder, and each Workspace group paging its own stream — because a reload
-              // triggered by a server event must refresh them, not blank them.
-              const pairs: { category: SessionCategory; scope: string }[] = [
-                { category: "active", scope: "" },
-              ];
-              for (const key of get().pageState.keys()) {
-                const parsed = parsePageKey(key);
-                if (parsed === null || parsed.agentId !== agentId) continue;
-                if (parsed.category === "active" && parsed.scope === "") continue;
-                pairs.push({ category: parsed.category, scope: parsed.scope });
-              }
-              try {
-                const pages = await Promise.all(
-                  pairs.map(async ({ category, scope }) => {
-                    const res = await api.listSessions(projectId, agentId, {
-                      offset: 0,
-                      limit: SIDEBAR_PAGE_SIZE + 1,
-                      category,
-                      ...(scope === "" ? {} : { workspaceGroup: scope }),
-                      ...(category === "active" && scope === "" ? { withCounts: true } : {}),
-                      ...(showCliSessions ? { cli: true } : {}),
-                    });
-                    return {
-                      category,
-                      scope,
-                      counts: res.counts,
-                      workspaceCounts: res.workspaceCounts,
-                      ...splitPage(res.sessions, SIDEBAR_PAGE_SIZE),
-                    };
-                  }),
-                );
-                return { agentId, pages };
-              } catch {
-                // A single Agent's fetch failure shouldn't bring down the whole batch (e.g. its directory was deleted externally).
-                return { agentId, pages: [] };
-              }
-            }),
+            agentIds.flatMap((agentId) =>
+              sources.map(async (source) => {
+                // The Agent's whole-stream active first page (with per-category totals)
+                // always; plus the first page of every other pair already on screen — an
+                // open folder, and each Workspace group paging its own stream — because a
+                // reload triggered by a server event must refresh them, not blank them.
+                const pairs: { category: SessionCategory; scope: string }[] = [
+                  { category: "active", scope: "" },
+                ];
+                for (const key of get().pageState.keys()) {
+                  const parsed = parsePageKey(key);
+                  if (parsed === null || parsed.agentId !== agentId || parsed.source !== source)
+                    continue;
+                  if (parsed.category === "active" && parsed.scope === "") continue;
+                  pairs.push({ category: parsed.category, scope: parsed.scope });
+                }
+                try {
+                  const pages = await Promise.all(
+                    pairs.map(async ({ category, scope }) => {
+                      const res = await api.listSessions(
+                        projectId,
+                        agentId,
+                        {
+                          offset: 0,
+                          limit: SIDEBAR_PAGE_SIZE + 1,
+                          category,
+                          ...(scope === "" ? {} : { workspaceGroup: scope }),
+                          ...(category === "active" && scope === "" ? { withCounts: true } : {}),
+                          ...(showCliSessions ? { cli: true } : {}),
+                        },
+                        source,
+                      );
+                      return {
+                        category,
+                        scope,
+                        counts: res.counts,
+                        workspaceCounts: res.workspaceCounts,
+                        ...splitPage(res.sessions, SIDEBAR_PAGE_SIZE),
+                      };
+                    }),
+                  );
+                  return { agentId, source, pages };
+                } catch {
+                  // One (Agent, machine) pair failing must not empty the list: an Agent is
+                  // per-server, so a machine simply not having this one answers 404 and is
+                  // the ORDINARY case, not an error worth showing.
+                  return { agentId, source, pages: [] };
+                }
+              }),
+            ),
           );
           if (g !== gen) return;
           const nextSessions: SessionInfo[] = [];
@@ -300,22 +334,64 @@ export function createSessionsStore() {
             string,
             Readonly<Record<string, SessionCategoryCounts>>
           >();
+          // Counts are SUMMED across sources, not overwritten: a folder badge that counted
+          // one machine would contradict the rows underneath it (mergeCounts).
+          const countParts = new Map<string, SessionCategoryCounts[]>();
+          const workspaceParts = new Map<
+            string,
+            Array<Readonly<Record<string, SessionCategoryCounts>>>
+          >();
           for (const r of results) {
             for (const p of r.pages) {
-              nextPageState.set(pageKey(r.agentId, p.category, p.scope), {
+              nextPageState.set(pageKey(r.agentId, p.category, p.scope, r.source), {
                 hasMore: p.hasMore,
                 fetched: p.items.length,
               });
-              if (p.counts) nextCounts.set(r.agentId, p.counts);
-              if (p.workspaceCounts) nextWorkspaceCounts.set(r.agentId, p.workspaceCounts);
+              if (p.counts)
+                countParts.set(r.agentId, [...(countParts.get(r.agentId) ?? []), p.counts]);
+              if (p.workspaceCounts) {
+                workspaceParts.set(r.agentId, [
+                  ...(workspaceParts.get(r.agentId) ?? []),
+                  p.workspaceCounts,
+                ]);
+              }
               for (const s of p.items) {
-                if (!seen.has(s.sessionId)) {
-                  seen.add(s.sessionId);
-                  nextSessions.push(s);
-                }
+                if (seen.has(s.sessionId)) continue;
+                seen.add(s.sessionId);
+                nextSessions.push(s);
+                // Where this row lives, so the two dozen Session-scoped calls about it reach
+                // the machine that holds it. Rebuilt by the very list that displays them,
+                // which is why the map is in memory and this is the only place it is filled.
+                rememberSessionMachine(s.sessionId, r.source);
               }
             }
           }
+          for (const [agentId, parts] of countParts) {
+            const merged = mergeCounts(parts);
+            if (merged) nextCounts.set(agentId, merged);
+          }
+          for (const [agentId, parts] of workspaceParts) {
+            // Per workspace path, summed the same way: two machines may hold Sessions in
+            // paths that are equal as strings, and the badge is about the path.
+            const byPath = new Map<string, SessionCategoryCounts[]>();
+            for (const part of parts) {
+              for (const [path, counts] of Object.entries(part)) {
+                byPath.set(path, [...(byPath.get(path) ?? []), counts]);
+              }
+            }
+            const out: Record<string, SessionCategoryCounts> = {};
+            for (const [path, list] of byPath) {
+              const merged = mergeCounts(list);
+              if (merged) out[path] = merged;
+            }
+            nextWorkspaceCounts.set(agentId, out);
+          }
+          // Newest first across every source: each answered sorted, and concatenating sorted
+          // lists does not give a sorted list.
+          nextSessions.sort(
+            (a, b) =>
+              b.createdAt.localeCompare(a.createdAt) || b.sessionId.localeCompare(a.sessionId),
+          );
           set({
             sessions: nextSessions,
             pageState: nextPageState,
@@ -343,54 +419,71 @@ export function createSessionsStore() {
        * walked, so the pool absorbs any overlap by sessionId.
        */
       loadMoreFor: async (agentIds, category, workspaceGroup) => {
-        const { projectId, showCliSessions } = get();
+        const { projectId, machineIds, showCliSessions } = get();
         if (!projectId) return;
+        const sources: (string | null)[] = [null, ...machineIds];
         const scope = scopeOf(workspaceGroup);
-        const targets = [...new Set(agentIds)].filter((agentId) => {
-          const position = get().pageState.get(pageKey(agentId, category, scope));
-          // An unloaded pair: the Agent's own totals still decide whether asking is worth a
-          // request. A scoped pair cannot consult them (they are not broken down by group
-          // here), so it always gets its first page — the caller only asks for a group it
-          // has reason to believe holds rows.
-          if (position === undefined)
-            return scope !== "" || (get().countsByAgent.get(agentId)?.[category] ?? 0) > 0;
-          return position.hasMore;
-        });
+        // One target per (Agent, SOURCE): each server pages its own Sessions with its own
+        // offsets, so a shared cursor would ask one machine for rows only another had
+        // reached — silently skipping the rows in between.
+        const targets = [...new Set(agentIds)].flatMap((agentId) =>
+          sources
+            .filter((source) => {
+              const position = get().pageState.get(pageKey(agentId, category, scope, source));
+              // An unloaded pair: the Agent's own totals still decide whether asking is
+              // worth a request — they are the SUM over sources, so a machine with none
+              // still gets one first page, which is what discovers that it has none. A
+              // scoped pair cannot consult them (they are not broken down by group here),
+              // so it always gets its first page — the caller only asks for a group it has
+              // reason to believe holds rows.
+              if (position === undefined)
+                return scope !== "" || (get().countsByAgent.get(agentId)?.[category] ?? 0) > 0;
+              return position.hasMore;
+            })
+            .map((source) => ({ agentId, source })),
+        );
         if (targets.length === 0) return;
         const g = gen;
         /**
-         * Rows of this (Agent, category, group) already in the pool. They arrived on pages of
-         * the Agent's whole stream, and a prefix of that stream cut by Workspace is a prefix
-         * of the group's stream — so the count doubles as the offset a FIRST scoped fetch
-         * starts from. Without it that fetch would re-read rows the group already shows and
-         * the click would appear to do nothing.
+         * Rows of this (Agent, category, group) already in the pool from ONE source. They
+         * arrived on pages of that source's whole stream, and a prefix of that stream cut by
+         * Workspace is a prefix of the group's stream — so the count doubles as the offset a
+         * FIRST scoped fetch starts from. Without it that fetch would re-read rows the group
+         * already shows and the click would appear to do nothing; counting every source's
+         * rows would instead skip rows only this source holds.
          */
-        const loadedInScope = (agentId: string, group: string) =>
+        const loadedInScope = (agentId: string, source: string | null, group: string) =>
           get().sessions.filter(
             (s) =>
               s.agentId === agentId &&
               sessionCategory(s) === category &&
-              workspaceGroupKey(s.workspace) === group,
+              workspaceGroupKey(s.workspace) === group &&
+              machineForSession(s.sessionId) === source,
           ).length;
         const results = await Promise.all(
-          targets.map(async (agentId) => {
-            const position = get().pageState.get(pageKey(agentId, category, scope));
+          targets.map(async ({ agentId, source }) => {
+            const position = get().pageState.get(pageKey(agentId, category, scope, source));
             const offset =
               position?.fetched ??
               (workspaceGroup === undefined || workspaceGroup === ""
                 ? 0
-                : loadedInScope(agentId, workspaceGroup));
+                : loadedInScope(agentId, source, workspaceGroup));
             try {
               const fetched = (
-                await api.listSessions(projectId, agentId, {
-                  offset,
-                  limit: SIDEBAR_PAGE_SIZE + 1,
-                  category,
-                  ...(scope === "" ? {} : { workspaceGroup: scope }),
-                  ...(showCliSessions ? { cli: true } : {}),
-                })
+                await api.listSessions(
+                  projectId,
+                  agentId,
+                  {
+                    offset,
+                    limit: SIDEBAR_PAGE_SIZE + 1,
+                    category,
+                    ...(scope === "" ? {} : { workspaceGroup: scope }),
+                    ...(showCliSessions ? { cli: true } : {}),
+                  },
+                  source,
+                )
               ).sessions;
-              return { agentId, offset, ...splitPage(fetched, SIDEBAR_PAGE_SIZE) };
+              return { agentId, source, offset, ...splitPage(fetched, SIDEBAR_PAGE_SIZE) };
             } catch {
               // Transient failure: leave the pair's state untouched (still unloaded / still
               // has-more), so the affordance stays and the user can retry.
@@ -402,11 +495,19 @@ export function createSessionsStore() {
         const ok = results.filter((r) => r !== null);
         const prev = get().sessions;
         const seen = new Set(prev.map((s) => s.sessionId));
-        const appended = ok.flatMap((r) => r.items.filter((s) => !seen.has(s.sessionId)));
+        const appended: SessionInfo[] = [];
+        for (const r of ok) {
+          for (const row of r.items) {
+            if (seen.has(row.sessionId)) continue;
+            seen.add(row.sessionId);
+            appended.push(row);
+            rememberSessionMachine(row.sessionId, r.source);
+          }
+        }
         const prevPageState = get().pageState;
         const nextPageState = new Map(prevPageState);
         for (const r of ok) {
-          const key = pageKey(r.agentId, category, scope);
+          const key = pageKey(r.agentId, category, scope, r.source);
           nextPageState.set(key, {
             hasMore: r.hasMore,
             // A first scoped fetch started at the rows the group already held (see
@@ -428,11 +529,23 @@ export function createSessionsStore() {
         // (deep-link self-heal of an unfetched row) the counts already include it — a
         // possible one-off drift self-heals on the next reload.
         const existed = get().sessions.some((s) => s.sessionId === session.sessionId);
+        // Per SOURCE and stream: the row belongs to the machine it lives on, and the whole
+        // stream (scope "") is the one the totals were fetched against. When its Workspace
+        // group also pages its own stream, that cursor is drained too — an open, half-loaded
+        // group could still hide the row, so it must not be counted as new.
+        const source = machineForSession(session.sessionId);
+        const category = sessionCategory(session);
+        const groupScope = workspaceGroupQuery(workspaceGroupKey(session.workspace));
+        const fullyLoaded = (pairScope: string) =>
+          get().pageState.get(pageKey(session.agentId, category, pairScope, source))?.hasMore ===
+          false;
         if (
           !existed &&
-          get().pageState.get(pageKey(session.agentId, sessionCategory(session)))?.hasMore === false
+          fullyLoaded("") &&
+          (!get().pageState.has(pageKey(session.agentId, category, groupScope, source)) ||
+            fullyLoaded(groupScope))
         ) {
-          adjustCount(session, sessionCategory(session), 1);
+          adjustCount(session, category, 1);
         }
         set({
           sessions: [session, ...get().sessions.filter((s) => s.sessionId !== session.sessionId)],
@@ -615,6 +728,40 @@ export function SessionsProvider({ children }: { children: ReactNode }) {
   const [store] = useState(createSessionsStore);
   const state = useStore(store);
 
+  /**
+   * The Project's machines, whose Sessions belong in this list too.
+   *
+   * A Session lives on the server whose filesystem its workspace is on, so a Project's list
+   * is not this server's answer — it is every one of them. Fetched once per Project rather
+   * than watched: a machine appearing is not a reason to refetch a list nobody asked for,
+   * and the Machines page is where that is managed.
+   *
+   * Failure leaves it empty, which degrades to exactly the old behaviour: this server's
+   * Sessions, listed. That is the right failure — a partial list beats none.
+   */
+  const [machineIdsKey, setMachineIdsKey] = useState("");
+  useEffect(() => {
+    if (projectId === null) {
+      setMachineIdsKey("");
+      return;
+    }
+    let cancelled = false;
+    void api
+      .getMachines(projectId)
+      .then((res) => {
+        if (cancelled) return;
+        const ids = workspaceMachines(res)
+          .filter((machine) => !machine.local && machine.selectable)
+          .map((machine) => machine.id)
+          .filter((id): id is string => id !== null);
+        setMachineIdsKey(ids.join(","));
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId]);
+
   // Hydrate the "show CLI sessions" preference once on mount (a bare setState, not the
   // setShowCliSessions action: hydration must not write the preference back).
   useEffect(() => {
@@ -644,13 +791,18 @@ export function SessionsProvider({ children }: { children: ReactNode }) {
     store.setState({
       projectId,
       agentIds: agentIdsKey === "" ? [] : agentIdsKey.split(","),
+      machineIds: machineIdsKey === "" ? [] : machineIdsKey.split(","),
       sessions: [],
       pageState: new Map(),
       countsByAgent: new Map(),
       workspaceCountsByAgent: new Map(),
     });
+    // Which machine owns which Session is rebuilt by the very fetch below, so the old
+    // answers are dropped with the rows they described: a stale entry would route a call at
+    // a machine that may no longer hold — or no longer have — that Session.
+    forgetSessionMachines();
     void store.getState().reload();
-  }, [store, projectId, agentIdsKey, showCliSessions]);
+  }, [store, projectId, agentIdsKey, machineIdsKey, showCliSessions]);
 
   // User-level event stream (/api/events); see applyUserEvent for what each event does. The
   // connection stays a single one for the whole login session and doesn't reconnect on Project
@@ -664,24 +816,39 @@ export function SessionsProvider({ children }: { children: ReactNode }) {
     return () => conn.close();
   }, [store]);
 
-  const { pageState, countsByAgent } = state;
+  const { pageState, countsByAgent, machineIds } = state;
+  const sources = useMemo<(string | null)[]>(() => [null, ...machineIds], [machineIds]);
+
+  // Loaded only when EVERY source has answered: one machine's first page arriving does not
+  // make the folder complete, and treating it as loaded would hide the rest behind a
+  // "load more" that never appears.
   const isLoadedFor = useCallback(
     (agentId: string, category: SessionCategory, workspaceGroup?: string) =>
-      pageState.has(pageKey(agentId, category, scopeOf(workspaceGroup))),
-    [pageState],
+      sources.every((source) =>
+        pageState.has(pageKey(agentId, category, scopeOf(workspaceGroup), source)),
+      ),
+    [pageState, sources],
   );
 
+  // More if ANY source has more — or if a source has not been asked at all and the counts,
+  // which are the sum over sources, say the category holds something.
   const hasMoreFor = useCallback(
     (agentId: string, category: SessionCategory, workspaceGroup?: string) => {
       const scope = scopeOf(workspaceGroup);
-      const position = pageState.get(pageKey(agentId, category, scope));
-      if (position !== undefined) return position.hasMore;
-      // Unloaded pair: anything the counts report is by definition still unfetched. A group's
-      // own stream is not in those counts, so an unloaded scoped pair answers from the
-      // Agent's total for the category — the group's share of it cannot exceed that.
+      let anyUnloaded = false;
+      for (const source of sources) {
+        const position = pageState.get(pageKey(agentId, category, scope, source));
+        if (position === undefined) anyUnloaded = true;
+        else if (position.hasMore) return true;
+      }
+      if (!anyUnloaded) return false;
+      // Unloaded: the counts are the sum over sources, so anything they report is by
+      // definition still unfetched somewhere. A group's own stream is not in those counts,
+      // so an unloaded scoped pair answers from the Agent's total for the category — the
+      // group's share of it cannot exceed that.
       return (countsByAgent.get(agentId)?.[category] ?? 0) > 0;
     },
-    [pageState, countsByAgent],
+    [pageState, countsByAgent, sources],
   );
 
   // Reads the store directly rather than the subscribed snapshot: this answers "is this id

--- a/packages/web/src/state/sessions.tsx
+++ b/packages/web/src/state/sessions.tsx
@@ -746,17 +746,42 @@ export function SessionsProvider({ children }: { children: ReactNode }) {
       return;
     }
     let cancelled = false;
-    void api
-      .getMachines(projectId)
-      .then((res) => {
-        if (cancelled) return;
-        const ids = workspaceMachines(res)
+    void (async () => {
+      let ids: string[];
+      try {
+        const res = await api.getMachines(projectId);
+        ids = workspaceMachines(res)
           .filter((machine) => !machine.local && machine.selectable)
           .map((machine) => machine.id)
           .filter((id): id is string => id !== null);
-        setMachineIdsKey(ids.join(","));
-      })
-      .catch(() => undefined);
+      } catch {
+        return; // No machine list: the store keeps none, and the list is this server's alone.
+      }
+      // A session on each machine BEFORE naming them, because a machine is a separate server
+      // with its own accounts: without one the proxy answers 401, the list's fetch treats it
+      // as "that machine has not got this Agent", and the rows are missing with nothing said.
+      // Sequential per machine but concurrent across them, and each failure is that machine's
+      // alone — one unreachable host must not cost the others their Sessions.
+      const reachable = await Promise.all(
+        ids.map(async (id) => {
+          try {
+            await api.meOnMachine(id);
+            return id;
+          } catch {
+            // Not signed in there yet. For a machine this server installed that is something
+            // it can settle itself, over ssh, without anyone typing that machine's password.
+          }
+          try {
+            await api.autoSignInOnMachine(projectId, id);
+            return id;
+          } catch {
+            return null;
+          }
+        }),
+      );
+      if (cancelled) return;
+      setMachineIdsKey(reachable.filter((id): id is string => id !== null).join(","));
+    })();
     return () => {
       cancelled = true;
     };

--- a/packages/web/src/state/sessions.tsx
+++ b/packages/web/src/state/sessions.tsx
@@ -144,7 +144,12 @@ function parsePageKey(
   if (parts.length !== 4) return null;
   const [agentId, category, scope, source] = parts as [string, string, string, string];
   return ALL_CATEGORIES.includes(category)
-    ? { agentId, category: category as SessionCategory, scope, source: source === "" ? null : source }
+    ? {
+        agentId,
+        category: category as SessionCategory,
+        scope,
+        source: source === "" ? null : source,
+      }
     : null;
 }
 

--- a/packages/web/test/session-aggregation.test.ts
+++ b/packages/web/test/session-aggregation.test.ts
@@ -1,0 +1,146 @@
+/**
+ * One Session list across several machines (state/sessions.tsx).
+ *
+ * A Session lives on the server whose filesystem its workspace is on, so a Project's list is
+ * not one server's answer — it is every one of them, merged. Everything that can go wrong
+ * here goes wrong QUIETLY, which is why these are pinned:
+ *
+ * - A machine's rows missing entirely. That is the bug this feature exists to fix: the rows
+ *   were there while browsing (add() holds them in memory) and gone after a refresh.
+ * - A shared page cursor. Each server pages its own Sessions with its own offsets, so one
+ *   cursor across sources asks machine B for rows only machine A had reached, skipping
+ *   whatever sat in between — with a list that still looks plausible.
+ * - Ownership not recorded. Every later call about a Session is routed by that map; a row
+ *   listed without it is asked of THIS server, which does not have it.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionInfo } from "@prismshadow/penguin-server/api";
+
+const listSessions = vi.fn();
+vi.mock("../src/api/endpoints", () => ({
+  listSessions: (...args: unknown[]) => listSessions(...args),
+  getPrefs: () => Promise.resolve({ prefs: {} }),
+  putPrefs: () => Promise.resolve({}),
+  getMachines: () => Promise.resolve({ machines: [] }),
+}));
+
+const { createSessionsStore } = await import("../src/state/sessions");
+const { machineForSession, forgetSessionMachines } = await import("../src/lib/session-machines");
+
+const REMOTE = "kUkIyqU-1GOfXgKD";
+
+function session(sessionId: string, createdAt: string, workspace = "/w"): SessionInfo {
+  return {
+    sessionId,
+    projectId: "default_project",
+    agentId: "default_agent",
+    provider: "custom",
+    modelId: "deepseek-v4-flash",
+    workspace,
+    approvalMode: "allow-all",
+    createdAt,
+    lastActiveAt: createdAt,
+    status: "idle",
+    hasTrace: true,
+  } as SessionInfo;
+}
+
+/** A store already pointed at one Agent and one machine, as the Provider would leave it. */
+function storeWithMachine() {
+  const store = createSessionsStore();
+  store.setState({
+    projectId: "default_project",
+    agentIds: ["default_agent"],
+    machineIds: [REMOTE],
+  });
+  return store;
+}
+
+beforeEach(() => {
+  listSessions.mockReset();
+  forgetSessionMachines();
+});
+
+describe("reload across machines", () => {
+  it("lists both servers' Sessions, newest first, and remembers where each lives", async () => {
+    listSessions.mockImplementation(async (_p: string, _a: string, _o: unknown, source: unknown) =>
+      source === REMOTE
+        ? {
+            sessions: [
+              session("remote-new", "2026-08-24T10:00:00.000Z", "/home/k/penguin-harness"),
+            ],
+            counts: { active: 5, archived: 0, subagent: 0, schedule: 0 },
+          }
+        : {
+            sessions: [
+              session("local-newest", "2026-08-24T11:00:00.000Z"),
+              session("local-old", "2026-08-24T09:00:00.000Z"),
+            ],
+            counts: { active: 8, archived: 0, subagent: 0, schedule: 0 },
+          },
+    );
+
+    const store = storeWithMachine();
+    await store.getState().reload();
+
+    // Concatenating two sorted lists does not give a sorted list; the merge has to re-sort.
+    expect(store.getState().sessions.map((s) => s.sessionId)).toEqual([
+      "local-newest",
+      "remote-new",
+      "local-old",
+    ]);
+    // Routing: without this, every later call about the remote row asks this server.
+    expect(machineForSession("remote-new")).toBe(REMOTE);
+    expect(machineForSession("local-newest")).toBeNull();
+    // Counts are SUMMED, or the folder badge would contradict the rows under it.
+    expect(store.getState().countsByAgent.get("default_agent")?.active).toBe(13);
+  });
+
+  it("keeps this server's Sessions when a machine cannot answer", async () => {
+    // An Agent is per-server: a machine that simply does not have this one answers 404, and
+    // that is the ordinary case, not a reason to show an empty list.
+    listSessions.mockImplementation(
+      async (_p: string, _a: string, _o: unknown, source: unknown) => {
+        if (source === REMOTE) throw new Error("404");
+        return { sessions: [session("local-1", "2026-08-24T11:00:00.000Z")], counts: undefined };
+      },
+    );
+    const store = storeWithMachine();
+    await store.getState().reload();
+    expect(store.getState().sessions.map((s) => s.sessionId)).toEqual(["local-1"]);
+  });
+});
+
+describe("paging across machines", () => {
+  it("advances each source on its own cursor", async () => {
+    // First page: this server returns a full page with more behind it; the machine returns
+    // one row and is done.
+    listSessions.mockImplementation(async (_p: string, _a: string, opts: any, source: unknown) => {
+      if (source === REMOTE) {
+        return opts.offset === 0
+          ? { sessions: [session("r1", "2026-08-24T10:00:00.000Z")], counts: { active: 1 } }
+          : { sessions: [] };
+      }
+      return opts.offset === 0
+        ? {
+            sessions: Array.from({ length: 21 }, (_, i) =>
+              session(`l${i}`, `2026-08-24T11:${String(59 - i).padStart(2, "0")}:00.000Z`),
+            ),
+            counts: { active: 40 },
+          }
+        : { sessions: [session("l-next", "2026-08-24T08:00:00.000Z")] };
+    });
+
+    const store = storeWithMachine();
+    await store.getState().reload();
+    listSessions.mockClear();
+    await store.getState().loadMoreFor(["default_agent"], "active");
+
+    // This server is asked from where IT stopped — one page (SIDEBAR_PAGE_SIZE) consumed.
+    // The machine had no more and is not asked at all: under a SHARED cursor it would have
+    // been asked at this server's offset instead of its own, skipping every row in between.
+    const offsets = listSessions.mock.calls.map((c) => [c[3] ?? null, (c[2] as any).offset]);
+    expect(offsets).toEqual([[null, 10]]);
+    expect(store.getState().sessions.some((s) => s.sessionId === "l-next")).toBe(true);
+  });
+});

--- a/packages/web/test/session-machines.test.ts
+++ b/packages/web/test/session-machines.test.ts
@@ -84,3 +84,20 @@ describe("machineForPath", () => {
     expect(machineForPath("/api/projects/p/agents/a/sessions")).toBeNull();
   });
 });
+
+describe("a Session that self-heals into a new id", () => {
+  it("must be re-recorded, or every later call goes to the wrong server", () => {
+    // postTask answers with the CURRENT id. The mapping written at creation is under the id
+    // we asked for, so after a self-heal the new id resolves to "this server" — and a remote
+    // Session asked of this server is a 404 nobody can explain from the symptom.
+    forgetSessionMachines();
+    rememberSessionMachine("created-id", "QS7J4YVgSovi-Z2c");
+    expect(machineForPath("/api/sessions/healed-id/messages")).toBeNull();
+
+    rememberSessionMachine("healed-id", "QS7J4YVgSovi-Z2c");
+    expect(machineForPath("/api/sessions/healed-id/messages")).toBe("QS7J4YVgSovi-Z2c");
+    // The old id keeps its mapping; nothing depends on it any more, and clearing it would be
+    // a second thing to get right for no gain.
+    expect(machineForPath("/api/sessions/created-id")).toBe("QS7J4YVgSovi-Z2c");
+  });
+});

--- a/packages/web/test/session-merge.test.ts
+++ b/packages/web/test/session-merge.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Merging Sessions from several machines into one sidebar list.
+ *
+ * Every source answers about itself — its own rows, its own pagination — so ordering and
+ * "there is more" are decided here. Both fail quietly if wrong: a mis-ordered list reads as
+ * arbitrary rather than recent, and a lost hasMore hides Sessions behind a button that never
+ * appears, which looks exactly like those Sessions not existing.
+ */
+import { describe, expect, it } from "vitest";
+import type { SessionInfo } from "@prismshadow/penguin-server/api";
+import { mergeCounts, mergeSessionPages } from "../src/lib/session-merge";
+
+const session = (id: string, createdAt: string): SessionInfo =>
+  ({ sessionId: id, createdAt }) as SessionInfo;
+
+describe("mergeSessionPages", () => {
+  it("interleaves sources newest-first", () => {
+    const merged = mergeSessionPages(
+      [
+        {
+          machineId: null,
+          items: [session("a", "2026-08-24T03:00:00Z"), session("c", "2026-08-24T01:00:00Z")],
+          hasMore: false,
+        },
+        { machineId: "m1", items: [session("b", "2026-08-24T02:00:00Z")], hasMore: false },
+      ],
+      10,
+    );
+    expect(merged.items.map((s) => s.sessionId)).toEqual(["a", "b", "c"]);
+  });
+
+  it("says where every Session came from, so later calls can be routed", () => {
+    const merged = mergeSessionPages(
+      [
+        { machineId: null, items: [session("a", "2026-08-24T03:00:00Z")], hasMore: false },
+        { machineId: "m1", items: [session("b", "2026-08-24T02:00:00Z")], hasMore: false },
+      ],
+      10,
+    );
+    expect(merged.owners).toEqual([
+      { sessionId: "a", machineId: null },
+      { sessionId: "b", machineId: "m1" },
+    ]);
+  });
+
+  it("keeps hasMore when ANY source had more", () => {
+    // Losing it hides that machine's remaining Sessions behind a button that never renders.
+    const merged = mergeSessionPages(
+      [
+        { machineId: null, items: [session("a", "3")], hasMore: false },
+        { machineId: "m1", items: [session("b", "2")], hasMore: true },
+      ],
+      10,
+    );
+    expect(merged.hasMore).toBe(true);
+  });
+
+  it("sets hasMore when the sources TOGETHER overflow the page", () => {
+    // Neither source had more of its own, but the merged page cannot show them all.
+    const merged = mergeSessionPages(
+      [
+        { machineId: null, items: [session("a", "4"), session("c", "2")], hasMore: false },
+        { machineId: "m1", items: [session("b", "3"), session("d", "1")], hasMore: false },
+      ],
+      3,
+    );
+    expect(merged.items).toHaveLength(3);
+    expect(merged.hasMore).toBe(true);
+    expect(merged.items.map((s) => s.sessionId)).toEqual(["a", "b", "c"]);
+  });
+
+  it("is false only when everything fits and nobody had more", () => {
+    const merged = mergeSessionPages(
+      [{ machineId: null, items: [session("a", "1")], hasMore: false }],
+      10,
+    );
+    expect(merged.hasMore).toBe(false);
+  });
+
+  it("drops a duplicate id rather than showing a Session twice", () => {
+    const merged = mergeSessionPages(
+      [
+        { machineId: null, items: [session("a", "2")], hasMore: false },
+        { machineId: "m1", items: [session("a", "2")], hasMore: false },
+      ],
+      10,
+    );
+    expect(merged.items).toHaveLength(1);
+    // The first source to claim it wins, so the owner does not flip between refreshes.
+    expect(merged.owners).toEqual([{ sessionId: "a", machineId: null }]);
+  });
+
+  it("keeps source order among equal timestamps, so the list does not reshuffle", () => {
+    const sources = [
+      { machineId: null, items: [session("a", "1")], hasMore: false },
+      { machineId: "m1", items: [session("b", "1")], hasMore: false },
+    ];
+    expect(mergeSessionPages(sources, 10).items.map((s) => s.sessionId)).toEqual(["a", "b"]);
+    expect(mergeSessionPages(sources, 10).items.map((s) => s.sessionId)).toEqual(["a", "b"]);
+  });
+
+  it("handles a machine that returned nothing", () => {
+    const merged = mergeSessionPages(
+      [
+        { machineId: null, items: [session("a", "1")], hasMore: false },
+        { machineId: "m1", items: [], hasMore: false },
+      ],
+      10,
+    );
+    expect(merged.items.map((s) => s.sessionId)).toEqual(["a"]);
+  });
+});
+
+describe("mergeCounts", () => {
+  it("sums each machine's counts, so a badge matches the rows under it", () => {
+    expect(mergeCounts([{ active: 2, archived: 1 }, { active: 3 }])).toEqual({
+      active: 5,
+      archived: 1,
+    });
+  });
+
+  it("is undefined when no machine reported any, rather than a misleading zero", () => {
+    expect(mergeCounts([undefined, undefined])).toBeUndefined();
+  });
+
+  it("ignores machines that reported none", () => {
+    expect(mergeCounts([{ active: 2 }, undefined])).toEqual({ active: 2 });
+  });
+});


### PR DESCRIPTION
> **Stacked on #451.** Review the diff against `feat/machines-project-config`. Last of the series.

A Session lives on the server whose filesystem its workspace is on, so a Project's list was never one server's answer — but that is all it ever fetched. Sessions started on a machine showed up while browsing, because `add()` holds each new row in memory, and **vanished on refresh** when the list was rebuilt from this server alone. Five conversations on a machine, and a sidebar reading `penguin-harness 0`.

## The merge

`reload()` and `loadMoreFor()` now fan out over this server plus the Project's machines.

**The page cursor moves per source**, which is the part that fails quietly. Every server pages its own Sessions with its own offsets, so one shared cursor asks machine B for rows only machine A had reached — skipping whatever sat between, with a list that still looks plausible. The page key carries the source for that reason, and `isLoadedFor` is true only when **every** source has answered: one machine's first page arriving does not make a folder complete, and calling it loaded hides the rest behind a "load more" that never appears.

Counts are **summed**, or a folder badge contradicts the rows under it. Ownership is recorded as rows land, since that map routes every later call about a Session — a row listed without it is asked of this server, which does not have it — and is forgotten on a Project switch, with the rows it described.

## The 401 that made it look like nothing

The fan-out was correct and **every request to a machine answered 401**: a machine is a separate server with its own accounts, and the browser had no session on it. The merge caught the failure and treated it as "that machine has not got this Agent" — a genuinely ordinary case, since an Agent is per-server — so the rows were missing with nothing said.

Both halves fixed: the browser's sign-in route now asks the machine's own CLI for a token first (the seeded-password path stops working on any machine whose admin password somebody set), and the provider establishes that session **before** naming a machine as a source. A machine that cannot be reached either way is left out entirely rather than added as a source that silently answers nothing — the list is then this server's, which is what it was before, instead of a list with holes.

## A self-healed Session

`postTask` answers with the **current** id — a Session with no Trace whose process restarted heals into a new one. The draft's send path recorded everything under the id it created and navigated to the one it got back. The routing map is the half that failed silently: a remote Session left mapped under the old id has its new id resolve to "this server", which does not have it.

## Verification

`pnpm typecheck`, `pnpm test`, `pnpm format:check` — green. Three new tests pin the merge, the per-source cursor, and the 404 tolerance; verified end to end against a real machine through the proxy path the sidebar uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)