### PR TITLE
The Windows signing identity is NaisNet Technology Co., Ltd.

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -285,7 +285,7 @@ jobs:
         run: |
           $ErrorActionPreference = "Stop"
 
-          $publisher = "RushRush Network Technology Ltd"
+          $publisher = "NaisNet Technology Co., Ltd."
           $outDir = "packages/desktop/out"
           $installer = Join-Path $outDir "penguin-desktop-win32-x64.exe"
           $latest = Join-Path $outDir "latest.yml"

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -99,8 +99,8 @@ win:
     signingHashAlgorithms:
       - sha256
     publisherName:
-      - CN=RushRush Network Technology Ltd, O=RushRush Network Technology Ltd
-      - RushRush Network Technology Ltd
+      - "CN=NaisNet Technology Co., Ltd., O=NaisNet Technology Co., Ltd."
+      - "NaisNet Technology Co., Ltd."
   target:
     - target: nsis
       arch: [x64]


### PR DESCRIPTION
The v0.2.5 release run's Windows desktop job failed at **Verify Windows signing and update metadata**:

```
penguin-desktop-win32-x64.exe signer does not contain expected publisher 'RushRush Network Technology Ltd'.
```

The binary is signed and timestamped; the signing identity changed:

| | |
| --- | --- |
| Asserted | `RushRush Network Technology Ltd` |
| Actual signer | `CN="NaisNet Technology Co., Ltd."`, issued by `Certum Extended Validation Code Signing 2021 CA` |

Both places that named the old identity are updated: `packages/desktop/electron-builder.yml`'s `publisherName` (what electron-builder writes into `app-update.yml`, which the updater uses to verify a downloaded update) and `.github/workflows/desktop-build.yml`'s assertion.

## Consequence for installed Windows clients

`v0.2.4` shipped `publisherName: RushRush Network Technology Ltd`, so every installed 0.2.4 desktop client has that name baked into its own `app-update.yml`. electron-updater verifies a downloaded update against **the installed app's** recorded publisher, so those clients will refuse a NaisNet-signed 0.2.5 installer and must be reinstalled by hand. That follows from the certificate change itself — no value of this string avoids it.

Listing both identities was considered and rejected: it cannot help already-installed 0.2.4 clients (their file is frozen), and it would leave a retired identity as a standing trust anchor for every future build.

## Verification

`pnpm format` + `format:check` clean, `git diff --check` clean. The assertion is `-notlike "*$publisher*"` against the certificate subject, which reads `CN="NaisNet Technology Co., Ltd.", O="NaisNet Technology Co., Ltd.", L=Shenyang, ...` — the substring matches. The YAML values are quoted because they contain commas; parsed back to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)