### PR TITLE
Dev CLI gets its own data root; agent-env and MCP hygiene guarantees pinned

### DIFF
--- a/.agents/skills/penguin-harness-manual-test/SKILL.md
+++ b/.agents/skills/penguin-harness-manual-test/SKILL.md
@@ -18,8 +18,9 @@ workspace deps); `pnpm desktop` runs a full `pnpm -r build`, so it is slow to st
 | `pnpm dev:docs` | http://localhost:7367 | none (static) |
 
 Other fixed ports (`packages/core/src/internal/ports.ts`): 7364 installed server, 7368 dev backend,
-7369 `pnpm penguin web`. On a shared box, `ss -tln` before assuming one is free; `PORT=` inline
-moves it.
+7369 `pnpm penguin web` (data root `~/.penguin/dev-data-cli` — its own, so it can serve while an
+Agent it hosts runs `pnpm dev`; the lock is per root). On a shared box, `ss -tln` before assuming
+one is free; `PORT=` inline moves it.
 
 The user's installed app, server and CLI all use `~/.penguin/data` — their real Agents, Sessions
 and keys. Never point a dev run there. Both surfaces print the root they took (`Data root: …`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,10 +45,18 @@ that only re-sync when the package's `build` script runs via pnpm
 cache — on the old build; if a running dev web app still serves stale core after a manual
 rebuild, delete `packages/web/node_modules/.vite` and restart.
 
-Dev entry points that touch data (`pnpm dev`, `pnpm dev:server`, `pnpm penguin`,
-`pnpm desktop`) default to a separate data root, `~/.penguin/dev-data`, kept apart from
-the installed CLI/server's `~/.penguin/data` — hacking on the repo never mixes state with
-your real agents. Need a different root? Pass `PENGUIN_HOME` inline, for the single
+Dev entry points that touch data default to separate data roots, kept apart from the
+installed CLI/server's `~/.penguin/data` — hacking on the repo never mixes state with
+your real agents. `pnpm dev`, `pnpm dev:server` and `pnpm desktop` share
+`~/.penguin/dev-data`; `pnpm penguin` takes its own `~/.penguin/dev-data-cli`, because a
+data root admits one server at a time (`<root>/server.lock`) and the dev CLI's
+`penguin web` is exactly the harness that then asks an Agent to run `pnpm dev` — on a
+shared root that `dev:server` would refuse to start against the harness's own lock (the
+same coexistence that already gives it port 7369, see
+`packages/core/src/internal/ports.ts`). To aim a dev CLI command at the `pnpm dev`
+dataset anyway, say so per command: `PENGUIN_HOME=~/.penguin/dev-data pnpm penguin
+config model list`, or `--root` where the subcommand takes it. Need a different root?
+Pass `PENGUIN_HOME` inline, for the single
 command that needs it (`PENGUIN_HOME=~/.penguin/dev-data-<topic> pnpm dev`) — never export
 it into your shell: those defaults apply only when the variable is unset or empty
 (`scripts/run-with-env.mjs`), so an exported value silently wins over all of them, and an

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,11 +51,11 @@ your real agents. `pnpm dev`, `pnpm dev:server` and `pnpm desktop` share
 `~/.penguin/dev-data`; `pnpm penguin` takes its own `~/.penguin/dev-data-cli`, because a
 data root admits one server at a time (`<root>/server.lock`) and the dev CLI's
 `penguin web` is exactly the harness that then asks an Agent to run `pnpm dev` — on a
-shared root that `dev:server` would refuse to start against the harness's own lock (the
-same coexistence that already gives it port 7369, see
+shared root that Agent's `dev:server` would refuse to start, blocked by the harness's
+own lock (the same coexistence that already gives it port 7369, see
 `packages/core/src/internal/ports.ts`). To aim a dev CLI command at the `pnpm dev`
-dataset anyway, say so per command: `PENGUIN_HOME=~/.penguin/dev-data pnpm penguin
-config model list`, or `--root` where the subcommand takes it. Need a different root?
+dataset anyway, say so per command — `PENGUIN_HOME=~/.penguin/dev-data pnpm penguin ...`,
+or `--root` where the subcommand takes it. Need a different root?
 Pass `PENGUIN_HOME` inline, for the single
 command that needs it (`PENGUIN_HOME=~/.penguin/dev-data-<topic> pnpm dev`) — never export
 it into your shell: those defaults apply only when the variable is unset or empty

