### PR TITLE
fix(web): wrap terminal close confirmation text

### DIFF
--- a/packages/web/src/features/dock/dock-panel.tsx
+++ b/packages/web/src/features/dock/dock-panel.tsx
@@ -749,7 +749,11 @@ export function DockPanel({
       onConfirm={killConfirmed}
       confirmLabel={S.terminal.killShell}
     >
-      {confirmKill !== null && <p>{S.dock.killConfirmBody(confirmKill.label)}</p>}
+      {confirmKill !== null && (
+        <p className="break-words text-sm text-gray-600 dark:text-gray-300">
+          {S.dock.killConfirmBody(confirmKill.label)}
+        </p>
+      )}
     </ConfirmModal>
   );
 


### PR DESCRIPTION
## Summary
- Match the terminal close confirmation body text with the smaller, muted style used by most confirmation dialogs.
- Allow long shell labels and paths to wrap so the dialog no longer creates horizontal scrolling.

## Changes
- Updated the terminal close confirmation copy in `packages/web/src/features/dock/dock-panel.tsx` with `text-sm`, muted text color, and `break-words`.

## Test plan
- [x] `git diff --check origin/main...HEAD`