### PR TITLE
feat(skills): penguin-orchestration — drive the harness from inside an agent

### DIFF
--- a/changelog/unreleased/2026-08-25-penguin-orchestration-skill.md
+++ b/changelog/unreleased/2026-08-25-penguin-orchestration-skill.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-25
 - **Type:** feature
 - **Scope:** `skills`, `docs`
+- **PR:** [#463](https://github.com/Prism-Shadow/penguin-harness/pull/463)
 
 [中文版](2026-08-25-penguin-orchestration-skill.zh.md)
 

--- a/changelog/unreleased/2026-08-25-penguin-orchestration-skill.md
+++ b/changelog/unreleased/2026-08-25-penguin-orchestration-skill.md
@@ -1,0 +1,15 @@
+# New built-in skill: penguin-orchestration
+
+- **Date:** 2026-08-25
+- **Type:** feature
+- **Scope:** `skills`, `docs`
+
+[中文版](2026-08-25-penguin-orchestration-skill.zh.md)
+
+Added `penguin-orchestration` (v1) to the skill library's AI App Development group, right after `penguin-cli`. It teaches an agent running inside PenguinHarness to drive the harness itself over the `penguin` CLI against its own local server: list and create agents, start sessions and steer them mid-flight, read transcripts, and query costs and scheduled tasks. The skill documents the server-backed CLI surface introduced on branch `feat/cli-on-server` — the injected `PENGUIN_API_URL` / `PENGUIN_API_TOKEN` / project, agent and session id environment variables inside agent sessions, and the lock-file attach or auto-start path outside — so it ships together with that rework and must merge after it lands.
+
+## Details
+
+- Recipes: summarize yesterday's conversations (session ids embed their creation timestamp, `session-YYYY-MM-DD-HH-mm-ss-<8hex>`), query the last 7 days of cost (`penguin cost --days 7 --by agent` and variants), create an agent and talk to it (`penguin agent create` then `penguin run --agent-id`), inspect scheduled tasks (`penguin schedule ls`) and create one by writing a schedule TOML with file tools, and run a CLI-driven conversation in the background — `exec_command` with `run_in_background` for a completion report, or `penguin run --background` for a server-side run that survives the caller — steering it mid-flight with `penguin input <session_id> -m ... --no-wait`.
+- Cautions cover the one-active-task-per-session rule, approval modes for unattended sessions (`allow-all` / `read-only`; `always-ask` hangs), runaway self-messaging loops, project-level cost attribution, and the standing ban on hand-editing `.project_config.toml` / `.vault.toml`.
+- Registered in `SKILL_GROUPS`, the package README table and the bilingual docs skill tables; hand-drawn `icon.svg` (a conductor node fanning out to two nodes). No `preinstall` marker, so new `default_agent`s get it like the rest of the library.

--- a/changelog/unreleased/2026-08-25-penguin-orchestration-skill.zh.md
+++ b/changelog/unreleased/2026-08-25-penguin-orchestration-skill.zh.md
@@ -1,0 +1,15 @@
+# 新增内置技能：penguin-orchestration
+
+- **Date:** 2026-08-25
+- **Type:** feature
+- **Scope:** `skills`, `docs`
+
+[English](2026-08-25-penguin-orchestration-skill.md)
+
+技能库 AI App Development 组新增 `penguin-orchestration`（v1），排在 `penguin-cli` 之后。它教运行在 PenguinHarness 内的 Agent 经 `penguin` CLI 驱动承载自己的那台本地服务：列出与创建 Agent、发起会话并中途改向、读取会话记录、查询成本与定时任务。技能文档记载的是 `feat/cli-on-server` 分支引入的服务端化 CLI 命令面——Agent 会话内注入的 `PENGUIN_API_URL` / `PENGUIN_API_TOKEN` 及项目、Agent、会话 id 环境变量，会话外经锁文件附着或自动拉起——因此与该改造同行，须在其落地后合并。
+
+## 细节
+
+- 配方：总结昨天的对话（会话 id 内嵌创建时间戳 `session-YYYY-MM-DD-HH-mm-ss-<8hex>`）、查询近 7 天成本（`penguin cost --days 7 --by agent` 及各变体）、创建 Agent 并与之对话（`penguin agent create` 后接 `penguin run --agent-id`）、查看定时任务（`penguin schedule ls`）并用文件工具写 schedule TOML 新建，以及在后台跑一场 CLI 驱动的对话——`exec_command` 带 `run_in_background` 可收到完成回报，`penguin run --background` 则由服务端持续执行、不随发起者结束——中途用 `penguin input <session_id> -m ... --no-wait` 改向。
+- 注意事项覆盖每会话单活跃任务规则、无人值守会话的审批模式（`allow-all` / `read-only`；`always-ask` 会挂起等待）、自我发消息的失控循环、成本记入同一 Project，以及一贯的禁止手改 `.project_config.toml` / `.vault.toml`。
+- 已登记进 `SKILL_GROUPS`、包 README 表格与双语文档技能表；手绘 `icon.svg`（指挥节点扇出到两个节点）。未设 `preinstall` 标记，新建 `default_agent` 与库内其余技能一样预装它。

--- a/changelog/unreleased/2026-08-25-penguin-orchestration-skill.zh.md
+++ b/changelog/unreleased/2026-08-25-penguin-orchestration-skill.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-25
 - **Type:** feature
 - **Scope:** `skills`, `docs`
+- **PR:** [#463](https://github.com/Prism-Shadow/penguin-harness/pull/463)
 
 [English](2026-08-25-penguin-orchestration-skill.md)
 

--- a/packages/docs/content/skills.en.md
+++ b/packages/docs/content/skills.en.md
@@ -68,6 +68,7 @@ The built-in Skills, by group (the group manifest is `SKILL_GROUPS` in `packages
 | | `remote-claude-code` | Run Claude Code on a remote host over SSH — a persistent expect session, headless `-p` with the stdin fix, a tmux-driven interactive TUI (one capture-verified keystroke at a time, user messages relayed verbatim) and multi-turn continuity (not preinstalled: install from the library when needed) |
 | AI App Development | `penguin-sdk` | Build agent, AI and RAG applications on the SDK — application code, not Agent State configuration: the createSession/run streaming loop, CLI-wrapped user tools, plus a complete retrieval recipe with chunk-revealing citations |
 | | `penguin-cli` | Manage model API keys, default models and per-agent Vault secrets with the penguin CLI |
+| | `penguin-orchestration` | Drive PenguinHarness itself from a shell: list and create agents and sessions, send and steer messages mid-flight, and query costs and scheduled tasks via the penguin CLI |
 | | `agenthub-models` | Call model APIs through `@prismshadow/agenthub`: streaming text, image generation, speech synthesis and embeddings |
 | | `vllm` | Deploy and serve LLMs with vLLM behind an OpenAI-compatible endpoint, with tool calling enabled for agent workloads |
 | | `ollama` | Deploy and serve local models with Ollama: pull and run them, then expose the OpenAI-compatible endpoint to apps and agents |

--- a/packages/docs/content/skills.zh.md
+++ b/packages/docs/content/skills.zh.md
@@ -68,6 +68,7 @@ Skill 库以 npm 包 `@prismshadow/penguin-skills` 发布，tarball 直接携带
 | | `remote-claude-code` | 通过 SSH 在远程主机上驱动 Claude Code：expect 持久会话、headless `-p` 的 stdin 修正、tmux 驱动的交互 TUI（逐个按键并截屏确认，用户消息原样转发）与多轮续接（不预装，按需从技能库安装） |
 | AI 应用开发 | `penguin-sdk` | 基于 SDK 构建智能体应用、AI 与 RAG 应用（写应用代码，而非配置 Agent State）：createSession/run 流式循环、以 CLI 形式接入用户已有工具，外加带可溯源引用的完整检索配方 |
 | | `penguin-cli` | 用 penguin CLI 管理模型 API Key、默认模型与各 Agent 的 Vault 密钥 |
+| | `penguin-orchestration` | 从 shell 驱动 PenguinHarness 自身：用 penguin CLI 列出与创建 Agent 和会话、发送并中途改向消息、查询成本与定时任务 |
 | | `agenthub-models` | 经 `@prismshadow/agenthub` 调用模型 API：流式文本、图像生成、语音合成与 Embedding |
 | | `vllm` | 用 vLLM 部署与服务 LLM，提供 OpenAI 兼容端点，并为 Agent 负载启用工具调用 |
 | | `ollama` | 用 Ollama 部署与运行本地模型，把 OpenAI 兼容端点接入应用与 Agent |

--- a/packages/server/test/skills.test.ts
+++ b/packages/server/test/skills.test.ts
@@ -90,6 +90,7 @@ describe("skills api", () => {
     expect(body.groups[2]!.skills.map((s) => s.name)).toEqual([
       "penguin-sdk",
       "penguin-cli",
+      "penguin-orchestration",
       "agenthub-models",
       "vllm",
       "ollama",

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -10,7 +10,7 @@ Included skills, in the order of the `SKILL_GROUPS` manifest in `src/index.ts` (
 | --- | --- |
 | Office Productivity | `data-analysis`, `firecrawl`, `bento-slides`, `humanizer` |
 | Software Development | `web-design`, `software-engineering`, `remote-claude-code` |
-| AI App Development | `penguin-sdk`, `penguin-cli`, `agenthub-models`, `vllm`, `ollama`, `llamafactory`, `skill-porting` |
+| AI App Development | `penguin-sdk`, `penguin-cli`, `penguin-orchestration`, `agenthub-models`, `vllm`, `ollama`, `llamafactory`, `skill-porting` |
 | Agent Tuning | `agent-initialization`, `benchmark-design`, `agent-evaluation`, `agent-optimization` |
 
 `humanizer` and `remote-claude-code` carry `preinstall: false`, so `default_agent` does not get them at initialization — they are installed from the library on demand.

--- a/packages/skills/skills/penguin-orchestration/SKILL.md
+++ b/packages/skills/skills/penguin-orchestration/SKILL.md
@@ -39,10 +39,13 @@ penguin ls --json         # the project's sessions, with running state
 ```
 penguin run -m <msg> [--project-id <id>] [--agent-id <id>] [--workspace <path>]
             [--model-id <id> --provider <p>] [--approve <mode>] [--thinking <level>]
-            [--session <session_id>] [--background] [--goal [budget]] [--json]
+            [--session <session_id>] [--background] [--timeout <duration>]
+            [--goal [budget]] [--json]
 penguin ls [--project-id <id>] [--agent-id <id>] [-a|--all] [--json]
-penguin input <session_id> -m <text> [--project-id <id>] [--no-wait] [--json]
-penguin logs <session_id> [--project-id <id>] [--tail <n>] [-f|--follow] [--json]
+penguin input <session_id> [-m <text>] [--no-wait] [--timeout <duration>]
+              [--project-id <id>] [--json] [--server <url>]
+penguin logs <session_id> [--project-id <id>] [--tail <n>] [-f|--follow]
+             [--timeout <duration>] [--json]
 penguin agent ls [--project-id <id>] [--json]
 penguin agent create --agent-id <id> [--name <s>] [--description <s>] [--skills <a,b>]
                      [--project-id <id>] [--json]
@@ -52,8 +55,10 @@ penguin cost [--days <n>] [--from <d> --to <d>] [--by date|agent|model|session]
 penguin schedule ls [--project-id <id>] [--agent-id <id>] [--json]
 ```
 
-- `run` starts a task and waits, rendering the conversation, unless `--background` — then it prints the new session id and exits while the server keeps running the task. `--session <session_id>` runs the task in an existing session instead of creating one. The model reference is the `--provider` + `--model-id` pair (both or neither; neither means the project default). `--thinking <level>` overrides the agent's thinking level for this run; `--workspace` sets the session's working directory (omit for a temporary workspace); `--goal [budget]` runs in goal mode — the session loops until the agent declares the goal complete, with an optional spend budget.
-- `input` steers a **running** session mid-turn (the agent absorbs it as a course correction within the current task) or starts a new turn on an idle one. By default it waits for the reply; `--no-wait` returns right after delivery.
+- `run` starts a task and waits, rendering the conversation, unless `--background` — then it prints the new session id and exits while the server keeps running the task. `--session <session_id>` runs the task in an existing session instead of creating one; the model reference is the `--provider` + `--model-id` pair (both or neither); `--goal [budget]` runs in goal mode — the session loops until the agent declares the goal complete, with an optional spend budget.
+- **Caller-context defaults.** Inside a harness agent, a session-creating `run` fills every field you leave unspecified from your own live session, per field independently: `--workspace`, the `--model-id`/`--provider` pair, `--approve` and `--thinking` inherit the caller's values — the same convention as `run_subagent` parent inheritance. Precedence: explicit flag > caller value > plain fallback (cwd, the Project default model, `allow-all`, none — used wholesale if the caller lookup fails, with a dim stderr note). So inside an agent, `penguin run -m "..."` alone typically does the right thing; pass flags only to diverge.
+- `--timeout <duration>` (`30s`, `5m`, `2h`, or bare seconds) bounds the wait of a foreground `run`, an `input`, or a `logs -f`. Expiry is a soft yield, not an error: the command exits 0 while the task keeps running server-side, printing a still-running note that names the follow-up commands (`--json` prints `{sessionId, status: "running", text}` with the text so far). Not combinable with `run --background`, `input --no-wait`, or `logs` without `-f`.
+- `input` with `-m` steers a **running** session mid-turn (the agent absorbs it as a course correction within the current task) or starts a new turn on an idle one; it waits for the reply unless `--no-wait`. Bare `input <session_id>` (no `-m`) **polls**: it prints the session's most recent complete assistant text — an idempotent snapshot that skips user/thinking/tool output and never touches approvals, mirroring `input_subagent`'s empty-prompt semantics. A running session is waited on first (bounded by `--timeout`, else indefinitely); a session with no reply yet prints `(no assistant reply yet)`. `--json` reports `{sessionId, status, text}` — `idle`/`running` when polling, `completed`/`aborted`/`running` with `-m`. `--no-wait` requires `-m`.
 - `ls` spans every agent of the project, newest first (by last active); archived sessions are left out unless `-a`/`--all` includes them. `logs` renders a session's transcript: `--tail <n>` for the last entries, `-f` to follow live.
 - Session ids embed their creation timestamp — `session-YYYY-MM-DD-HH-mm-ss-<8hex>`. Every `<session_id>` argument takes any unique substring of an id; the 8-hex tail is the recommended short form, and an ambiguous fragment errors listing the candidates. On `input` and `logs`, `--project-id` scopes that fragment search (unnecessary with a full id).
 
@@ -90,6 +95,7 @@ penguin run --agent-id research_bot -m "Introduce yourself and list your skills.
 
 - Agent ids must match `^[a-z][a-z0-9_]{1,63}$`: a lowercase letter first, then lowercase letters, digits and underscores — no hyphens.
 - The new agent gets its own Agent State (system prompt, tools, skills, vault) in the current project; `--skills a,b` installs library skills at creation.
+- `--agent-id` switches only the agent: workspace, model, approval and thinking still inherit from your own session (caller-context defaults) — add those flags to change them too.
 - Each `run` without `--session` opens a fresh session; reuse a session id to continue a conversation.
 
 ### Inspect an agent's scheduled tasks
@@ -130,18 +136,18 @@ penguin run --agent-id research_bot -m "<long task>"
 
 - The harness delivers a `[background_task_done]` report when the CLI exits — no polling needed for completion.
 - Meanwhile, find the session with `penguin ls --json` (it shows as running, with the newest id) and steer it: `penguin input <session_id> -m "Focus on X; skip Y" --no-wait`.
-- Peek at progress any time with `penguin logs <session_id> --tail 20`.
+- Poll the latest answer with bare `penguin input <session_id> --timeout 30s` — a bounded wait that exits 0 with a still-running note when the reply is not in yet — or read the raw transcript with `penguin logs <session_id> --tail 20`.
 
 **(b) Server-side background — survives you.** `penguin run --background --agent-id research_bot -m "<long task>"` prints the session id and exits; the server keeps running the task with no local process.
 
-- Poll with `penguin ls --json` (running state) and read with `penguin logs <session_id> -f` or `--tail`; steer with `penguin input` the same way.
+- Poll the latest answer with bare `penguin input <session_id> --timeout 30s`, watch live with `penguin logs <session_id> -f`, and check running state with `penguin ls --json`; steer with `penguin input <session_id> -m ...` the same way.
 
-Prefer (a) when you stay around for the result — the completion report comes to you. Prefer (b) when the work must survive your own session ending, or when fanning out many tasks without holding a process per task.
+Prefer (a) when you stay around for the result — the completion report comes to you. Prefer (b) when the work must survive your own session ending, or when fanning out many tasks without holding a process per task. A bounded foreground run is the middle ground: `penguin run --timeout 5m -m "..."` renders up to the bound, then soft-yields with the task still running — pick up the answer later with a bare `penguin input <session_id>`.
 
 ## Cautions
 
 - **One active task per session.** `penguin input` at a busy session steers the running task rather than starting a second one; a new task sent at a busy session waits its turn. For parallel work, start parallel sessions.
-- **Unattended sessions must not need a human.** `penguin run` defaults to `--approve allow-all`; choose `--approve read-only` when the spawned agent should not write. Only an explicitly set `always-ask` carries the hang risk — that session waits for approval in the web UI.
+- **Unattended sessions must not need a human.** A spawned session inherits your approval mode (`allow-all` when there is no caller to inherit from); if you yourself run under `always-ask`, pass `--approve allow-all` (trusted work) or `--approve read-only` explicitly — an unattended `always-ask` session hangs waiting for approval in the web UI.
 - **No runaway loops.** An agent that messages itself — directly, through a chain of agents, or through a schedule aimed back at its own session — keeps spending until someone stops it. Make every automated conversation terminate.
 - **Spawned work bills the project.** Everything you start lands in the same project's usage (`penguin cost` shows it); a fan-out of sessions multiplies spend.
 - **Configuration stays CLI-managed.** Never read or hand-edit `.project_config.toml` or `agent_state/.vault.toml` — models and secrets go through `penguin config` (see the penguin-cli skill).

--- a/packages/skills/skills/penguin-orchestration/SKILL.md
+++ b/packages/skills/skills/penguin-orchestration/SKILL.md
@@ -41,8 +41,8 @@ penguin run -m <msg> [--project-id <id>] [--agent-id <id>] [--workspace <path>]
             [--model-id <id> --provider <p>] [--approve <mode>] [--thinking <level>]
             [--session <session_id>] [--background] [--goal [budget]] [--json]
 penguin ls [--project-id <id>] [--agent-id <id>] [-a|--all] [--json]
-penguin input <session_id> -m <text> [--no-wait] [--json]
-penguin logs <session_id> [--tail <n>] [-f|--follow] [--json]
+penguin input <session_id> -m <text> [--project-id <id>] [--no-wait] [--json]
+penguin logs <session_id> [--project-id <id>] [--tail <n>] [-f|--follow] [--json]
 penguin agent ls [--project-id <id>] [--json]
 penguin agent create --agent-id <id> [--name <s>] [--description <s>] [--skills <a,b>]
                      [--project-id <id>] [--json]
@@ -54,8 +54,8 @@ penguin schedule ls [--project-id <id>] [--agent-id <id>] [--json]
 
 - `run` starts a task and waits, rendering the conversation, unless `--background` — then it prints the new session id and exits while the server keeps running the task. `--session <session_id>` runs the task in an existing session instead of creating one. The model reference is the `--provider` + `--model-id` pair (both or neither; neither means the project default). `--thinking <level>` overrides the agent's thinking level for this run; `--workspace` sets the session's working directory (omit for a temporary workspace); `--goal [budget]` runs in goal mode — the session loops until the agent declares the goal complete, with an optional spend budget.
 - `input` steers a **running** session mid-turn (the agent absorbs it as a course correction within the current task) or starts a new turn on an idle one. By default it waits for the reply; `--no-wait` returns right after delivery.
-- `ls` lists sessions newest first; `-a`/`--all` lifts the default cap and lists the full history. `logs` renders a session's transcript: `--tail <n>` for the last entries, `-f` to follow live.
-- Session ids embed their creation timestamp — `session-YYYY-MM-DD-HH-mm-ss-<8hex>` — and every `<session_id>` argument accepts the unique 8-hex tail alone.
+- `ls` spans every agent of the project, newest first (by last active); archived sessions are left out unless `-a`/`--all` includes them. `logs` renders a session's transcript: `--tail <n>` for the last entries, `-f` to follow live.
+- Session ids embed their creation timestamp — `session-YYYY-MM-DD-HH-mm-ss-<8hex>`. Every `<session_id>` argument takes any unique substring of an id; the 8-hex tail is the recommended short form, and an ambiguous fragment errors listing the candidates. On `input` and `logs`, `--project-id` scopes that fragment search (unnecessary with a full id).
 
 ## Recipes
 
@@ -63,7 +63,7 @@ penguin schedule ls [--project-id <id>] [--agent-id <id>] [--json]
 
 ```bash
 Y="$(date -d yesterday +%F 2>/dev/null || date -v-1d +%F)"   # YYYY-MM-DD
-penguin ls -a --json
+penguin ls -a --json    # every agent's sessions, archived included
 ```
 
 - Pick the candidates from the listing: a session id starting `session-$Y-` was created yesterday; also keep earlier sessions whose last-active timestamp in the JSON falls on `$Y` — conversations that continued into yesterday.
@@ -98,7 +98,7 @@ penguin run --agent-id research_bot -m "Introduce yourself and list your skills.
 penguin schedule ls --agent-id research_bot
 ```
 
-Read the fields: `enabled` (a disabled entry never fires), `startAt` (first firing), `period` (recurrence; absent means one-shot), the target — an existing session id versus a new session per firing — and `lastFiredAt`.
+Read the fields: the AGENT column (without `--agent-id` the listing spans agents), `enabled` (a disabled entry never fires), `startAt` (first firing), `period` (recurrence; absent means one-shot), the target — an existing session id versus a new session per firing — and `lastFiredAt`.
 
 To **create** a schedule, write a TOML file with your file tools — that is the sanctioned path: schedule files are meant to be edited directly, and your own agent's current ones are already listed in your system prompt's schedule roster. The path is `<app_data_dir>/agents/<agent_id>/agent_state/schedule/<name>.toml` (App Data Dir is in your Environment section):
 
@@ -141,7 +141,7 @@ Prefer (a) when you stay around for the result — the completion report comes t
 ## Cautions
 
 - **One active task per session.** `penguin input` at a busy session steers the running task rather than starting a second one; a new task sent at a busy session waits its turn. For parallel work, start parallel sessions.
-- **Unattended sessions must not need a human.** Create them with `--approve allow-all` (trusted work) or `--approve read-only`; a session left on `always-ask` hangs waiting for approval in the web UI.
+- **Unattended sessions must not need a human.** `penguin run` defaults to `--approve allow-all`; choose `--approve read-only` when the spawned agent should not write. Only an explicitly set `always-ask` carries the hang risk — that session waits for approval in the web UI.
 - **No runaway loops.** An agent that messages itself — directly, through a chain of agents, or through a schedule aimed back at its own session — keeps spending until someone stops it. Make every automated conversation terminate.
 - **Spawned work bills the project.** Everything you start lands in the same project's usage (`penguin cost` shows it); a fan-out of sessions multiplies spend.
 - **Configuration stays CLI-managed.** Never read or hand-edit `.project_config.toml` or `agent_state/.vault.toml` — models and secrets go through `penguin config` (see the penguin-cli skill).

--- a/packages/skills/skills/penguin-orchestration/SKILL.md
+++ b/packages/skills/skills/penguin-orchestration/SKILL.md
@@ -41,8 +41,8 @@ penguin run -m <msg> [--project-id <id>] [--agent-id <id>] [--workspace <path>]
             [--model-id <id> --provider <p>] [--approve <mode>] [--thinking <level>]
             [--session <session_id>] [--background] [--timeout <duration>]
             [--goal [budget]] [--json]
-penguin ls [--project-id <id>] [--agent-id <id>] [-a|--all] [--json]
-penguin input <session_id> [-m <text>] [--no-wait] [--timeout <duration>]
+penguin ls [--project-id <id>] [--agent-id <id>] [--days <n>] [-a|--all] [--json]
+penguin input <session_id> [-m <text>] [--timeout <duration>]
               [--project-id <id>] [--json] [--server <url>]
 penguin logs <session_id> [--project-id <id>] [--tail <n>] [-f|--follow]
              [--timeout <duration>] [--json]
@@ -53,76 +53,84 @@ penguin project ls [--json]
 penguin cost [--days <n>] [--from <d> --to <d>] [--by date|agent|model|session]
              [--project-id <id>] [--agent-id <id>] [--json]
 penguin schedule ls [--project-id <id>] [--agent-id <id>] [--json]
+penguin schedule add <name> --prompt <s> --start-at <ISO|now> [--period <duration>]
+                    [--end-at <ISO>] [--session-id <id> | --workspace <path>
+                    [--model-id <id> --provider <p>]] [--disabled]
+                    [--project-id <id>] [--agent-id <id>]
+penguin schedule update <name> [<same field flags>] [--enable|--disable]
+                    [--project-id <id>] [--agent-id <id>]
+penguin schedule rm <name> [--project-id <id>] [--agent-id <id>]
 ```
 
 - `run` starts a task and waits, rendering the conversation, unless `--background` — then it prints the new session id and exits while the server keeps running the task. `--session <session_id>` runs the task in an existing session instead of creating one; the model reference is the `--provider` + `--model-id` pair (both or neither); `--goal [budget]` runs in goal mode — the session loops until the agent declares the goal complete, with an optional spend budget.
 - **Caller-context defaults.** Inside a harness agent, a session-creating `run` fills every field you leave unspecified from your own live session, per field independently: `--workspace`, the `--model-id`/`--provider` pair, `--approve` and `--thinking` inherit the caller's values — the same convention as `run_subagent` parent inheritance. Precedence: explicit flag > caller value > plain fallback (cwd, the Project default model, `allow-all`, none — used wholesale if the caller lookup fails, with a dim stderr note). So inside an agent, `penguin run -m "..."` alone typically does the right thing; pass flags only to diverge.
-- `--timeout <duration>` (`30s`, `5m`, `2h`, or bare seconds) bounds the wait of a foreground `run`, an `input`, or a `logs -f`. Expiry is a soft yield, not an error: the command exits 0 while the task keeps running server-side, printing a still-running note that names the follow-up commands (`--json` prints `{sessionId, status: "running", text}` with the text so far). Not combinable with `run --background`, `input --no-wait`, or `logs` without `-f`.
-- `input` with `-m` steers a **running** session mid-turn (the agent absorbs it as a course correction within the current task) or starts a new turn on an idle one; it waits for the reply unless `--no-wait`. Bare `input <session_id>` (no `-m`) **polls**: it prints the session's most recent complete assistant text — an idempotent snapshot that skips user/thinking/tool output and never touches approvals, mirroring `input_subagent`'s empty-prompt semantics. A running session is waited on first (bounded by `--timeout`, else indefinitely); a session with no reply yet prints `(no assistant reply yet)`. `--json` reports `{sessionId, status, text}` — `idle`/`running` when polling, `completed`/`aborted`/`running` with `-m`. `--no-wait` requires `-m`.
-- `ls` spans every agent of the project, newest first (by last active); archived sessions are left out unless `-a`/`--all` includes them. `logs` renders a session's transcript: `--tail <n>` for the last entries, `-f` to follow live.
+- `--timeout <duration>` (`30s`, `5m`, `2h`, or bare seconds) bounds the wait of a foreground `run`, an `input`, or a `logs -f`. Expiry is a soft yield, not an error: the command exits 0 while the task keeps running server-side, printing a still-running note that names the follow-up commands (`--json` prints `{sessionId, status: "running", text}` with the text so far). `--timeout 0` (also `0s`) returns immediately after delivery — the same note without collected text (`--json`: `{sessionId, status: "running"}`); on a bare poll it snapshots a running session instantly. `run --background` stays the idiomatic fire-and-forget for new tasks and rejects `--timeout`; `logs --timeout` requires `-f`.
+- `input` with `-m` steers a **running** session mid-turn (the agent absorbs it as a course correction within the current task) or starts a new turn on an idle one; it waits for the reply unless a `--timeout` bounds the wait (`--timeout 0` = deliver and return at once). Bare `input <session_id>` (no `-m`) **polls**: it prints the session's most recent complete assistant text — an idempotent snapshot that skips user/thinking/tool output and never touches approvals, mirroring `input_subagent`'s empty-prompt semantics. A running session is waited on first (bounded by `--timeout`, else indefinitely); a session with no reply yet prints `(no assistant reply yet)`. `--json` reports `{sessionId, status, text}` — `idle`/`running` when polling, `completed`/`aborted`/`running` with `-m`.
+- `ls` spans every agent of the project, newest first (by last active); archived sessions are left out unless `-a`/`--all` includes them, and `--days <n>` keeps only sessions last active since local midnight n−1 days ago — today counts as day 1, so `--days 2` is yesterday and today, `--days 7` this week. `logs` renders a session's transcript: `--tail <n>` for the last entries, `-f` to follow live.
 - Session ids embed their creation timestamp — `session-YYYY-MM-DD-HH-mm-ss-<8hex>`. Every `<session_id>` argument takes any unique substring of an id; the 8-hex tail is the recommended short form, and an ambiguous fragment errors listing the candidates. On `input` and `logs`, `--project-id` scopes that fragment search (unnecessary with a full id).
 
 ## Recipes
 
-### Summarize yesterday's conversations
+### Yesterday's or this week's sessions, with their latest replies
 
 ```bash
-Y="$(date -d yesterday +%F 2>/dev/null || date -v-1d +%F)"   # YYYY-MM-DD
-penguin ls -a --json    # every agent's sessions, archived included
+penguin ls --days 2 --json    # yesterday + today (today counts as day 1)
+penguin ls --days 7 --json    # this week; add -a to include archived sessions
+penguin input <session_id>    # one session's latest complete assistant reply
 ```
 
-- Pick the candidates from the listing: a session id starting `session-$Y-` was created yesterday; also keep earlier sessions whose last-active timestamp in the JSON falls on `$Y` — conversations that continued into yesterday.
-- Read each candidate with `penguin logs <8hex> --tail 100` (widen the tail if the transcript is cut short; `--json` if you want to parse rather than read).
-- Then write the summary yourself — per session: which agent, what was asked, what came of it. There is no summarize command; you are the summarizer.
+- `--days <n>` keeps sessions last active since local midnight n−1 days ago. For strictly-yesterday, take `--days 2` and drop today's entries client-side — ids embed the creation date and the JSON carries last-active.
+- Bare `input` prints the latest reply; add `--timeout 0` to snapshot a running session instantly instead of waiting for its turn to finish.
 
-### Last 7 days of cost
+### Summarize this week's history in a new session
+
+A fresh session gets a fresh context window for the summary; feed it through a file, not the prompt:
 
 ```bash
-penguin cost                       # summary card: today, last 7 days, total
-penguin cost --days 7 --by agent   # who spent it
+penguin ls --days 7 --json               # pick the sessions
+penguin logs <session_id> --tail 100     # gather each transcript (widen if cut short)
+# write what you gathered into a workspace file with your file tools, then:
+penguin run -m "Read ./weekly-material.md and write the weekly summary to ./weekly-summary.md"
 ```
 
-- The default summary already carries the last-7-days figure; `--by` breaks a range down per `date`, `agent`, `model` or `session`.
-- `--days 7 --by model` and `--days 7 --by date` answer "on which models" and "on which days"; `--from <d> --to <d>` takes an exact range; `--project-id` / `--agent-id` narrow the scope; `--json` for exact numbers.
+- **Exchange big material through workspace files.** Caller-context defaults mean the new session shares your workspace — write the gathered transcripts to `./weekly-material.md` and have the new session read it there. Pages of transcript do not belong in `-m`.
+- Read the result from `./weekly-summary.md` (the foreground run also renders the reply).
 
-### Create an agent and talk to it
+### Create an agent and say hello
 
 ```bash
-penguin agent create --agent-id research_bot --name "Research Bot" \
-  --description "Collects and digests sources" --skills firecrawl,data-analysis
-penguin run --agent-id research_bot -m "Introduce yourself and list your skills."
+penguin agent create --agent-id greeter --name "Greeter" --description "Welcomes people"
+penguin run --agent-id greeter -m "Hello! Introduce yourself."
 ```
 
 - Agent ids must match `^[a-z][a-z0-9_]{1,63}$`: a lowercase letter first, then lowercase letters, digits and underscores — no hyphens.
-- The new agent gets its own Agent State (system prompt, tools, skills, vault) in the current project; `--skills a,b` installs library skills at creation.
-- `--agent-id` switches only the agent: workspace, model, approval and thinking still inherit from your own session (caller-context defaults) — add those flags to change them too.
-- Each `run` without `--session` opens a fresh session; reuse a session id to continue a conversation.
+- A newly created agent starts with **no skills preinstalled**: seed it at creation with `--skills a,b` (library names) — include `penguin-orchestration` itself when the new agent must drive the harness too.
+- `--agent-id` switches only the agent: workspace, model, approval and thinking still inherit from your own session (caller-context defaults) — add those flags to change them too. Each `run` without `--session` opens a fresh session; reuse a session id to continue a conversation.
 
-### Inspect an agent's scheduled tasks
+### Summarize each agent's costs in a new session
 
 ```bash
-penguin schedule ls --agent-id research_bot
+penguin cost --days 7 --by agent --json    # who spent what this week
+penguin run -m "Summarize this per-agent cost report and flag anomalies: <the JSON>"
 ```
 
-Read the fields: the AGENT column (without `--agent-id` the listing spans agents), `enabled` (a disabled entry never fires), `startAt` (first firing), `period` (recurrence; absent means one-shot), the target — an existing session id versus a new session per firing — and `lastFiredAt`.
+- The default `penguin cost` card already carries today / last 7 days / total; `--by date|model|session` and `--from <d> --to <d>` give the other cuts, `--project-id` / `--agent-id` narrow the scope.
+- A `--by agent` report is small enough to inline in `-m`; for long breakdowns (`--by session` over a busy week), use the file-exchange pattern from the weekly-summary recipe.
 
-To **create** a schedule, write a TOML file with your file tools — that is the sanctioned path: schedule files are meant to be edited directly, and your own agent's current ones are already listed in your system prompt's schedule roster. The path is `<app_data_dir>/agents/<agent_id>/agent_state/schedule/<name>.toml` (App Data Dir is in your Environment section):
+### Set up a scheduled task for the current agent
 
-```toml
-prompt = "Summarize yesterday's sessions into notes/daily.md"   # required
-enabled = true                       # defaults to false — set true or it never fires
-start_at = "2026-08-26T09:00:00Z"    # ISO 8601, required
-period = "1d"                        # e.g. 30m / 12h / 1d / 7d, minimum 5m; omit for a one-shot
-# end_at = "2026-12-31T00:00:00Z"    # optional stop date
-# Target — either an existing session:
-# session_id = "session-2026-08-25-09-00-00-1a2b3c4d"
-# ...or a new session per firing (workspace plus the provider/model_id pair):
-workspace = "/home/user/project"
-provider = "deepseek"
-model_id = "deepseek-v4-flash"
+```bash
+penguin schedule add daily-report --prompt "Summarize yesterday's conversations" \
+  --start-at now --period 1d
+penguin schedule ls                                  # verify
+penguin schedule update daily-report --period 12h    # adjust; --enable/--disable to toggle
+penguin schedule rm daily-report                     # remove — no confirmation prompt
 ```
 
-The server's scheduler reconciles the folder periodically — a written file is picked up on its own; there is no register command and nothing to restart.
+- `--agent-id` defaults to yourself from the caller env, so this schedules the current agent. `--start-at` takes ISO 8601 or `now`; `--period` is at least 5m (`30m`/`12h`/`1d`/`7d`), omit it for a one-shot; `--end-at` bounds recurrence. Target flags are optional: `--session-id <id>` fires into that existing session, `--workspace <path>` (optionally with the `--model-id` + `--provider` pair) pins the new-session form.
+- `add` creates the schedule **enabled** (`--disabled` stages it off) — deliberately diverging from the raw file, where `enabled` defaults to false. `update` is read-modify-write: unspecified fields keep their stored values, and switching the target form clears the other one.
+- In `schedule ls`, read: the AGENT column (without `--agent-id` the listing spans agents), `enabled` (a disabled entry never fires), `startAt` (first firing), `period` (absent means one-shot), the target — an existing session versus a new session per firing — and `lastFiredAt`.
+- The CLI writes through the schedules API, so mistakes are rejected synchronously. The TOML file stays the single source of truth — `<app_data_dir>/agents/<agent_id>/agent_state/schedule/<name>.toml`, fields mirroring the flags (`prompt`, `enabled` — false by default in the file, `start_at`, `period`, `end_at`, `session_id` / `workspace`+`provider`+`model_id`) — and remains editable with file tools; your system prompt's schedule roster lists yours. A hand edit is only validated by the periodic reconcile (roughly every 30s), with errors landing in error records rather than your terminal — prefer the CLI.
 
 ### Run a conversation in the background and steer it mid-flight
 
@@ -131,14 +139,14 @@ Two patterns; both leave you free while the conversation runs.
 **(a) Background CLI process — you get a completion report.** Run the CLI itself as a background command: `exec_command` with `run_in_background: true` and the command
 
 ```bash
-penguin run --agent-id research_bot -m "<long task>"
+penguin run --agent-id <agent_id> -m "<long task>"
 ```
 
 - The harness delivers a `[background_task_done]` report when the CLI exits — no polling needed for completion.
-- Meanwhile, find the session with `penguin ls --json` (it shows as running, with the newest id) and steer it: `penguin input <session_id> -m "Focus on X; skip Y" --no-wait`.
+- Meanwhile, find the session with `penguin ls --json` (it shows as running, with the newest id) and steer it: `penguin input <session_id> -m "Focus on X; skip Y" --timeout 0` (deliver and return at once).
 - Poll the latest answer with bare `penguin input <session_id> --timeout 30s` — a bounded wait that exits 0 with a still-running note when the reply is not in yet — or read the raw transcript with `penguin logs <session_id> --tail 20`.
 
-**(b) Server-side background — survives you.** `penguin run --background --agent-id research_bot -m "<long task>"` prints the session id and exits; the server keeps running the task with no local process.
+**(b) Server-side background — survives you.** `penguin run --background --agent-id <agent_id> -m "<long task>"` prints the session id and exits; the server keeps running the task with no local process.
 
 - Poll the latest answer with bare `penguin input <session_id> --timeout 30s`, watch live with `penguin logs <session_id> -f`, and check running state with `penguin ls --json`; steer with `penguin input <session_id> -m ...` the same way.
 

--- a/packages/skills/skills/penguin-orchestration/SKILL.md
+++ b/packages/skills/skills/penguin-orchestration/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: penguin-orchestration
+description: Drive PenguinHarness itself from a shell — list and create agents and sessions, send and steer messages mid-flight, and query costs and scheduled tasks via the penguin CLI over the local server.
+short_description: Orchestrate agents, sessions, costs and schedules with the penguin CLI.
+short_description_zh: 用 penguin CLI 编排智能体、会话、成本与定时任务。
+version: 1
+updated: 2026-08-25T00:00:00Z
+---
+
+# Penguin Orchestration
+
+The `penguin` CLI is a thin client of the PenguinHarness server. Inside a harness agent session it reaches the same server that is running you, so you can orchestrate the platform yourself: list and create agents, start conversations with them, steer those conversations while they run, and query costs and scheduled tasks.
+
+## Before you start
+
+If the user's message only invokes this skill (e.g. "use penguin-orchestration skill") without a concrete request, ask the user what they want to orchestrate. Read-only commands (`project ls`, `agent ls`, `ls`, `logs`, `cost`, `schedule ls`) are always safe; do not create agents, start sessions or send messages until the goal is clear.
+
+## How the connection works
+
+- **Inside a harness agent session** (you, now): every command subprocess has `PENGUIN_API_URL`, `PENGUIN_API_TOKEN`, `PENGUIN_PROJECT_ID`, `PENGUIN_AGENT_ID` and `PENGUIN_SESSION_ID` injected, so `penguin` commands automatically reach your own server with your project and agent as the defaults — no login step.
+- **Outside an agent** (a human shell): the CLI attaches to the running local server via its lock file, or auto-starts one; the local `<data-root>/api-token` file (0600) authenticates it.
+- You are operating the same server that runs you: sessions and agents you create appear live in the web UI, where the user sees and owns everything you spawn.
+- The injected token is admin-equivalent. Act accordingly: stick to what the task requires, and prefer read-only commands until a mutation is clearly needed.
+
+## Orient first
+
+Before mutating anything, see what exists:
+
+```bash
+penguin project ls        # projects on this server
+penguin agent ls          # agents in the current project
+penguin ls --json         # the project's sessions, with running state
+```
+
+`--json` on any listing gives machine-parseable output.
+
+## Command surface
+
+```
+penguin run -m <msg> [--project-id <id>] [--agent-id <id>] [--workspace <path>]
+            [--model-id <id> --provider <p>] [--approve <mode>] [--thinking <level>]
+            [--session <session_id>] [--background] [--goal [budget]] [--json]
+penguin ls [--project-id <id>] [--agent-id <id>] [-a|--all] [--json]
+penguin input <session_id> -m <text> [--no-wait] [--json]
+penguin logs <session_id> [--tail <n>] [-f|--follow] [--json]
+penguin agent ls [--project-id <id>] [--json]
+penguin agent create --agent-id <id> [--name <s>] [--description <s>] [--skills <a,b>]
+                     [--project-id <id>] [--json]
+penguin project ls [--json]
+penguin cost [--days <n>] [--from <d> --to <d>] [--by date|agent|model|session]
+             [--project-id <id>] [--agent-id <id>] [--json]
+penguin schedule ls [--project-id <id>] [--agent-id <id>] [--json]
+```
+
+- `run` starts a task and waits, rendering the conversation, unless `--background` — then it prints the new session id and exits while the server keeps running the task. `--session <session_id>` runs the task in an existing session instead of creating one. The model reference is the `--provider` + `--model-id` pair (both or neither; neither means the project default). `--thinking <level>` overrides the agent's thinking level for this run; `--workspace` sets the session's working directory (omit for a temporary workspace); `--goal [budget]` runs in goal mode — the session loops until the agent declares the goal complete, with an optional spend budget.
+- `input` steers a **running** session mid-turn (the agent absorbs it as a course correction within the current task) or starts a new turn on an idle one. By default it waits for the reply; `--no-wait` returns right after delivery.
+- `ls` lists sessions newest first; `-a`/`--all` lifts the default cap and lists the full history. `logs` renders a session's transcript: `--tail <n>` for the last entries, `-f` to follow live.
+- Session ids embed their creation timestamp — `session-YYYY-MM-DD-HH-mm-ss-<8hex>` — and every `<session_id>` argument accepts the unique 8-hex tail alone.
+
+## Recipes
+
+### Summarize yesterday's conversations
+
+```bash
+Y="$(date -d yesterday +%F 2>/dev/null || date -v-1d +%F)"   # YYYY-MM-DD
+penguin ls -a --json
+```
+
+- Pick the candidates from the listing: a session id starting `session-$Y-` was created yesterday; also keep earlier sessions whose last-active timestamp in the JSON falls on `$Y` — conversations that continued into yesterday.
+- Read each candidate with `penguin logs <8hex> --tail 100` (widen the tail if the transcript is cut short; `--json` if you want to parse rather than read).
+- Then write the summary yourself — per session: which agent, what was asked, what came of it. There is no summarize command; you are the summarizer.
+
+### Last 7 days of cost
+
+```bash
+penguin cost                       # summary card: today, last 7 days, total
+penguin cost --days 7 --by agent   # who spent it
+```
+
+- The default summary already carries the last-7-days figure; `--by` breaks a range down per `date`, `agent`, `model` or `session`.
+- `--days 7 --by model` and `--days 7 --by date` answer "on which models" and "on which days"; `--from <d> --to <d>` takes an exact range; `--project-id` / `--agent-id` narrow the scope; `--json` for exact numbers.
+
+### Create an agent and talk to it
+
+```bash
+penguin agent create --agent-id research_bot --name "Research Bot" \
+  --description "Collects and digests sources" --skills firecrawl,data-analysis
+penguin run --agent-id research_bot -m "Introduce yourself and list your skills."
+```
+
+- Agent ids must match `^[a-z][a-z0-9_]{1,63}$`: a lowercase letter first, then lowercase letters, digits and underscores — no hyphens.
+- The new agent gets its own Agent State (system prompt, tools, skills, vault) in the current project; `--skills a,b` installs library skills at creation.
+- Each `run` without `--session` opens a fresh session; reuse a session id to continue a conversation.
+
+### Inspect an agent's scheduled tasks
+
+```bash
+penguin schedule ls --agent-id research_bot
+```
+
+Read the fields: `enabled` (a disabled entry never fires), `startAt` (first firing), `period` (recurrence; absent means one-shot), the target — an existing session id versus a new session per firing — and `lastFiredAt`.
+
+To **create** a schedule, write a TOML file with your file tools — that is the sanctioned path: schedule files are meant to be edited directly, and your own agent's current ones are already listed in your system prompt's schedule roster. The path is `<app_data_dir>/agents/<agent_id>/agent_state/schedule/<name>.toml` (App Data Dir is in your Environment section):
+
+```toml
+prompt = "Summarize yesterday's sessions into notes/daily.md"   # required
+enabled = true                       # defaults to false — set true or it never fires
+start_at = "2026-08-26T09:00:00Z"    # ISO 8601, required
+period = "1d"                        # e.g. 30m / 12h / 1d / 7d, minimum 5m; omit for a one-shot
+# end_at = "2026-12-31T00:00:00Z"    # optional stop date
+# Target — either an existing session:
+# session_id = "session-2026-08-25-09-00-00-1a2b3c4d"
+# ...or a new session per firing (workspace plus the provider/model_id pair):
+workspace = "/home/user/project"
+provider = "deepseek"
+model_id = "deepseek-v4-flash"
+```
+
+The server's scheduler reconciles the folder periodically — a written file is picked up on its own; there is no register command and nothing to restart.
+
+### Run a conversation in the background and steer it mid-flight
+
+Two patterns; both leave you free while the conversation runs.
+
+**(a) Background CLI process — you get a completion report.** Run the CLI itself as a background command: `exec_command` with `run_in_background: true` and the command
+
+```bash
+penguin run --agent-id research_bot -m "<long task>"
+```
+
+- The harness delivers a `[background_task_done]` report when the CLI exits — no polling needed for completion.
+- Meanwhile, find the session with `penguin ls --json` (it shows as running, with the newest id) and steer it: `penguin input <session_id> -m "Focus on X; skip Y" --no-wait`.
+- Peek at progress any time with `penguin logs <session_id> --tail 20`.
+
+**(b) Server-side background — survives you.** `penguin run --background --agent-id research_bot -m "<long task>"` prints the session id and exits; the server keeps running the task with no local process.
+
+- Poll with `penguin ls --json` (running state) and read with `penguin logs <session_id> -f` or `--tail`; steer with `penguin input` the same way.
+
+Prefer (a) when you stay around for the result — the completion report comes to you. Prefer (b) when the work must survive your own session ending, or when fanning out many tasks without holding a process per task.
+
+## Cautions
+
+- **One active task per session.** `penguin input` at a busy session steers the running task rather than starting a second one; a new task sent at a busy session waits its turn. For parallel work, start parallel sessions.
+- **Unattended sessions must not need a human.** Create them with `--approve allow-all` (trusted work) or `--approve read-only`; a session left on `always-ask` hangs waiting for approval in the web UI.
+- **No runaway loops.** An agent that messages itself — directly, through a chain of agents, or through a schedule aimed back at its own session — keeps spending until someone stops it. Make every automated conversation terminate.
+- **Spawned work bills the project.** Everything you start lands in the same project's usage (`penguin cost` shows it); a fan-out of sessions multiplies spend.
+- **Configuration stays CLI-managed.** Never read or hand-edit `.project_config.toml` or `agent_state/.vault.toml` — models and secrets go through `penguin config` (see the penguin-cli skill).

--- a/packages/skills/skills/penguin-orchestration/icon.svg
+++ b/packages/skills/skills/penguin-orchestration/icon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="5.2" r="2.5" />
+  <circle cx="5.5" cy="18.3" r="2.2" />
+  <circle cx="18.5" cy="18.3" r="2.2" />
+  <path d="M10.9 7.4 6.6 16.3" />
+  <path d="M13.1 7.4 17.4 16.3" />
+  <path d="M8.4 18.3h7.2" />
+</svg>

--- a/packages/skills/src/index.ts
+++ b/packages/skills/src/index.ts
@@ -212,6 +212,7 @@ export const SKILL_GROUPS: SkillGroupInfo[] = [
     skills: [
       "penguin-sdk",
       "penguin-cli",
+      "penguin-orchestration",
       "agenthub-models",
       "vllm",
       "ollama",

--- a/packages/skills/test/skills.test.ts
+++ b/packages/skills/test/skills.test.ts
@@ -152,6 +152,7 @@ describe("loadSkillGroups / groupSkills", () => {
     expect(groups[2]!.skills.map((s) => s.name)).toEqual([
       "penguin-sdk",
       "penguin-cli",
+      "penguin-orchestration",
       "agenthub-models",
       "vllm",
       "ollama",
@@ -221,6 +222,7 @@ describe("loadSkillGroups / groupSkills", () => {
         skills: [
           "penguin-sdk",
           "penguin-cli",
+          "penguin-orchestration",
           "agenthub-models",
           "vllm",
           "ollama",


### PR DESCRIPTION
Adds the shipped skill `penguin-orchestration` to the library's AI App Development group (right after `penguin-cli`). It teaches an agent running inside PenguinHarness to drive the harness itself over the `penguin` CLI against its own local server: list and create agents, start sessions and steer them mid-flight, read transcripts, and query costs and scheduled tasks — including running a CLI-driven conversation in the background (`exec_command` with `run_in_background`, or `penguin run --background`) and course-correcting it with `penguin input`.

## Depends on #466

This skill documents the server-backed CLI surface introduced by [#466](https://github.com/Prism-Shadow/penguin-harness/pull/466) (branch `feat/cli-on-server`: `penguin run/ls/input/logs/agent/project/cost/schedule`, the injected `PENGUIN_API_URL` / `PENGUIN_API_TOKEN` / `PENGUIN_PROJECT_ID` / `PENGUIN_AGENT_ID` / `PENGUIN_SESSION_ID` env vars inside agent sessions, and lock-file attach / auto-start outside). **It should merge after #466 lands.** The documented surface is synced with #466 through its capability-review round; the skill pins, among others:

- `run -m` + `--project-id/--agent-id/--workspace/--model-id+--provider/--approve/--thinking/--session/--background/--timeout/--goal [budget]/--json`; caller-context defaults (workspace / model pair / approve / thinking inherit from the calling session; explicit flag > caller value > plain fallback)
- `--timeout <duration>` soft-yield on foreground `run`, `input`, `logs -f` (expiry exits 0, task keeps running; `--timeout 0` = deliver/snapshot and return immediately; `--background --timeout` rejected)
- `ls --days <n> -a|--all --json` (project-wide, newest first by last active; `--days`: last-active since local midnight n−1 days ago, today = day 1; `-a` includes archived; JSON includes running state)
- `input <session_id> [-m] [--timeout] [--project-id]` (with `-m`: steer a running session / new turn on an idle one; bare: poll the latest complete assistant text, mirroring `input_subagent`'s empty prompt)
- `logs <session_id> [--project-id] --tail <n> -f|--follow --json`
- `agent create --agent-id --name --description --skills --project-id --json` (id regex `^[a-z][a-z0-9_]{1,63}$`; new agents start with no skills preinstalled)
- `cost --days/--from+--to/--by date|agent|model|session` (default prints today / last-7-days / total)
- `schedule ls` (AGENT column) and `schedule add/update/rm <name>` — validated writers over the schedules API (`add` defaults to enabled, diverging from the raw file's disabled default; `update` is read-modify-write; `rm` prompts nothing); the `agent_state/schedule/<name>.toml` file stays the single source of truth and hand-editing remains the documented advanced path with the reconcile-lag caveat
- session ids `session-YYYY-MM-DD-HH-mm-ss-<8hex>`; id arguments take any unique substring, the 8-hex tail as the recommended short form (ambiguous fragments error listing candidates)

The recipes are organized around five concrete scenarios: recent sessions with their latest replies (`ls --days` + bare `input`), a weekly summary written by a new session via workspace-file exchange, create-an-agent-and-say-hello, a per-agent cost summary, and scheduling the current agent — plus the background-run-and-steer pattern.

## Changes

- New `packages/skills/skills/penguin-orchestration/` (SKILL.md v1 + hand-drawn icon.svg); no `preinstall` marker, so `default_agent` preinstalls it.
- Registered in `SKILL_GROUPS`, both membership assertions in `packages/skills/test/skills.test.ts`, the API-shape assertion in `packages/server/test/skills.test.ts`, the package README table, and the bilingual docs tables (`packages/docs/content/skills.{en,zh}.md`).
- Bilingual changelog pair under `changelog/unreleased/`.
- Design-repo counterpart (skill-group list in `specs/05-ARCHITECTURE.md` + `specs/08-CHANGELOG.md` entry): [penguin-harness-design#60](https://github.com/Prism-Shadow/penguin-harness-design/pull/60).

Not touched (pre-existing drift, kept out of scope): the root `README.md`/`README.zh.md` group tables and `packages/landing/src/lib/strings*.ts` skill lists already lack `skill-porting` and are not test-pinned.

## Verification

- `pnpm -r build`, `pnpm -r typecheck` — green (exit 0, checked with pipefail).
- `pnpm --filter @prismshadow/penguin-skills test` — 25/25 passed.
- `pnpm --filter @prismshadow/penguin-docs test` — 53/53 passed (includes `skills-sync.test.ts`).
- `pnpm --filter @prismshadow/penguin-server exec vitest run test/skills.test.ts` — 18/18 passed.
- `pnpm format` + `pnpm format:check`, `git diff --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HY3k3oyazaJhvc6gRwLXAL