--- a/changelog/unreleased/2026-08-24-agent-commands-own-data-root.md
+++ b/changelog/unreleased/2026-08-24-agent-commands-own-data-root.md
@@ -34,7 +34,7 @@ nobody is thinking about it, so a variable a future feature adds is covered with
 - Matching is case-insensitive, like every other stripped name, so a Windows `set Penguin_Home=…`
   is removed too.
 
-## 兼容性
+## Compatibility
 
 A command run by an Agent that relied on inheriting any `PENGUIN_*` variable from the serving
 process now sees none of them, and any harness it starts resolves the default root

--- a/changelog/unreleased/2026-08-26-agent-env-hygiene.md
+++ b/changelog/unreleased/2026-08-26-agent-env-hygiene.md
@@ -1,0 +1,41 @@
+# The dev CLI serves from its own data root, so it coexists with `pnpm dev`
+
+- **Date:** 2026-08-26
+- **Type:** fix
+- **Scope:** `tooling`, `core`, `cli`
+
+[中文版](2026-08-26-agent-env-hygiene.zh.md)
+
+`pnpm penguin` moved to its own default data root, `~/.penguin/dev-data-cli`, completing the
+isolation its port (7369) began. A data root admits one server at a time (`<root>/server.lock`), so
+on the shared `~/.penguin/dev-data` the dev CLI's `penguin web` and `pnpm dev:server` could only run
+alternately — and a harness started as `pnpm penguin web` is exactly the one that asks an Agent to
+run `pnpm dev` in this repo. With the split, that Agent's `dev:server` starts instead of exiting 3
+against the harness's own lock.
+
+## Details
+
+- The allocation table in `packages/core/src/internal/ports.ts` grew a data-root column and now
+  also names the desktop's port behavior (no fixed port; sticky `PORT=0` allocation) and the web
+  e2e harness's ports and throwaway root, so one place answers both questions.
+- A new `dev-entry-isolation` test in the CLI package pins the pairwise disjointness of the
+  (port, data root) pairs — the assignments live on package.json script lines that nothing
+  type-checks — and that the root and `packages/cli` spellings of the `penguin` script agree.
+- The dev desktop shell stayed on `~/.penguin/dev-data` deliberately: a second server on a locked
+  root is its attach-mode case rather than a startup failure, and `pnpm dev` and `pnpm desktop`
+  used alternately sharing one dataset is the point of the common root. The test pins that choice
+  too.
+- Two regression tests pinned environment guarantees that previously had no local coverage: a
+  stdio MCP server never sees the serving process's `PENGUIN_*` / `PORT` (its child environment is
+  the MCP SDK's safe-inherited allowlist plus the entry's own `env` — the same outcome the
+  [command-environment strip](2026-08-24-agent-commands-own-data-root.md) enforces, by the opposite
+  mechanism), and an explicit injection layered after that strip wins for any `PENGUIN_*` name —
+  the seam the Agent vault uses today and any later injection layer composes with.
+
+## Compatibility
+
+Contributors take a one-time move: `pnpm penguin` had run on `~/.penguin/dev-data`, so Agents and
+Sessions created through it no longer appear in its window — the data itself stays on disk,
+untouched. To aim a dev CLI command at the `pnpm dev` dataset, say so per command
+(`PENGUIN_HOME=~/.penguin/dev-data pnpm penguin config model list`, or `--root` where the
+subcommand takes it). Installed entry points and both desktop forms are unaffected.

--- a/changelog/unreleased/2026-08-26-agent-env-hygiene.md
+++ b/changelog/unreleased/2026-08-26-agent-env-hygiene.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-26
 - **Type:** fix
 - **Scope:** `tooling`, `core`, `cli`
