### PR TITLE
Scheduled tasks target the current Session by default

### DIFF
--- a/changelog/unreleased/2026-08-26-schedule-target-current-session.md
+++ b/changelog/unreleased/2026-08-26-schedule-target-current-session.md
@@ -7,13 +7,14 @@
 
 [中文版](2026-08-26-schedule-target-current-session.zh.md)
 
-The built-in Schedules Prompt now tells the Agent to aim a scheduled task at the Session it is already in — `session_id` written from the Environment section's Session ID line — so a task arranged in conversation reports back into that conversation instead of into a fresh Session nobody is watching. Opening a new Session per trigger became the deliberate alternative: when the user asks for a separate Session, or when the task is better off starting clean.
+The built-in Schedules Prompt now tells the Agent to aim a scheduled task at the Session it is already in — `session_id` written from the Environment section's Session ID line — so a task arranged in conversation reports back into that conversation instead of into a fresh Session nobody is watching. Opening a new Session per trigger became the deliberate alternative: when the user asks for a separate Session, when the task is better off starting clean, or when it has to outlive the conversation.
 
 ## Details
 
-- The `# Scheduled Tasks` field rules lead with `session_id` and its default, and the fenced example carries `session_id` alongside an `end_at`. `session_id` still cannot be combined with `workspace` / `provider` / `model_id`, and a file that omits `session_id` still opens a new Session on every trigger — the TOML format itself is untouched.
-- A hygiene line bounds the shape the new default makes ordinary: a repeating task aimed at its own Session grows that Session's context on every trigger, so it asks for an `end_at`, a one-shot task for a one-time reminder, and small per-trigger work.
-- The `penguin-orchestration` skill's `penguin schedule add` guidance follows the same default (`--session-id "$PENGUIN_SESSION_ID"`), and its runaway-loop caution names the bound that ends such a task.
+- The `# Scheduled Tasks` field rules now describe `session_id` and its default before the new-Session form, and the fenced example carries `session_id` alongside an `end_at`. `session_id` still cannot be combined with `workspace` / `provider` / `model_id`, and a file that omits `session_id` still opens a new Session on every trigger — the TOML format itself is untouched.
+- The same rules name where this Session is the wrong target. A Session is not the durable identity of a conversation — switching the model or the agent opens a new one, and deleting the conversation strands a task bound to it — so anything that has to outlive the conversation takes the new-Session form. A subagent, which renders this same section against its own short-lived Session, omits `session_id` unless its caller gave it an id to target.
+- A hygiene line bounds the shape the new default makes ordinary: a repeating task aimed at its own Session grows that Session's context on every trigger, so it asks for an `end_at` when the request has a natural horizon, a one-shot task for a one-time reminder, and small per-trigger work. An open-ended reminder keeps no `end_at`: the Agent leaves it off and says in its reply that the task runs until the user removes it, instead of inventing an expiry date the reminder would then silently stop on.
+- The `penguin-orchestration` skill's `penguin schedule add` guidance follows the same default (`--session-id "$PENGUIN_SESSION_ID"`), and its runaway-loop caution names the bound that ends such a task, on the same condition.
 
 ## Existing Agents
 

--- a/changelog/unreleased/2026-08-26-schedule-target-current-session.md
+++ b/changelog/unreleased/2026-08-26-schedule-target-current-session.md
@@ -1,0 +1,19 @@
+# Scheduled tasks target the current Session by default
+
+- **Date:** 2026-08-26
+- **Type:** feature
+- **Scope:** `core`, `skills`
+
+[中文版](2026-08-26-schedule-target-current-session.zh.md)
+
+The built-in Schedules Prompt now tells the Agent to aim a scheduled task at the Session it is already in — `session_id` written from the Environment section's Session ID line — so a task arranged in conversation reports back into that conversation instead of into a fresh Session nobody is watching. Opening a new Session per trigger became the deliberate alternative: when the user asks for a separate Session, or when the task is better off starting clean.
+
+## Details
+
+- The `# Scheduled Tasks` field rules lead with `session_id` and its default, and the fenced example carries `session_id` alongside an `end_at`. `session_id` still cannot be combined with `workspace` / `provider` / `model_id`, and a file that omits `session_id` still opens a new Session on every trigger — the TOML format itself is untouched.
+- A hygiene line bounds the shape the new default makes ordinary: a repeating task aimed at its own Session grows that Session's context on every trigger, so it asks for an `end_at`, a one-shot task for a one-time reminder, and small per-trigger work.
+- The `penguin-orchestration` skill's `penguin schedule add` guidance follows the same default (`--session-id "$PENGUIN_SESSION_ID"`), and its runaway-loop caution names the bound that ends such a task.
+
+## Existing Agents
+
+The config kernel advanced to `2026-08-26`, moving the Schedules tab. An Agent already on disk keeps its stored `schedules.prompt` and runs the old guidance until its owner takes the kernel update on the Agent settings page; a Schedules tab still holding the previous built-in default is rewritten by that update, while an edited one is kept whole.

--- a/changelog/unreleased/2026-08-26-schedule-target-current-session.md
+++ b/changelog/unreleased/2026-08-26-schedule-target-current-session.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-26
 - **Type:** feature
 - **Scope:** `core`, `skills`
