### PR TITLE
fix(landing): refine hero proof-point copy

### DIFF
--- a/changelog/unreleased/2026-08-27-landing-cross-platform-copy.md
+++ b/changelog/unreleased/2026-08-27-landing-cross-platform-copy.md
@@ -1,0 +1,15 @@
+# Landing proof-point copy
+
+- **Date:** 2026-08-27
+- **Type:** fix
+- **Scope:** `landing`
+
+[中文版](2026-08-27-landing-cross-platform-copy.zh.md)
+
+Refined three proof points on the landing page.
+
+## Details
+
+- Replaced the literal-sounding platform phrase with "Cross-Platform Local Deployment" while retaining the supported operating systems below it.
+- Renamed the self-evolution claim to "First Self-Improving Harness" for more natural English.
+- Shortened the Chinese Apache 2.0 supporting label without repeating the open-source claim above it.

--- a/changelog/unreleased/2026-08-27-landing-cross-platform-copy.md
+++ b/changelog/unreleased/2026-08-27-landing-cross-platform-copy.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-27
 - **Type:** fix
 - **Scope:** `landing`
+- **PR:** [#478](https://github.com/Prism-Shadow/penguin-harness/pull/478)
 
 [中文版](2026-08-27-landing-cross-platform-copy.zh.md)
 

--- a/changelog/unreleased/2026-08-27-landing-cross-platform-copy.md
+++ b/changelog/unreleased/2026-08-27-landing-cross-platform-copy.md
@@ -1,4 +1,4 @@
-# Landing proof-point copy
+# Landing copy and RAG poster
 
 - **Date:** 2026-08-27
 - **Type:** fix
@@ -7,10 +7,11 @@
 
 [中文版](2026-08-27-landing-cross-platform-copy.zh.md)
 
-Refined three proof points on the landing page.
+Refined three landing-page proof points and the RAG demo poster.
 
 ## Details
 
 - Replaced the literal-sounding platform phrase with "Cross-Platform Local Deployment" while retaining the supported operating systems below it.
 - Renamed the self-evolution claim to "First Self-Improving Harness" for more natural English.
 - Shortened the Chinese Apache 2.0 supporting label without repeating the open-source claim above it.
+- Replaced the RAG demo's finished-app poster with locale- and theme-matched screenshots of PenguinHarness building the app.

--- a/changelog/unreleased/2026-08-27-landing-cross-platform-copy.zh.md
+++ b/changelog/unreleased/2026-08-27-landing-cross-platform-copy.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-27
 - **Type:** fix
 - **Scope:** `landing`
+- **PR:** [#478](https://github.com/Prism-Shadow/penguin-harness/pull/478)
 
 [English](2026-08-27-landing-cross-platform-copy.md)
 

--- a/changelog/unreleased/2026-08-27-landing-cross-platform-copy.zh.md
+++ b/changelog/unreleased/2026-08-27-landing-cross-platform-copy.zh.md
@@ -1,0 +1,15 @@
+# 落地页特点文案
+
+- **Date:** 2026-08-27
+- **Type:** fix
+- **Scope:** `landing`
+
+[English](2026-08-27-landing-cross-platform-copy.md)
+
+优化了落地页的三项特点文案。
+
+## 细节
+
+- 将略显生硬的平台表述改为“Cross-Platform Local Deployment”，同时保留下方支持的操作系统列表。
+- 将自进化特点改为更自然的英文表达“First Self-Improving Harness”。
+- 精简 Apache 2.0 的中文说明，避免与上方“100% 开源”重复表达。

--- a/changelog/unreleased/2026-08-27-landing-cross-platform-copy.zh.md
+++ b/changelog/unreleased/2026-08-27-landing-cross-platform-copy.zh.md
@@ -1,4 +1,4 @@
-# 落地页特点文案
+# 落地页文案与 RAG 视频封面
 
 - **Date:** 2026-08-27
 - **Type:** fix
@@ -7,10 +7,11 @@
 
 [English](2026-08-27-landing-cross-platform-copy.md)
 
-优化了落地页的三项特点文案。
+优化了落地页的三项特点文案与 RAG 演示视频封面。
 
 ## 细节
 
 - 将略显生硬的平台表述改为“Cross-Platform Local Deployment”，同时保留下方支持的操作系统列表。
 - 将自进化特点改为更自然的英文表达“First Self-Improving Harness”。
 - 精简 Apache 2.0 的中文说明，避免与上方“100% 开源”重复表达。
+- 将 RAG 演示视频的成品应用封面替换为匹配语言与亮暗主题的 PenguinHarness 构建运行截图。

--- a/packages/landing/src/lib/strings-en.ts
+++ b/packages/landing/src/lib/strings-en.ts
@@ -58,9 +58,9 @@ export const en: Strings = {
     cliInstall: "Command-line install",
     stats: [
       { value: "1000+ Models", label: "Support for Major Providers" },
-      { value: "Local on Every Platform", label: "Linux · Windows · macOS" },
+      { value: "Cross-Platform Local Deployment", label: "Linux · Windows · macOS" },
       { value: "100% Open Source", label: "Apache 2.0 Licensed" },
-      { value: "First Self-Evolving Harness", label: "Native Agent Self-Evolution Engine" },
+      { value: "First Self-Improving Harness", label: "Native Agent Self-Evolution Engine" },
     ],
     supportedModelsLabel: "Supported models",
     supportedModels: [

--- a/packages/landing/src/lib/strings.ts
+++ b/packages/landing/src/lib/strings.ts
@@ -60,7 +60,7 @@ export const zh = {
     stats: [
       { value: "1000+ 模型", label: "支持主流供应商" },
       { value: "跨平台本地部署", label: "Linux，Windows，macOS 多系统兼容" },
-      { value: "100% 开源", label: "Apache 2.0 协议开源" },
+      { value: "100% 开源", label: "Apache 2.0 协议" },
       { value: "首个自进化 Harness", label: "原生 Agent 自进化引擎" },
     ],
     supportedModelsLabel: "支持模型",

--- a/packages/landing/src/sections/cases.tsx
+++ b/packages/landing/src/sections/cases.tsx
@@ -1,8 +1,8 @@
 /**
  * Use-case gallery as switchable tabs — the RAG docs expert and the penguin sled
- * game, each shown as its FINISHED PRODUCT (mockup shots matched to the visitor's
- * locale and theme) under its condensed one-sentence prompt. Tab order follows
- * S.cases.tabs; CASE_SHOTS is index-aligned with it. A tab may carry a `cost`
+ * game under their condensed one-sentence prompts. Video entries use a matching
+ * PenguinHarness run as their poster; still-only entries show the finished product.
+ * Tab order follows S.cases.tabs; CASE_STILLS is index-aligned with it. A tab may carry a `cost`
  * line (the RAG one does) — an emphasized token-cost hook under the caption.
  */
 import { useState } from "react";
@@ -12,10 +12,10 @@ import type { Locale } from "../state/locale";
 import { Section } from "../components/section";
 import { BrowserFrame } from "../components/browser-frame";
 import { demoVideoUrl } from "../lib/links";
-import ragAppZhLight from "../assets/rag-app-zh-light.webp";
-import ragAppZhDark from "../assets/rag-app-zh-dark.webp";
-import ragAppEnLight from "../assets/rag-app-en-light.webp";
-import ragAppEnDark from "../assets/rag-app-en-dark.webp";
+import chatZhLight from "../assets/shots/chat-zh-light.webp";
+import chatZhDark from "../assets/shots/chat-zh-dark.webp";
+import chatEnLight from "../assets/shots/chat-en-light.webp";
+import chatEnDark from "../assets/shots/chat-en-dark.webp";
 import gameZhLight from "../assets/game-zh-light.webp";
 import gameZhDark from "../assets/game-zh-dark.webp";
 import gameEnLight from "../assets/game-en-light.webp";
@@ -26,19 +26,19 @@ type ShotSet = Record<Locale, { light: string; dark: string }>;
 /**
  * Demo recording for a case, index-aligned with S.cases.tabs; null where the finished
  * product is still shown as a still. The community-hosted file only downloads on play
- * (preload="none"), and the matching screenshot doubles as the poster — so a video tab
- * costs a visitor exactly what an image tab already did until they press play.
+ * (preload="none"), and a matching PenguinHarness run doubles as the poster — so a video
+ * tab costs a visitor exactly what an image tab already did until they press play.
  */
 const CASE_VIDEOS: Array<Record<Locale, string> | null> = [
   { zh: demoVideoUrl("rag_zh"), en: demoVideoUrl("rag_en") },
   null,
 ];
 
-/** Finished-product shots, index-aligned with S.cases.tabs. */
-const CASE_SHOTS: ShotSet[] = [
+/** Theme- and locale-matched posters or stills, index-aligned with S.cases.tabs. */
+const CASE_STILLS: ShotSet[] = [
   {
-    zh: { light: ragAppZhLight, dark: ragAppZhDark },
-    en: { light: ragAppEnLight, dark: ragAppEnDark },
+    zh: { light: chatZhLight, dark: chatZhDark },
+    en: { light: chatEnLight, dark: chatEnDark },
   },
   {
     zh: { light: gameZhLight, dark: gameZhDark },
@@ -51,7 +51,7 @@ export function Cases() {
   const tabs = S.cases.tabs;
   const [active, setActive] = useState(0);
   const tab = tabs[active] ?? tabs[0]!;
-  const shots = (CASE_SHOTS[active] ?? CASE_SHOTS[0]!)[locale];
+  const shots = (CASE_STILLS[active] ?? CASE_STILLS[0]!)[locale];
   const video = (CASE_VIDEOS[active] ?? null)?.[locale];
 
   return (


### PR DESCRIPTION
## Summary

- replace the literal-sounding platform claim with `Cross-Platform Local Deployment`
- rename the self-improvement claim to `First Self-Improving Harness`
- shorten the Chinese Apache 2.0 supporting label to avoid repeating the open-source claim
- use locale- and theme-matched PenguinHarness run screenshots as the RAG demo video posters

## Verification

- landing TypeScript check
- landing test suite (63 tests)
- landing production build
- repository-wide Prettier check
- Playwright viewport checks at 320 px, 390 px, and 1280 px
- Playwright poster checks for Chinese light and English dark themes