+- **PR:** [#471](https://github.com/Prism-Shadow/penguin-harness/pull/471)
 
 [中文版](2026-08-26-agent-env-hygiene.zh.md)
 

--- a/changelog/unreleased/2026-08-26-agent-env-hygiene.zh.md
+++ b/changelog/unreleased/2026-08-26-agent-env-hygiene.zh.md
@@ -1,0 +1,37 @@
+# dev CLI 使用独立数据根，与 `pnpm dev` 并行共存
+
+- **Date:** 2026-08-26
+- **Type:** fix
+- **Scope:** `tooling`, `core`, `cli`
+
+[English](2026-08-26-agent-env-hygiene.md)
+
+`pnpm penguin` 改用独立的默认数据根 `~/.penguin/dev-data-cli`，把它的端口（7369）开始的隔离补齐。
+一个数据根同时只允许一个 server（`<root>/server.lock`），因此在共享的 `~/.penguin/dev-data` 上，
+dev CLI 的 `penguin web` 与 `pnpm dev:server` 只能交替运行——而以 `pnpm penguin web` 启动的
+harness 恰恰就是那个会让 Agent 在本仓库里运行 `pnpm dev` 的实例。拆分之后，该 Agent 的
+`dev:server` 可以正常启动，不再对着 harness 自己持有的锁以退出码 3 收场。
+
+## 细节
+
+- `packages/core/src/internal/ports.ts` 的分配表增加了数据根一列，并补记桌面端的端口行为
+  （无固定端口；粘滞的 `PORT=0` 分配）与 web e2e harness 的端口和一次性数据根，两类问题在同一处
+  得到回答。
+- CLI 包新增 `dev-entry-isolation` 测试，钉住各（端口, 数据根）组合的两两不相交——这些赋值都写在
+  package.json 脚本行上，没有任何类型检查覆盖——同时钉住根目录与 `packages/cli` 两处 `penguin`
+  脚本的赋值保持一致。
+- 桌面端 dev shell 刻意留在 `~/.penguin/dev-data`：对已加锁数据根再起一个 server 属于它的附着模式
+  而非启动失败，且交替使用的 `pnpm dev` 与 `pnpm desktop` 共享同一份数据正是共用数据根的意义所在。
+  测试同样钉住了这一选择。
+- 两个回归测试钉住了此前没有本地覆盖的环境保证：stdio MCP server 永远看不到服务进程自身的
+  `PENGUIN_*` / `PORT`（其子进程环境 = MCP SDK 安全继承白名单 + 条目自身 `env`——与
+  [命令环境剥离](2026-08-24-agent-commands-own-data-root.zh.md)以相反机制达成同一结果）；在该剥离
+  之后显式注入的变量对任何 `PENGUIN_*` 名称一律以注入值为准——这正是 Agent vault 今天所用、后续
+  任何注入层也将依赖的组合边界。
+
+## 兼容性
+
+贡献者需要一次性迁移：`pnpm penguin` 此前运行在 `~/.penguin/dev-data` 上，经它创建的 Agent 与
+Session 不再出现在它的窗口中——磁盘上的数据本身原样保留、不受影响。要把 dev CLI 命令指向
+`pnpm dev` 的数据集，按命令显式声明（`PENGUIN_HOME=~/.penguin/dev-data pnpm penguin config model
+list`，或在支持处使用 `--root`）。已安装的入口与两种桌面形态均不受影响。

--- a/changelog/unreleased/2026-08-26-agent-env-hygiene.zh.md
+++ b/changelog/unreleased/2026-08-26-agent-env-hygiene.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-26
 - **Type:** fix
 - **Scope:** `tooling`, `core`, `cli`
+- **PR:** [#471](https://github.com/Prism-Shadow/penguin-harness/pull/471)
 
 [English](2026-08-26-agent-env-hygiene.md)
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:e2e": "pnpm --filter @prismshadow/penguin-core test:e2e",
     "build": "pnpm -r build && pnpm link:cli",
     "link:cli": "pnpm --dir packages/cli link --global || echo '[link:cli] pnpm global directory not configured; skipping the global penguin link (run pnpm setup once first)'",
-    "penguin": "node scripts/run-with-env.mjs PENGUIN_HOME=~/.penguin/dev-data PORT=7369 -- tsx packages/cli/src/penguin.ts",
+    "penguin": "node scripts/run-with-env.mjs PENGUIN_HOME=~/.penguin/dev-data-cli PORT=7369 -- tsx packages/cli/src/penguin.ts",
     "dev": "concurrently -n server,web -c cyan,magenta \"pnpm dev:server\" \"pnpm dev:web\"",
     "dev:server": "pnpm --filter @prismshadow/penguin-server dev",
     "dev:web": "node scripts/dev-prebuild.mjs && pnpm --filter @prismshadow/penguin-web dev",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "test": "vitest run --passWithNoTests",
     "build": "tsup",
-    "penguin": "node ../../scripts/run-with-env.mjs PENGUIN_HOME=~/.penguin/dev-data PORT=7369 -- tsx src/penguin.ts"
+    "penguin": "node ../../scripts/run-with-env.mjs PENGUIN_HOME=~/.penguin/dev-data-cli PORT=7369 -- tsx src/penguin.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/client": "^2.0.0",

--- a/packages/cli/test/dev-entry-isolation.test.ts
+++ b/packages/cli/test/dev-entry-isolation.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Drift guard for the port/data-root isolation of the dev entry points.
+ *
+ * Two servers cannot share a port, and a data root admits one server at a time
+ * (`<root>/server.lock`) — so entry points meant to run at the same time must differ in
+ * BOTH. The pair that carries that requirement is `pnpm dev:server` and the dev CLI's
+ * `penguin web`: a harness started as `pnpm penguin web` is exactly what asks an Agent to
+ * run `pnpm dev` in this repo (the allocation table lives in
+ * `packages/core/src/internal/ports.ts`). The assignments themselves are run-with-env
+ * defaults on package.json script lines that nothing type-checks, so this test parses
+ * them back out and pins the disjointness — including against the installed server's
+ * port and root, which those dev entries must never touch.
+ *
+ * The desktop's dev shell deliberately shares `~/.penguin/dev-data` with `dev:server`
+ * (a second server on a locked root is its attach-mode case, and the two surfaces
+ * sharing one dataset when used alternately is the point), and it binds no fixed port —
+ * so it is pinned to that root rather than away from it.
+ */
+import { readFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { DEFAULT_SERVER_PORT } from "@prismshadow/penguin-core";
+
+const cliDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = path.resolve(cliDir, "..", "..");
+
+const readScripts = (pkgPath: string): Record<string, string> =>
+  (JSON.parse(readFileSync(pkgPath, "utf8")) as { scripts?: Record<string, string> }).scripts ?? {};
+
+/**
+ * The `VAR=value` defaults a script passes to run-with-env.mjs (the segment between the
+ * script path and the `--` separator). Returns null when the script does not use it.
+ */
+function runWithEnvDefaults(script: string | undefined): Record<string, string> | null {
+  if (script === undefined) return null;
+  const m = script.match(/run-with-env\.mjs\s+(.+?)\s+--\s/);
+  if (m === null) return null;
+  const defaults: Record<string, string> = {};
+  for (const token of m[1]!.split(/\s+/)) {
+    const eq = token.indexOf("=");
+    if (eq > 0) defaults[token.slice(0, eq)] = token.slice(eq + 1);
+  }
+  return defaults;
+}
+
+/** Expands the leading `~/` the same way run-with-env.mjs does, then normalizes. */
+function expandHome(value: string): string {
+  const expanded =
+    value === "~" || value.startsWith("~/") ? path.join(os.homedir(), value.slice(2)) : value;
+  return path.normalize(expanded);
+}
+
+const rootScripts = readScripts(path.join(repoRoot, "package.json"));
+const serverScripts = readScripts(path.join(repoRoot, "packages", "server", "package.json"));
+const cliScripts = readScripts(path.join(cliDir, "package.json"));
+
+const devServer = runWithEnvDefaults(serverScripts["dev"]);
+const devCli = runWithEnvDefaults(rootScripts["penguin"]);
+const devDesktop = runWithEnvDefaults(rootScripts["desktop"]);
+
+/** The installed server/CLI root, `~/.penguin/data` (core's resolveRoot() default). */
+const installedRoot = path.join(os.homedir(), ".penguin", "data");
+
+describe("dev entry point isolation (ports and data roots)", () => {
+  it("dev:server and the dev CLI each declare a port and a data root", () => {
+    for (const [name, defaults] of [
+      ["dev:server", devServer],
+      ["penguin", devCli],
+    ] as const) {
+      expect(defaults, `${name} must set its defaults through run-with-env`).not.toBeNull();
+      expect(defaults!.PORT, `${name} must pin a port`).toMatch(/^\d+$/);
+      expect(defaults!.PENGUIN_HOME, `${name} must pin a data root`).toBeDefined();
+    }
+  });
+
+  it("no two simultaneously runnable server entries share a port", () => {
+    const ports = [
+      Number(devServer!.PORT),
+      Number(devCli!.PORT),
+      DEFAULT_SERVER_PORT, // the installed server both dev entries must coexist with
+    ];
+    expect(new Set(ports).size).toBe(ports.length);
+  });
+
+  it("no two simultaneously runnable server entries share a data root", () => {
+    const roots = [
+      expandHome(devServer!.PENGUIN_HOME!),
+      expandHome(devCli!.PENGUIN_HOME!),
+      path.normalize(installedRoot),
+    ];
+    expect(new Set(roots).size).toBe(roots.length);
+  });
+
+  it("the root and packages/cli penguin scripts agree on their defaults", () => {
+    // Two spellings of the same entry point; a root moved in one and not the other
+    // would make `pnpm penguin` and `pnpm --dir packages/cli penguin` serve different data.
+    expect(runWithEnvDefaults(cliScripts["penguin"])).toEqual(devCli);
+  });
+
+  it("the dev desktop shell stays on dev:server's root, by design", () => {
+    expect(devDesktop).not.toBeNull();
+    expect(expandHome(devDesktop!.PENGUIN_HOME!)).toBe(expandHome(devServer!.PENGUIN_HOME!));
+    // No PORT: the embedded server allocates its own (PORT=0 + sticky preference).
+    expect(devDesktop!.PORT).toBeUndefined();
+  });
+});

--- a/packages/core/src/environment/mcp/provider.ts
+++ b/packages/core/src/environment/mcp/provider.ts
@@ -342,6 +342,11 @@ export class McpToolProvider {
         // Safe inherited defaults plus the entry's own env — and nothing else: the Agent
         // vault is deliberately NOT injected into MCP server processes (unlike command
         // subprocesses); a variable a server needs must be listed in the entry's env.
+        // The SDK defaults are an allowlist (HOME/PATH/SHELL-class names only), so the
+        // harness's own configuration — every PENGUIN_* variable, PORT/HOST and the rest —
+        // never reaches a server: the same outcome the command-session strip enforces,
+        // by the opposite mechanism. Widening this base (e.g. to process.env) would undo
+        // that; the "harness variables never reach a stdio server" test pins it.
         env: { ...getDefaultEnvironment(), ...t.env },
         ...(t.cwd !== undefined || this.workspaceDir !== undefined
           ? { cwd: t.cwd ?? this.workspaceDir }

--- a/packages/core/src/environment/tools/command/session-manager.ts
+++ b/packages/core/src/environment/tools/command/session-manager.ts
@@ -193,6 +193,14 @@ export class CommandSessionManager {
       // policy applied (strip or inject); the vault still wins — over an injected proxy
       // too — so a user who genuinely wants PORT, or their own proxy, in commands can set
       // it there.
+      //
+      // The strip governs inheritance only: it runs inside hostEnvForChild and never
+      // re-applies to later spread entries, so anything the harness deliberately layers
+      // into this spread after the host env carries authoritative values into the child,
+      // stripped names — PENGUIN_* included — and all. An injection layer added to this
+      // spread later composes with the strip for free: the inherited copy is gone, the
+      // injected value stands (pinned by the "an explicit injection layered after the
+      // strip wins" test).
       env: { ...hostEnvForChild(this.proxyEnv?.() ?? null), ...this.vault, ...HARDENED_ENV },
     });
   }

--- a/packages/core/src/internal/ports.ts
+++ b/packages/core/src/internal/ports.ts
@@ -36,8 +36,8 @@
  * to the left -- `dev:server` failing to bind, or the Vite proxy answering from the harness.
  * Its data root is split from `dev-data` for the same reason as its port: a data root
  * admits one server at a time (`<root>/server.lock`), so on a shared root the Agent's
- * `dev:server` would refuse to start against the harness's own lock no matter how the
- * ports are laid out. The dev desktop shell deliberately stays on `dev-data`: a second
+ * `dev:server` would refuse to start, blocked by the harness's own lock, no matter how
+ * the ports are laid out. The dev desktop shell deliberately stays on `dev-data`: a second
  * server on a locked root is its attach-mode case (the window opens the running
  * instance), not a startup failure, and sharing one dataset between `pnpm dev` and
  * `pnpm desktop` used alternately is the point of the common root.

--- a/packages/core/src/internal/ports.ts
+++ b/packages/core/src/internal/ports.ts
@@ -7,18 +7,23 @@
  */
 
 /**
- * Port allocation across the repo (documented here because it is the one place a reader
- * looks for it; the dev ports themselves live in vite configs and package.json scripts,
- * neither of which can import this module):
+ * Port and data-root allocation across the repo (documented here because it is the one
+ * place a reader looks for it; the dev ports themselves live in vite configs and
+ * package.json scripts, neither of which can import this module):
  *
- * | port | who                                | where                                       |
- * | ---- | ---------------------------------- | ------------------------------------------- |
- * | 7364 | installed server / Web UI          | `DEFAULT_SERVER_PORT` below                 |
- * | 7365 | `pnpm dev:web` (Vite)              | `packages/web/vite.config.ts`               |
- * | 7366 | `pnpm dev:landing` (Vite)          | `packages/landing/vite.config.ts`           |
- * | 7367 | `pnpm dev:docs` (Vite)             | `packages/docs/vite.config.ts`              |
- * | 7368 | `pnpm dev:server` (dev backend)    | `packages/server/package.json` `dev`        |
- * | 7369 | `pnpm penguin web` (dev CLI)       | the root and cli `penguin` scripts          |
+ * | port | who                                | data root                  | where                                |
+ * | ---- | ---------------------------------- | -------------------------- | ------------------------------------ |
+ * | 7364 | installed server / Web UI          | `~/.penguin/data`          | `DEFAULT_SERVER_PORT` below          |
+ * | 7365 | `pnpm dev:web` (Vite)              | none (proxies to 7368)     | `packages/web/vite.config.ts`        |
+ * | 7366 | `pnpm dev:landing` (Vite)          | none (static)              | `packages/landing/vite.config.ts`    |
+ * | 7367 | `pnpm dev:docs` (Vite)             | none (static)              | `packages/docs/vite.config.ts`       |
+ * | 7368 | `pnpm dev:server` (dev backend)    | `~/.penguin/dev-data`      | `packages/server/package.json` `dev` |
+ * | 7369 | `pnpm penguin web` (dev CLI)       | `~/.penguin/dev-data-cli`  | the root and cli `penguin` scripts   |
+ *
+ * The desktop app binds no fixed port in either form (PORT=0 with a per-instance sticky
+ * preference); its release form shares `~/.penguin/data` with the CLI by design and its
+ * dev form takes `~/.penguin/dev-data` (see `packages/desktop/src/app-identity.ts`). The
+ * web e2e harness runs on 8930/8931 against a throwaway root (`packages/web/e2e/run.sh`).
  *
  * The development backend deliberately does **not** share 7364 with an installed one: the
  * two are routinely running at once, and before they were split, `pnpm dev` either failed
@@ -29,6 +34,16 @@
  * run at once: a harness started as `pnpm penguin web` is exactly what asks an Agent to run
  * `pnpm dev` in this repo, and sharing the number would reintroduce that collision one step
  * to the left -- `dev:server` failing to bind, or the Vite proxy answering from the harness.
+ * Its data root is split from `dev-data` for the same reason as its port: a data root
+ * admits one server at a time (`<root>/server.lock`), so on a shared root the Agent's
+ * `dev:server` would refuse to start against the harness's own lock no matter how the
+ * ports are laid out. The dev desktop shell deliberately stays on `dev-data`: a second
+ * server on a locked root is its attach-mode case (the window opens the running
+ * instance), not a startup failure, and sharing one dataset between `pnpm dev` and
+ * `pnpm desktop` used alternately is the point of the common root.
+ *
+ * `packages/cli/test/dev-entry-isolation.test.ts` pins the pairwise disjointness of the
+ * (port, root) pairs above.
  */
 
 /** Default main server / Web UI port; deliberately avoids common defaults like 3000/8080. */

--- a/packages/core/test/exec-session.test.ts
+++ b/packages/core/test/exec-session.test.ts
@@ -463,6 +463,31 @@ describe("harness environment variables never reach a spawned command", () => {
       vaultEnv.dispose();
     }
   });
+
+  it("an explicit injection layered after the strip wins, for any PENGUIN_* name", async () => {
+    // The strip governs inheritance only — it runs while the host env is copied and never
+    // re-applies to entries spread in after it. That seam is what every injection layer
+    // relies on (the vault stands in for all of them here): the host's copy of the name is
+    // set to a different value to prove the child's value came from the injection, not
+    // through inheritance.
+    const savedInherited = process.env.PENGUIN_API_URL;
+    process.env.PENGUIN_API_URL = "http://inherited.invalid";
+    const vaultEnv = new Environment({
+      workspaceDir: tmp,
+      toolConfig: sessionConfig(),
+      vault: { PENGUIN_API_URL: "http://injected.example" },
+    });
+    try {
+      const res = await runTool(vaultEnv, "exec_command", {
+        cmd: `node -e "console.log('A=[' + (process.env.PENGUIN_API_URL ?? '') + ']')"`,
+      });
+      expect(res.output).toContain("A=[http://injected.example]");
+    } finally {
+      vaultEnv.dispose();
+      if (savedInherited === undefined) delete process.env.PENGUIN_API_URL;
+      else process.env.PENGUIN_API_URL = savedInherited;
+    }
+  });
 });
 
 describe("proxyEnv policy governs the proxy variables commands inherit", () => {

--- a/packages/core/test/fixtures/mcp-stdio-server.mjs
+++ b/packages/core/test/fixtures/mcp-stdio-server.mjs
@@ -52,9 +52,20 @@ server.registerTool(
 
 server.registerTool(
   "probe",
-  { description: "Reports FIXTURE_SECRET and the process cwd.", inputSchema: z.object({}) },
+  {
+    description:
+      "Reports FIXTURE_SECRET, the process cwd, and the host's PENGUIN_HOME/PORT (which must not arrive).",
+    inputSchema: z.object({}),
+  },
   async () => ({
-    content: [{ type: "text", text: `${process.env.FIXTURE_SECRET ?? ""}|${process.cwd()}` }],
+    content: [
+      {
+        type: "text",
+        text:
+          `${process.env.FIXTURE_SECRET ?? ""}|${process.cwd()}` +
+          `|${process.env.PENGUIN_HOME ?? ""}|${process.env.PORT ?? ""}`,
+      },
+    ],
   }),
 );
 

--- a/packages/core/test/mcp-tools.test.ts
+++ b/packages/core/test/mcp-tools.test.ts
@@ -263,6 +263,33 @@ describe("MCP over stdio — per-server budgets and interruption", () => {
     }
   });
 
+  it("the host's harness variables never reach a stdio server", async () => {
+    // The stdio child env is the MCP SDK's safe-inherited allowlist plus the entry's own
+    // env — assembled in provider.ts, apart from the command-session strip — so the
+    // serving process's PENGUIN_HOME/PORT must be invisible here even though no strip
+    // runs on this path. Pinned locally because only the allowlist guarantees it: a
+    // widened inherited base (say, spreading process.env) would leak silently otherwise.
+    // The child env is captured when the server connects, i.e. at the first tool call of
+    // this fresh Environment, so the pollution below is what that capture sees.
+    const saved = { PENGUIN_HOME: process.env.PENGUIN_HOME, PORT: process.env.PORT };
+    process.env.PENGUIN_HOME = "leak-check-root";
+    process.env.PORT = "7364";
+    const env = makeEnv({ env: { FIXTURE_SECRET: "still-arrives" } });
+    try {
+      const final = finalPayload(await runTool(env, "mcp__fx__probe", {}));
+      const [secret, , penguinHome, port] = (final.output ?? "").split("|");
+      expect(secret).toBe("still-arrives");
+      expect(penguinHome).toBe("");
+      expect(port).toBe("");
+    } finally {
+      env.dispose();
+      for (const [k, v] of Object.entries(saved)) {
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      }
+    }
+  });
+
   it("skips an unreachable server with a warning instead of failing", async () => {
     const warn = vi.fn();
     const provider = new McpToolProvider(


### PR DESCRIPTION
## What

Environment-hygiene and port/data-root isolation pass over every entry point, in two parts.

**Part A — audit of the port/data-root landscape, with one fix.** Every place a port or a data root is chosen was enumerated (`ports.ts`, package.json script lines, vite configs, the desktop shell, the e2e harness, `penguin-hmr`, `run-with-env.mjs`). The matrix of server-holding entry points:

| Entry point | Port | Data root | When a second server hits the root |
| --- | --- | --- | --- |
| installed `penguin server` / `penguin web` | 7364 | `~/.penguin/data` | `server`: refuses with the URL; `web`: opens the existing instance |
| installed desktop | none fixed (sticky `PORT=0`) | `~/.penguin/data` (shares the CLI root by design) | attach mode |
| `pnpm dev:server` (also via `pnpm dev`) | 7368 | `~/.penguin/dev-data` | refuses, exit 3 |
| `pnpm penguin web` (dev CLI) | 7369 | **was `~/.penguin/dev-data` → now `~/.penguin/dev-data-cli`** | opens the existing instance |
| `pnpm desktop` (dev shell) | none fixed (sticky, own userData per #292 fix) | `~/.penguin/dev-data` | attach mode |
| web e2e (`packages/web/e2e/run.sh`) | 8930 (+8931 mock) | `mktemp -d`, deleted after | n/a |
| `penguin-hmr` | whatever the pushed CLI binds (7364 default) | `~/.penguin/data` | deliberate: a pushed CLI acts as the installed one |

Non-serving dev ports: vite web 7365 (proxy → 7368, or `PORT`/`PENGUIN_API_PROXY`), landing 7366, docs 7367 — no data roots.

Findings:

- **Installed × dev holds everywhere**: ports 7364 vs 7365–7369/ephemeral, roots `data` vs `dev-data*`, and `run-with-env.mjs` already names any default an exported variable displaces.
- **One genuine conflict, fixed**: the dev CLI shared `~/.penguin/dev-data` with `pnpm dev:server`. The lock is per root, so the pair that port 7369 exists to let run simultaneously (`ports.ts`: a harness started as `pnpm penguin web` is exactly what asks an Agent to run `pnpm dev` in this repo) could not actually coexist — the Agent's `dev:server` exited 3 against the harness's own lock. `pnpm penguin` now defaults to `~/.penguin/dev-data-cli` (root + cli scripts). Trade-off stated in CONTRIBUTING and the changelog: aiming a dev CLI command at the `pnpm dev` dataset is now said per command (inline `PENGUIN_HOME` or `--root`).
- **Deliberate sharing, now pinned instead of implicit**: the dev desktop stays on `~/.penguin/dev-data` — a second server on a locked root is its attach-mode case, not a failure, and the two surfaces used alternately sharing one dataset is the point. A new `packages/cli/test/dev-entry-isolation.test.ts` pins the (port, root) disjointness of the simultaneous pairs, the root/cli script agreement, and the desktop's root-sharing choice; the `ports.ts` table now carries the data-root column plus the desktop/e2e rows.

**Part B — exec_command / MCP environment hygiene.** The strip itself landed in #434 (every `PENGUIN_*` by prefix, plus `PORT`/`HOST`/`FORCE_COLOR`/`CLICOLOR_FORCE`; removal not blanking; case-insensitive for Windows; vault re-adds), so this PR verifies and pins rather than reimplements:

- **Layering seam made explicit** for injection layers added to the spawn spread later (e.g. control-var injection): the strip runs inside `hostEnvForChild` and never re-applies to later spread entries, so `{ ...hostEnvForChild(...), ...vault, ...HARDENED_ENV }` composes with any future `...injected` for free — inherited copy gone, injected value stands. Asserted in a comment at the spread and a new test ("an explicit injection layered after the strip wins, for any `PENGUIN_*` name") that pollutes the parent with one value and injects another.
- **MCP stdio checked for the same leak: there is none.** Its child env is the MCP SDK's safe-inherited allowlist (`HOME`/`PATH`/`SHELL`-class names only) plus the entry's own `env` — the spec'd shape — so no `PENGUIN_*`/`PORT` can arrive by construction. That guarantee had no local coverage (only the SDK's implementation provided it); a new test pins it (fixture probe now reports `PENGUIN_HOME`/`PORT`), and the provider comment now names the invariant. Policy kept as-is: commands strip a blocklist from a full inherit, MCP inherits an allowlist — different mechanisms, same outcome (harness config never reaches a child), each fitting its spec.
- The web terminal was considered and left alone: it is the signed-in user's own shell on the host, full-env inheritance is its documented design, and a shell running as the server's OS user could read the server's environment regardless — stripping there would be cosmetic.

## Compatibility

- The #434 break (agent shells no longer inherit `PENGUIN_HOME` etc.) is unchanged here; its entry documents the vault migration. Control-var injection (PR #466) will cover the "call the same harness's API" need without any inheritance; sharing a data root with the running harness remains a vault decision.
- The dev CLI root move is contributor-facing only; the changelog entry's Compatibility section states the one-time move and the explicit-root escape hatch. No compat code was added, so no dedicated backward-compatibility entry.
- Drive-by: the #434 entry's English file used the Chinese compat heading; normalized to `## Compatibility` per changelog/README.

## Verification

- `pnpm -r build`, `pnpm -r typecheck` — green (Node 24).
- `pnpm --filter @prismshadow/penguin-core test` — 991 passed, 5 skipped; `--filter @prismshadow/penguin-server test` — 977 passed; `--filter @prismshadow/penguin-cli test` — 306 passed.
- `pnpm format` + `pnpm format:check`, `git diff --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HY3k3oyazaJhvc6gRwLXAL