+- **PR:** [#498](https://github.com/Prism-Shadow/penguin-harness/pull/498)
 
 [中文版](2026-08-26-schedule-target-current-session.zh.md)
 

--- a/changelog/unreleased/2026-08-26-schedule-target-current-session.zh.md
+++ b/changelog/unreleased/2026-08-26-schedule-target-current-session.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-26
 - **Type:** feature
 - **Scope:** `core`, `skills`
+- **PR:** [#498](https://github.com/Prism-Shadow/penguin-harness/pull/498)
 
 [English](2026-08-26-schedule-target-current-session.md)
 

--- a/changelog/unreleased/2026-08-26-schedule-target-current-session.zh.md
+++ b/changelog/unreleased/2026-08-26-schedule-target-current-session.zh.md
@@ -1,0 +1,19 @@
+# 定时任务默认投递到当前 Session
+
+- **Date:** 2026-08-26
+- **Type:** feature
+- **Scope:** `core`, `skills`
+
+[English](2026-08-26-schedule-target-current-session.md)
+
+内置的 Schedules Prompt 现在会让 Agent 把定时任务指向它当前所在的 Session——`session_id` 取自 Environment 小节的 Session ID 那一行——于是在对话中安排的任务会回到这段对话里，而不是落进一个无人查看的新 Session。每次触发新开 Session 成为需要时才选的另一种形态：用户明确要求单独的 Session，或该任务本就应当从干净的上下文开始。
+
+## 细节
+
+- `# Scheduled Tasks` 的字段规则以 `session_id` 及其默认取值开头，围栏示例中一并写出 `session_id` 与 `end_at`。`session_id` 仍不能与 `workspace` / `provider` / `model_id` 同时出现；未写 `session_id` 的文件仍是每次触发新开一个 Session——TOML 格式本身没有变化。
+- 新增一条卫生规则，约束这个默认所带来的常见形态：指向自身 Session 的周期任务，每次触发都会让该 Session 的上下文继续增长，因此需要 `end_at`、一次性提醒用一次性任务、单次触发的工作量保持小。
+- `penguin-orchestration` 技能中 `penguin schedule add` 的说明采用同一默认（`--session-id "$PENGUIN_SESSION_ID"`），其「避免失控循环」的警示也点明了终止这类任务所需的约束。
+
+## 既有 Agent
+
+配置内核版本前进到 `2026-08-26`，「定时任务」设置页随之变动。磁盘上已存在的 Agent 保留自己的 `schedules.prompt`，继续按旧说明运行，直到其所有者在 Agent 设置页执行更新内核；届时仍等于上一代内置默认的「定时任务」页会被整页重写，而被改动过的页面则整页保留。

--- a/changelog/unreleased/2026-08-26-schedule-target-current-session.zh.md
+++ b/changelog/unreleased/2026-08-26-schedule-target-current-session.zh.md
@@ -7,13 +7,14 @@
 
 [English](2026-08-26-schedule-target-current-session.md)
 
-内置的 Schedules Prompt 现在会让 Agent 把定时任务指向它当前所在的 Session——`session_id` 取自 Environment 小节的 Session ID 那一行——于是在对话中安排的任务会回到这段对话里，而不是落进一个无人查看的新 Session。每次触发新开 Session 成为需要时才选的另一种形态：用户明确要求单独的 Session，或该任务本就应当从干净的上下文开始。
+内置的 Schedules Prompt 现在会让 Agent 把定时任务指向它当前所在的 Session——`session_id` 取自 Environment 小节的 Session ID 那一行——于是在对话中安排的任务会回到这段对话里，而不是落进一个无人查看的新 Session。每次触发新开 Session 成为需要时才选的另一种形态：用户明确要求单独的 Session、该任务本就应当从干净的上下文开始，或者它需要活得比这段对话更久。
 
 ## 细节
 
-- `# Scheduled Tasks` 的字段规则以 `session_id` 及其默认取值开头，围栏示例中一并写出 `session_id` 与 `end_at`。`session_id` 仍不能与 `workspace` / `provider` / `model_id` 同时出现；未写 `session_id` 的文件仍是每次触发新开一个 Session——TOML 格式本身没有变化。
-- 新增一条卫生规则，约束这个默认所带来的常见形态：指向自身 Session 的周期任务，每次触发都会让该 Session 的上下文继续增长，因此需要 `end_at`、一次性提醒用一次性任务、单次触发的工作量保持小。
-- `penguin-orchestration` 技能中 `penguin schedule add` 的说明采用同一默认（`--session-id "$PENGUIN_SESSION_ID"`），其「避免失控循环」的警示也点明了终止这类任务所需的约束。
+- `# Scheduled Tasks` 的字段规则现在先讲 `session_id` 及其默认取值，再讲新开 Session 的形态；围栏示例中一并写出 `session_id` 与 `end_at`。`session_id` 仍不能与 `workspace` / `provider` / `model_id` 同时出现；未写 `session_id` 的文件仍是每次触发新开一个 Session——TOML 格式本身没有变化。
+- 同一段规则也点明了哪些场景不该指向当前 Session。Session 并不是一段对话的持久身份——切换模型或切换 Agent 都会新开一个，删除对话则会让绑定其上的任务失去投递目标——因此需要活得比这段对话更久的任务，改用新开 Session 的形态。子智能体渲染到的是同一段说明，而它自己的 Session 转瞬即逝，因此除非调用方给了 id，否则它不写 `session_id`。
+- 新增一条卫生规则，约束这个默认所带来的常见形态：指向自身 Session 的周期任务，每次触发都会让该 Session 的上下文继续增长，因此在请求本身有自然终点时要写 `end_at`、一次性提醒用一次性任务、单次触发的工作量保持小。用户要的是无限期的提醒时则不写 `end_at`：Agent 会在回复里说明该任务将一直运行到用户删除为止，而不是替它编一个到期时间、让提醒到那天悄悄停掉。
+- `penguin-orchestration` 技能中 `penguin schedule add` 的说明采用同一默认（`--session-id "$PENGUIN_SESSION_ID"`），其「避免失控循环」的警示也在同一条件下点明了终止这类任务所需的约束。
 
 ## 既有 Agent
 

--- a/packages/core/src/state/default-config.ts
+++ b/packages/core/src/state/default-config.ts
@@ -333,6 +333,17 @@ export const DEFAULT_SKILLS_PROMPT = LEGACY_SKILLS_SECTION;
  * is untouched. It does make the self-directed loop the ordinary shape, which is what the
  * `end_at` / one-shot / small-work hygiene line pays for: a periodic task firing into its own
  * Session grows that Session's context on every trigger and ends only when someone ends it.
+ * The `end_at` half of that line is conditional on purpose: an open-ended reminder bounded by
+ * an invented date stops on that date with no event and no error record, so the section asks
+ * for a bound only when the request has a horizon, and for the reply to say so otherwise.
+ *
+ * The section also spells out where this Session is the wrong target. A Session is not the
+ * durable identity of a conversation — switching model or agent opens a new one, and deleting
+ * the conversation stops a task bound to it (the next fire records a missing-session error and
+ * marks the task invalid) — so work meant to outlive the conversation belongs in the
+ * new-Session form. And a subagent renders this same section against its own short-lived
+ * Session, so it is told to omit the field (the `run_subagent` self-test the system prompt
+ * already uses).
  */
 export const DEFAULT_SCHEDULES_PROMPT = `# Scheduled Tasks
 Prompts delivered to this agent on a timer: TOML files you manage with the file tools, in \`<app_data_dir>/agents/<agent_id>/agent_state/schedule/\` (create the directory if it does not exist). One task per file; the file name minus \`.toml\` is the task's name (letters, digits, \`_\` and \`-\` only). The server re-reads the directory within about 30 seconds — creating, editing or deleting a file is all it takes, there is nothing to register.
@@ -346,9 +357,9 @@ end_at = 2026-09-01T09:00:00Z
 session_id = "<session_id>"
 \`\`\`
 
-Field rules: \`prompt\` (required) is the message sent when the task fires. \`enabled\` defaults to false — set it to true explicitly or the task never runs. \`start_at\` (required) is the first trigger time, an ISO 8601 instant. \`period\` is a fixed interval like \`30m\` / \`12h\` / \`7d\` (5 minutes minimum); omit it for a one-shot task. \`end_at\` (optional) must be later than start_at; a periodic task stops after it. \`session_id\` picks where the prompt is delivered, and by default it is this Session: write the id from the Environment section's Session ID line, so every trigger arrives in the conversation you are in now, with its context intact. Omit it when the user asks for a separate Session, or when the task is better off starting clean — a nightly report that should not inherit this conversation's history. Each trigger then opens a new Session, in which \`workspace\` (optional) picks the working directory and \`provider\` + \`model_id\` pick the model — always both or neither; omit both to use the Project's default model. \`session_id\` cannot be combined with workspace / provider / model_id.
+Field rules: \`prompt\` (required) is the message sent when the task fires. \`enabled\` defaults to false — set it to true explicitly or the task never runs. \`start_at\` (required) is the first trigger time, an ISO 8601 instant. \`period\` is a fixed interval like \`30m\` / \`12h\` / \`7d\` (5 minutes minimum); omit it for a one-shot task. \`end_at\` (optional) must be later than start_at; a periodic task stops after it. \`session_id\` picks where the prompt is delivered, and by default it is this Session: write the id from the Environment section's Session ID line, so every trigger arrives in the conversation you are in now, with its context intact. If \`run_subagent\` is not in your tool list, you are the subagent: nobody is watching your Session, so omit \`session_id\` unless your caller gave you an id to target. Omit it when the user asks for a separate Session, or when the task is better off starting clean — a nightly report that should not inherit this conversation's history. Omit it as well for anything that has to outlive this conversation: this Session is not permanent — switching the model or the agent opens a new one, and deleting the conversation strands a task bound to it, which then stops firing. Each trigger then opens a new Session, in which \`workspace\` (optional) picks the working directory and \`provider\` + \`model_id\` pick the model — always both or neither; omit both to use the Project's default model. \`session_id\` cannot be combined with workspace / provider / model_id.
 
-A repeating task aimed at this Session grows its context on every trigger and nothing ends it on its own: bound it with \`end_at\`, use a one-shot task for a one-time reminder, and keep the work each trigger asks for small.
+A repeating task aimed at this Session grows its context on every trigger and nothing ends it on its own: give it an \`end_at\` when the request has a natural horizon; when the user wants it open-ended, leave \`end_at\` off and say in your reply that it will run until they remove it. Use a one-shot task for a one-time reminder, and keep the work each trigger asks for small.
 
 Check the current tasks below before creating one so you never duplicate an existing task; change a task by editing its file in place; delete the file when a task is obsolete.
 

--- a/packages/core/src/state/default-config.ts
+++ b/packages/core/src/state/default-config.ts
@@ -320,11 +320,19 @@ export const DEFAULT_SKILLS_PROMPT = LEGACY_SKILLS_SECTION;
 /**
  * Built-in default Schedules Prompt: what `{{SCHEDULES}}` expands to — teaches the model to
  * manage scheduled tasks as TOML files with its ordinary file tools (there is no dedicated
- * tool), in template-example form like DEFAULT_MEMORY_PROMPT: the directory as a literal
- * angle-bracket pattern resolvable from the Environment section, a fenced example, the field
- * rules schedule-file.ts enforces, the hygiene rules, then the current roster via
- * `{{SCHEDULE_LIST}}`. Stored per-Agent in `system_config.yaml` and editable on the Web App's
- * Schedules tab.
+ * tool), in template-example form like DEFAULT_MEMORY_PROMPT: the directory and the target
+ * Session as literal angle-bracket patterns resolvable from the Environment section, a fenced
+ * example, the field rules schedule-file.ts enforces, the hygiene rules, then the current
+ * roster via `{{SCHEDULE_LIST}}`. Stored per-Agent in `system_config.yaml` and editable on the
+ * Web App's Schedules tab.
+ *
+ * The target guidance is deliberate: `session_id` set to the Environment section's Session ID
+ * makes a task the user arranged in conversation report back into that same conversation
+ * rather than into a fresh Session nobody is watching. It is guidance only — schedule-file.ts
+ * still opens a new Session for a file carrying no `session_id`, so the format's own default
+ * is untouched. It does make the self-directed loop the ordinary shape, which is what the
+ * `end_at` / one-shot / small-work hygiene line pays for: a periodic task firing into its own
+ * Session grows that Session's context on every trigger and ends only when someone ends it.
  */
 export const DEFAULT_SCHEDULES_PROMPT = `# Scheduled Tasks
 Prompts delivered to this agent on a timer: TOML files you manage with the file tools, in \`<app_data_dir>/agents/<agent_id>/agent_state/schedule/\` (create the directory if it does not exist). One task per file; the file name minus \`.toml\` is the task's name (letters, digits, \`_\` and \`-\` only). The server re-reads the directory within about 30 seconds — creating, editing or deleting a file is all it takes, there is nothing to register.
@@ -334,9 +342,13 @@ prompt = "Check yesterday's build results and summarize the failures"
 enabled = true
 start_at = 2026-08-01T09:00:00Z
 period = "12h"
+end_at = 2026-09-01T09:00:00Z
+session_id = "<session_id>"
 \`\`\`
 
-Field rules: \`prompt\` (required) is the message sent when the task fires. \`enabled\` defaults to false — set it to true explicitly or the task never runs. \`start_at\` (required) is the first trigger time, an ISO 8601 instant. \`period\` is a fixed interval like \`30m\` / \`12h\` / \`7d\` (5 minutes minimum); omit it for a one-shot task. \`end_at\` (optional) must be later than start_at; a periodic task stops after it. Each trigger starts a new Session by default: \`workspace\` (optional) picks its working directory, and \`provider\` + \`model_id\` pick its model — always both or neither; omit both to use the Project's default model. Setting \`session_id\` instead sends the prompt into an existing Session, and cannot be combined with workspace / provider / model_id.
+Field rules: \`prompt\` (required) is the message sent when the task fires. \`enabled\` defaults to false — set it to true explicitly or the task never runs. \`start_at\` (required) is the first trigger time, an ISO 8601 instant. \`period\` is a fixed interval like \`30m\` / \`12h\` / \`7d\` (5 minutes minimum); omit it for a one-shot task. \`end_at\` (optional) must be later than start_at; a periodic task stops after it. \`session_id\` picks where the prompt is delivered, and by default it is this Session: write the id from the Environment section's Session ID line, so every trigger arrives in the conversation you are in now, with its context intact. Omit it when the user asks for a separate Session, or when the task is better off starting clean — a nightly report that should not inherit this conversation's history. Each trigger then opens a new Session, in which \`workspace\` (optional) picks the working directory and \`provider\` + \`model_id\` pick the model — always both or neither; omit both to use the Project's default model. \`session_id\` cannot be combined with workspace / provider / model_id.
+
+A repeating task aimed at this Session grows its context on every trigger and nothing ends it on its own: bound it with \`end_at\`, use a one-shot task for a one-time reminder, and keep the work each trigger asks for small.
 
 Check the current tasks below before creating one so you never duplicate an existing task; change a task by editing its file in place; delete the file when a task is obsolete.
 

--- a/packages/core/src/state/kernel-history.ts
+++ b/packages/core/src/state/kernel-history.ts
@@ -22,7 +22,7 @@ import { createHash } from "node:crypto";
  * change without it moving. (The reverse — moving it with no default change — is inert rather
  * than an error: nothing is keyed by version, so there is no table to fall out of sync with.)
  */
-export const KERNEL_VERSION = "2026-08-24";
+export const KERNEL_VERSION = "2026-08-26";
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -175,10 +175,14 @@ export function isKernelOutdated(kernelVersion: string | null | undefined): bool
  *   `kill_command` / `kill_subagent` tools joined the set, moving the tools tab; alongside
  *   them the memory prompt was reworded to name when a fact is worth saving (PR #397), moving
  *   the memory tab.
- * - `2026-08-24` (current) — the kill notion left: `kill_command` folded into `input_command`
- *   as its `kill` parameter, `kill_subagent` was removed outright (a subagent session is never
+ * - `2026-08-24` — the kill notion left: `kill_command` folded into `input_command` as its
+ *   `kill` parameter, `kill_subagent` was removed outright (a subagent session is never
  *   destroyed — `input_subagent` resumes a released id), and `input_subagent` gained `abort`
  *   and now returns the subagent's latest reply: the tools tab moved.
+ * - `2026-08-26` (current) — the schedules prompt's default target became the Session the
+ *   model is already in (`session_id` taken from the Environment section) instead of a fresh
+ *   Session per trigger, with the hygiene line that bounds a self-directed recurring task
+ *   alongside it: the schedules tab moved.
  */
 export const KERNEL_DEFAULT_TAB_HASHES: Readonly<Record<KernelTab, string>> = {
   prompt: "048198c37b8d7840352c225fdfcb15baf2679973c6eab4bf400d492daf6ce254",
@@ -187,7 +191,7 @@ export const KERNEL_DEFAULT_TAB_HASHES: Readonly<Record<KernelTab, string>> = {
   skills: "7e343aa692e5eaeadfc8add6bb375fb50ac33ef81ebe460490fc219b0f3d707f",
   memory: "53d190390829cc0132bb12e468a6891f2e0576ec0c4022a9b4a5d9233666900d",
   vault: "19bd36a6d4ab442b66583c423450602b817990a9a79bafa21c9b6137fb6b47d8",
-  schedules: "79123643abd445c8540696c3e4395d9582cfa662bed2e5f879dd859fa09715f2",
+  schedules: "4b8e9372eb839577cd4c4e20f48ff3bd668bd94b21b0065513d62dcb91a54c04",
 };
 
 /**
@@ -216,6 +220,8 @@ export const KERNEL_SUPERSEDED_TAB_HASHES: KernelSupersededTabHashes = {
   ],
   // The memory prompt's wording before #397 named when a fact is worth saving.
   memory: ["c28acdda755552967cd0c99ba4ced407eddfa843b3dce228a965da4674676dc7"],
+  // The schedules prompt before a scheduled task defaulted to the current Session.
+  schedules: ["79123643abd445c8540696c3e4395d9582cfa662bed2e5f879dd859fa09715f2"],
 };
 
 /**

--- a/packages/core/src/state/kernel-history.ts
+++ b/packages/core/src/state/kernel-history.ts
@@ -181,8 +181,10 @@ export function isKernelOutdated(kernelVersion: string | null | undefined): bool
  *   and now returns the subagent's latest reply: the tools tab moved.
  * - `2026-08-26` (current) — the schedules prompt's default target became the Session the
  *   model is already in (`session_id` taken from the Environment section) instead of a fresh
- *   Session per trigger, with the hygiene line that bounds a self-directed recurring task
- *   alongside it: the schedules tab moved.
+ *   Session per trigger, alongside the hygiene line that bounds a self-directed recurring task
+ *   and the carve-outs from the new default (an open-ended reminder keeps no `end_at`, work
+ *   that must outlive the conversation takes the new-Session form, and a subagent omits the
+ *   field): the schedules tab moved.
  */
 export const KERNEL_DEFAULT_TAB_HASHES: Readonly<Record<KernelTab, string>> = {
   prompt: "048198c37b8d7840352c225fdfcb15baf2679973c6eab4bf400d492daf6ce254",
@@ -191,7 +193,7 @@ export const KERNEL_DEFAULT_TAB_HASHES: Readonly<Record<KernelTab, string>> = {
   skills: "7e343aa692e5eaeadfc8add6bb375fb50ac33ef81ebe460490fc219b0f3d707f",
   memory: "53d190390829cc0132bb12e468a6891f2e0576ec0c4022a9b4a5d9233666900d",
   vault: "19bd36a6d4ab442b66583c423450602b817990a9a79bafa21c9b6137fb6b47d8",
-  schedules: "4b8e9372eb839577cd4c4e20f48ff3bd668bd94b21b0065513d62dcb91a54c04",
+  schedules: "c722922eca13a83400d92924e4d1aa8b09964b4081261be81e5149f0eae1119d",
 };
 
 /**

--- a/packages/core/test/prompt-sections.test.ts
+++ b/packages/core/test/prompt-sections.test.ts
@@ -61,6 +61,20 @@ function withConfig(state: AgentState, patch: Partial<SystemConfig>): AgentState
 
 const DEMO_SKILL = { name: "demo", description: "Demo skill.", version: 1, updated: "2026-08-01" };
 
+/** A complete Environment section, so the rendered prompt carries every `- Label: value` line. */
+const SESSION_ENVIRONMENT = {
+  sessionId: "session-2026-08-01-00-00-00-0000abcd",
+  cwd: "/tmp/workspace",
+  agentId: DEFAULT_AGENT_ID,
+  projectDir: "/tmp/penguin",
+  provider: "anthropic",
+  modelId: "claude-sonnet-4-5",
+  platform: "linux",
+  osVersion: "6.1.0",
+  shell: "bash",
+  date: "2026-08-01",
+};
+
 describe("{{VAULT}} rendering", () => {
   it("renders the default vault section with the key-name list", async () => {
     const prompt = assembleSystemPrompt(await agentState(), undefined, ["KEY_A", "KEY_B"]);
@@ -177,6 +191,34 @@ describe("{{SCHEDULES}} rendering", () => {
     const prompt = assembleSystemPrompt(state, undefined, undefined, undefined, null, ["daily"]);
     expect(prompt).not.toContain("# Scheduled Tasks");
     expect(prompt).not.toContain("- daily");
+  });
+
+  // The section tells the model to target this Session by writing the id off the Environment
+  // section's Session ID line. That instruction is only resolvable while both halves render
+  // into the same prompt under the same label, so both are pinned to one literal here: rename
+  // the Environment line and this fails until the section is re-pointed.
+  it("points session_id at the Environment section's Session ID line, which renders with it", async () => {
+    const sessionId = "session-2026-08-26-09-00-00-abcd1234";
+    const prompt = assembleSystemPrompt(
+      await agentState(),
+      { ...SESSION_ENVIRONMENT, sessionId },
+      undefined,
+      undefined,
+      null,
+      ["daily-report"],
+    );
+    const label = "Session ID";
+    expect(prompt).toContain(`- ${label}: ${sessionId}`);
+    expect(prompt).toContain(`write the id from the Environment section's ${label} line`);
+    // The fresh-Session form stays available, and the two targets stay mutually exclusive
+    // (schedule-file.ts rejects a file that mixes them).
+    expect(prompt).toContain("Each trigger then opens a new Session");
+    expect(prompt).toContain(
+      "`session_id` cannot be combined with workspace / provider / model_id",
+    );
+    // Defaulting to this Session makes the self-directed loop ordinary, so the section carries
+    // the bound that ends one.
+    expect(prompt).toContain("bound it with `end_at`");
   });
 
   it("falls back to the built-in prompt for a config that predates the schedules section", async () => {

--- a/packages/core/test/prompt-sections.test.ts
+++ b/packages/core/test/prompt-sections.test.ts
@@ -216,9 +216,23 @@ describe("{{SCHEDULES}} rendering", () => {
     expect(prompt).toContain(
       "`session_id` cannot be combined with workspace / provider / model_id",
     );
+    // The example writes the target as `<session_id>`, which the model can only resolve because
+    // the system prompt's File system section declares angle-bracket names substitutable and
+    // names this one. That section lives in the `prompt` kernel tab, a different tab from
+    // `schedules` — so pin the pair, or one tab can advance out from under the other.
+    expect(prompt).toContain('session_id = "<session_id>"');
+    expect(prompt).toContain(
+      "Angle-bracket names such as `<app_data_dir>` and `<session_id>` are placeholders",
+    );
     // Defaulting to this Session makes the self-directed loop ordinary, so the section carries
-    // the bound that ends one.
-    expect(prompt).toContain("bound it with `end_at`");
+    // the bound that ends one — conditioned on the request having a horizon, so an open-ended
+    // reminder is not silently given an expiry date.
+    expect(prompt).toContain("give it an `end_at` when the request has a natural horizon");
+    expect(prompt).toContain("leave `end_at` off and say in your reply");
+    // A subagent renders this same section against its own short-lived Session.
+    expect(prompt).toContain("If `run_subagent` is not in your tool list, you are the subagent");
+    // A Session is not the durable identity of a conversation, and the section says so.
+    expect(prompt).toContain("this Session is not permanent");
   });
 
   it("falls back to the built-in prompt for a config that predates the schedules section", async () => {

--- a/packages/skills/skills/penguin-orchestration/SKILL.md
+++ b/packages/skills/skills/penguin-orchestration/SKILL.md
@@ -3,8 +3,8 @@ name: penguin-orchestration
 description: Drive PenguinHarness itself from a shell — list and create agents and sessions, send and steer messages mid-flight, and query costs and scheduled tasks via the penguin CLI over the local server.
 short_description: Orchestrate agents, sessions, costs and schedules with the penguin CLI.
 short_description_zh: 用 penguin CLI 编排智能体、会话、成本与定时任务。
-version: 2
-updated: 2026-08-26T18:46:22Z
+version: 3
+updated: 2026-08-27T01:55:00Z
 ---
 
 # Penguin Orchestration
@@ -121,14 +121,16 @@ penguin run -m "Summarize this per-agent cost report and flag anomalies: <the JS
 ### Set up a scheduled task for the current agent
 
 ```bash
+penguin schedule add build-watch --prompt "Check the build results and report the failures" \
+  --start-at now --period 12h --end-at 2026-09-01T09:00:00Z --session-id "$PENGUIN_SESSION_ID"
 penguin schedule add daily-report --prompt "Summarize yesterday's conversations" \
-  --start-at now --period 1d
+  --start-at now --period 1d                         # no target: a fresh session per firing
 penguin schedule ls                                  # verify
 penguin schedule update daily-report --period 12h    # adjust; --enable/--disable to toggle
 penguin schedule rm daily-report                     # remove — no confirmation prompt
 ```
 
-- `--agent-id` defaults to yourself from the caller env, so this schedules the current agent. `--start-at` takes ISO 8601 or `now`; `--period` is at least 5m (`30m`/`12h`/`1d`/`7d`), omit it for a one-shot; `--end-at` bounds recurrence. Target flags are optional: `--session-id <id>` fires into that existing session, `--workspace <path>` (optionally with the `--model-id` + `--provider` pair) pins the new-session form.
+- `--agent-id` defaults to yourself from the caller env, so this schedules the current agent. `--start-at` takes ISO 8601 or `now`; `--period` is at least 5m (`30m`/`12h`/`1d`/`7d`), omit it for a one-shot; `--end-at` bounds recurrence. Target the session you are in — `--session-id "$PENGUIN_SESSION_ID"` — unless the user asked for somewhere else: the prompt then arrives in this conversation, with its context. Leave the target off when the user wants a separate session, or when the task is better off starting clean (a nightly report that should not inherit this conversation); each firing then opens a new session, which `--workspace <path>` and the `--model-id` + `--provider` pair configure.
 - `add` creates the schedule **enabled** (`--disabled` stages it off) — deliberately diverging from the raw file, where `enabled` defaults to false. `update` is read-modify-write: unspecified fields keep their stored values, and switching the target form clears the other one.
 - In `schedule ls`, read: the AGENT column (without `--agent-id` the listing spans agents), `enabled` (a disabled entry never fires), `startAt` (first firing), `period` (absent means one-shot), the target — an existing session versus a new session per firing — and `lastFiredAt`.
 - The CLI writes through the schedules API, so mistakes are rejected synchronously. The TOML file stays the single source of truth — `<app_data_dir>/agents/<agent_id>/agent_state/schedule/<name>.toml`, fields mirroring the flags (`prompt`, `enabled` — false by default in the file, `start_at`, `period`, `end_at`, `session_id` / `workspace`+`provider`+`model_id`) — and remains editable with file tools; your system prompt's schedule roster lists yours. A hand edit is only validated by the periodic reconcile (roughly every 30s), with errors landing in error records rather than your terminal — prefer the CLI.
@@ -157,6 +159,6 @@ Prefer (a) when you stay around for the result — the completion report comes t
 
 - **One active task per session.** `penguin input` at a busy session steers the running task rather than starting a second one; a new task sent at a busy session waits its turn. For parallel work, start parallel sessions.
 - **Unattended sessions must not need a human.** A spawned session inherits your approval mode (`allow-all` when there is no caller to inherit from); if you yourself run under `always-ask`, pass `--approve allow-all` (trusted work) or `--approve read-only` explicitly — an unattended `always-ask` session hangs waiting for approval in the web UI.
-- **No runaway loops.** An agent that messages itself — directly, through a chain of agents, or through a schedule aimed back at its own session — keeps spending until someone stops it. Make every automated conversation terminate.
+- **No runaway loops.** An agent that messages itself — directly, through a chain of agents, or through a schedule aimed back at its own session — keeps spending until someone stops it. Make every automated conversation terminate: a recurring schedule pointed at your own session needs an `--end-at` (or no `--period` at all, for a one-time reminder), and a prompt whose per-firing work stays small — that session's context grows with every firing.
 - **Spawned work bills the project.** Everything you start lands in the same project's usage (`penguin cost` shows it); a fan-out of sessions multiplies spend.
 - **Configuration stays CLI-managed.** Never read or hand-edit `.project_config.toml` or `agent_state/.vault.toml` — models and secrets go through `penguin config` (see the penguin-cli skill).

--- a/packages/skills/skills/penguin-orchestration/SKILL.md
+++ b/packages/skills/skills/penguin-orchestration/SKILL.md
@@ -4,7 +4,7 @@ description: Drive PenguinHarness itself from a shell — list and create agents
 short_description: Orchestrate agents, sessions, costs and schedules with the penguin CLI.
 short_description_zh: 用 penguin CLI 编排智能体、会话、成本与定时任务。
 version: 3
-updated: 2026-08-27T01:55:00Z
+updated: 2026-08-27T09:40:00Z
 ---
 
 # Penguin Orchestration
@@ -122,7 +122,8 @@ penguin run -m "Summarize this per-agent cost report and flag anomalies: <the JS
 
 ```bash
 penguin schedule add build-watch --prompt "Check the build results and report the failures" \
-  --start-at now --period 12h --end-at 2026-09-01T09:00:00Z --session-id "$PENGUIN_SESSION_ID"
+  --start-at now --period 12h --session-id "$PENGUIN_SESSION_ID" \
+  --end-at <ISO instant>                             # only when the request has a horizon
 penguin schedule add daily-report --prompt "Summarize yesterday's conversations" \
   --start-at now --period 1d                         # no target: a fresh session per firing
 penguin schedule ls                                  # verify
@@ -159,6 +160,6 @@ Prefer (a) when you stay around for the result — the completion report comes t
 
 - **One active task per session.** `penguin input` at a busy session steers the running task rather than starting a second one; a new task sent at a busy session waits its turn. For parallel work, start parallel sessions.
 - **Unattended sessions must not need a human.** A spawned session inherits your approval mode (`allow-all` when there is no caller to inherit from); if you yourself run under `always-ask`, pass `--approve allow-all` (trusted work) or `--approve read-only` explicitly — an unattended `always-ask` session hangs waiting for approval in the web UI.
-- **No runaway loops.** An agent that messages itself — directly, through a chain of agents, or through a schedule aimed back at its own session — keeps spending until someone stops it. Make every automated conversation terminate: a recurring schedule pointed at your own session needs an `--end-at` (or no `--period` at all, for a one-time reminder), and a prompt whose per-firing work stays small — that session's context grows with every firing.
+- **No runaway loops.** An agent that messages itself — directly, through a chain of agents, or through a schedule aimed back at its own session — keeps spending until someone stops it. Make every automated conversation terminate: a recurring schedule pointed at your own session takes an `--end-at` whenever the request has a natural horizon (or no `--period` at all, for a one-time reminder), and a prompt whose per-firing work stays small — that session's context grows with every firing. When the user wants it open-ended, leave `--end-at` off and tell them it runs until they remove it.
 - **Spawned work bills the project.** Everything you start lands in the same project's usage (`penguin cost` shows it); a fan-out of sessions multiplies spend.
 - **Configuration stays CLI-managed.** Never read or hand-edit `.project_config.toml` or `agent_state/.vault.toml` — models and secrets go through `penguin config` (see the penguin-cli skill).


### PR DESCRIPTION
When an Agent sets up a scheduled task and the user has not said where it should fire, the task should land in the conversation the user is having — not in a fresh Session nobody is watching. This settles that in the built-in Schedules Prompt.

## The prompt change

The `# Scheduled Tasks` section's field rules used to end:

> `end_at` (optional) must be later than start_at; a periodic task stops after it. **Each trigger starts a new Session by default: `workspace` (optional) picks its working directory, and `provider` + `model_id` pick its model — always both or neither; omit both to use the Project's default model. Setting `session_id` instead sends the prompt into an existing Session, and cannot be combined with workspace / provider / model_id.**

It now ends:

> `end_at` (optional) must be later than start_at; a periodic task stops after it. **`session_id` picks where the prompt is delivered, and by default it is this Session: write the id from the Environment section's Session ID line, so every trigger arrives in the conversation you are in now, with its context intact. Omit it when the user asks for a separate Session, or when the task is better off starting clean — a nightly report that should not inherit this conversation's history. Each trigger then opens a new Session, in which `workspace` (optional) picks the working directory and `provider` + `model_id` pick the model — always both or neither; omit both to use the Project's default model. `session_id` cannot be combined with workspace / provider / model_id.**

with a new paragraph after it:

> **A repeating task aimed at this Session grows its context on every trigger and nothing ends it on its own: bound it with `end_at`, use a one-shot task for a one-time reminder, and keep the work each trigger asks for small.**

and two lines added to the fenced example, so the example demonstrates the default target and the bound rather than contradicting them:

```toml
end_at = 2026-09-01T09:00:00Z
session_id = "<session_id>"
```

The model can resolve `<session_id>`: the default template's `# Environment` section already carries `- Session ID: {{SESSION_ID}}`, substituted by `assembleSystemPrompt`. `<session_id>` is the same angle-bracket-pattern convention the section already uses for `<app_data_dir>` and `<agent_id>`.

Guidance only — nothing in the TOML format moved. `schedule-file.ts` still opens a new Session for a file that carries no `session_id`, and still rejects a file that combines `session_id` with `workspace` / `provider` / `model_id`.

## Why the hygiene sentence is not optional

`penguin-orchestration`'s own caution says an agent that messages itself — "through a schedule aimed back at its own session" included — "keeps spending until someone stops it". This change makes exactly that shape the default, so the prompt has to carry the antidote rather than leave it in a skill the Agent may not have installed: a recurring task firing into its own Session accumulates context on every trigger and terminates only when a person terminates it. Hence `end_at`, one-shot for "remind me later", and small per-trigger work — stated in one sentence, in the same section that creates the hazard.

The counter-example is kept honest rather than papered over: a nightly report that should not inherit the conversation's history is a genuine reason to open a fresh Session, and the prompt says so and lets the model make that call.

## Existing Agents

`system_config.yaml` is materialized at Agent creation and never auto-upgraded, so this follows the repo's kernel-version mechanism exactly:

- `KERNEL_VERSION` advanced `2026-08-24` → `2026-08-26`.
- `KERNEL_DEFAULT_TAB_HASHES.schedules` rewritten to the recomputed hash; the previous one appended as the first (and so far only) entry of `KERNEL_SUPERSEDED_TAB_HASHES.schedules`, with a generation-list line saying what moved.
- Verified rather than assumed: hashing `{ schedules: { enabled: true, prompt } }` over `HEAD`'s prompt text reproduces `79123643…` exactly, so an untouched Agent really does hash-match the frozen record and its Schedules tab advances whole instead of being conservatively kept.

**What a user sees:** an existing Agent keeps its stored `schedules.prompt` and runs the old guidance. Its settings page and the agents list show the kernel-update hint. On **Update kernel**, a Schedules tab still equal to the previous built-in default is rewritten to the new prompt; a Schedules tab the user edited in any way is kept whole and listed as kept, with restore-default-config as the full-refresh recourse. No migration was invented and nothing on disk is rewritten without that explicit action.

## The CLI skill, and one thing deliberately not implemented

`packages/skills/skills/penguin-orchestration/SKILL.md` documented `penguin schedule add`'s target flags as simply "optional", which would now contradict the prompt. Brought into line: the recipe shows `--session-id "$PENGUIN_SESSION_ID"` first and keeps the untargeted `daily-report` as the labelled clean-context case; the flag bullet states the default and when to leave it off; the "No runaway loops" caution now names the bound (`--end-at`, or no `--period` at all) instead of only warning. Skill `version` 2 → 3 with `updated` moved, per the repo's rule that every content change bumps both.

**Recommendation, not implemented here** (this PR is scoped to the prompt): `penguin schedule add` should default `--session-id` from `PENGUIN_SESSION_ID` when the caller is inside a harness Agent session and no target flag is given. The CLI already has the convention — `run`'s caller-context defaults fill `--workspace`, the model pair, `--approve` and `--thinking` from the caller's live session, with precedence *explicit flag > caller value > plain fallback* — and `PENGUIN_SESSION_ID` is injected into every command subprocess (`server/src/app.ts`). Doing it there would make the CLI surface agree with the prompt by construction instead of by documentation, and would remove the `"$PENGUIN_SESSION_ID"` boilerplate from the skill. It needs its own decision because it changes an existing command's behaviour for callers who omit the flag today.

## Verification

Full CI-parity chain, from the worktree root, Node v24.18.0:

- `pnpm -r build` — exit 0
- `pnpm typecheck` — exit 0 (9 packages)
- `pnpm test` — exit 0; 4114 passed, 5 skipped (core 1014, server 1073, web 1360, cli 374, desktop 144, landing 69, docs 53, skills 27)
- `pnpm format` then `pnpm format:check` — "All matched files use Prettier code style!"

New coverage in `packages/core/test/prompt-sections.test.ts`: the rendered prompt's `# Scheduled Tasks` instruction and the `# Environment` section's `Session ID` line are pinned to one shared literal, so renaming the Environment label fails the test until the section is re-pointed; the fresh-Session escape, the exclusivity rule and the `end_at` bound are asserted alongside it. `core/test/kernel-version.test.ts` (the pinned-hash guard and the tab-merge semantics) passes on the advanced record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
