### PR TITLE
fix(web): the Telegram binding's links lead where their labels promise

### DIFF
--- a/changelog/unreleased/2026-08-27-telegram-botfather-link.md
+++ b/changelog/unreleased/2026-08-27-telegram-botfather-link.md
@@ -3,29 +3,35 @@
 - **Date:** 2026-08-27
 - **Type:** fix
 - **Scope:** `web`
+- **PR:** [#506](https://github.com/Prism-Shadow/penguin-harness/pull/506)
 
 [中文版](2026-08-27-telegram-botfather-link.zh.md)
 
 The Bot Token field's corner link was labelled "open developer console" and pointed at
 `core.telegram.org/bots/api`, the Bot API reference. Telegram has no developer console, and
 that page does not issue tokens — so a user standing on the one field that needs a token,
-following the one link that offers to supply it, landed in an 860KB API manual. The link now
-opens `@BotFather`, which is where the token comes from, and says so.
+following the one link that offers to supply it, landed in an 860KB API manual. The link was
+repointed at `@BotFather`, where the token actually comes from, and the label was reworded to
+name it.
 
 ## Details
 
-- `console` for Telegram is `https://t.me/BotFather`. Telegram's own page for it is titled
-  "Launch @BotFather" and describes it as the bot "to create new bot accounts and manage your
-  existing bots".
-- The label follows the target rather than the other way round: this channel uses its own
-  `openBotFather` string instead of the shared "open developer console" wording, which stays
-  in place for the channels that have one. The label is read at render rather than captured
-  in the module-level link table, because `S` is a live binding the locale provider swaps.
-- The setup fold's companion link moves from `https://core.telegram.org/bots/tutorial` to
+- Telegram's corner link was repointed at `https://t.me/BotFather`. Telegram's own page for it
+  is titled "Launch @BotFather" and describes it as the bot "to create new bot accounts and
+  manage your existing bots".
+- The label was made to follow the target rather than the other way round: this channel took
+  its own `openBotFather` string instead of the shared "open developer console" wording, which
+  stayed in place for the channels that have one.
+- The link table's key was renamed `console` → `credentialSource`, and the comments around it
+  stopped calling that slot a console — the next channel added to the table reads a name and a
+  description that fit a credential issued from a chat as readily as one issued from a page.
+- The setup fold's companion link was moved from `https://core.telegram.org/bots/tutorial` to
   `https://core.telegram.org/bots/features#botfather`. The former is "From BotFather to
   'Hello World'", which past its token section is about downloading an IDE and picking a
   framework — writing a bot, which nobody doing this is doing. The latter is the BotFather
   guide itself, opening on `/newbot` and the token it returns, which is what the fold's steps
   already say.
-- Tests pin both halves: the corner link's target, and that its label and its target name the
-  same thing.
+- Tests were extended to pin both halves — the corner link's target, and that its label and
+  its target name the same thing, asserted as one anchor — and to run over both dictionaries,
+  so the label cannot regress in the locale the suite does not activate.
+- The design spec was updated to match ([penguin-harness-design #70](https://github.com/Prism-Shadow/penguin-harness-design/pull/70)).

--- a/changelog/unreleased/2026-08-27-telegram-botfather-link.md
+++ b/changelog/unreleased/2026-08-27-telegram-botfather-link.md
@@ -1,0 +1,31 @@
+# The Telegram binding's links lead where their labels promise
+
+- **Date:** 2026-08-27
+- **Type:** fix
+- **Scope:** `web`
+
+[中文版](2026-08-27-telegram-botfather-link.zh.md)
+
+The Bot Token field's corner link was labelled "open developer console" and pointed at
+`core.telegram.org/bots/api`, the Bot API reference. Telegram has no developer console, and
+that page does not issue tokens — so a user standing on the one field that needs a token,
+following the one link that offers to supply it, landed in an 860KB API manual. The link now
+opens `@BotFather`, which is where the token comes from, and says so.
+
+## Details
+
+- `console` for Telegram is `https://t.me/BotFather`. Telegram's own page for it is titled
+  "Launch @BotFather" and describes it as the bot "to create new bot accounts and manage your
+  existing bots".
+- The label follows the target rather than the other way round: this channel uses its own
+  `openBotFather` string instead of the shared "open developer console" wording, which stays
+  in place for the channels that have one. The label is read at render rather than captured
+  in the module-level link table, because `S` is a live binding the locale provider swaps.
+- The setup fold's companion link moves from `https://core.telegram.org/bots/tutorial` to
+  `https://core.telegram.org/bots/features#botfather`. The former is "From BotFather to
+  'Hello World'", which past its token section is about downloading an IDE and picking a
+  framework — writing a bot, which nobody doing this is doing. The latter is the BotFather
+  guide itself, opening on `/newbot` and the token it returns, which is what the fold's steps
+  already say.
+- Tests pin both halves: the corner link's target, and that its label and its target name the
+  same thing.

--- a/changelog/unreleased/2026-08-27-telegram-botfather-link.zh.md
+++ b/changelog/unreleased/2026-08-27-telegram-botfather-link.zh.md
@@ -1,0 +1,26 @@
+# Telegram 绑定的链接指向其文案承诺的地方
+
+- **Date:** 2026-08-27
+- **Type:** fix
+- **Scope:** `web`
+
+[English](2026-08-27-telegram-botfather-link.md)
+
+Bot Token 字段角上的链接文案是「前往开发者后台」，指向的却是 Bot API 参考文档
+`core.telegram.org/bots/api`。Telegram 根本没有开发者后台，那个页面也不签发 Token——于是用户
+站在唯一需要 Token 的字段上，点开唯一承诺提供它的链接，落进了一份 860KB 的 API 手册。现在这个
+链接打开 `@BotFather`，也就是 Token 真正的来源，并且文案照实说明。
+
+## 细节
+
+- Telegram 的 `console` 改为 `https://t.me/BotFather`。Telegram 自己给这个页面的标题就是
+  「Launch @BotFather」，并说明它用于「创建新的机器人账号并管理已有机器人」。
+- 是文案跟随目标，而不是反过来：该渠道改用自己的 `openBotFather` 文案，而共享的「前往开发者
+  后台」留给确实有后台的渠道。该文案在渲染时读取，而不是存进模块级链接表——`S` 是语言 Provider
+  会整体替换的 live binding，在模块初始化时取值会把语言固定住。
+- 创建步骤折叠区的配套链接由 `https://core.telegram.org/bots/tutorial` 改为
+  `https://core.telegram.org/bots/features#botfather`。前者是「From BotFather to 'Hello
+  World'」，在讲完取 Token 之后就转去下载 IDE、挑选框架——那是在写一个机器人，而这里没有人在写
+  机器人。后者正是 BotFather 指南本身，开篇即 `/newbot` 与它返回的 Token，与折叠区里已有的步骤
+  一致。
+- 两处都有测试锁定：角上链接的目标，以及它的文案与目标指的是同一件事。

--- a/changelog/unreleased/2026-08-27-telegram-botfather-link.zh.md
+++ b/changelog/unreleased/2026-08-27-telegram-botfather-link.zh.md
@@ -3,24 +3,28 @@
 - **Date:** 2026-08-27
 - **Type:** fix
 - **Scope:** `web`
+- **PR:** [#506](https://github.com/Prism-Shadow/penguin-harness/pull/506)
 
 [English](2026-08-27-telegram-botfather-link.md)
 
 Bot Token 字段角上的链接文案是「前往开发者后台」，指向的却是 Bot API 参考文档
 `core.telegram.org/bots/api`。Telegram 根本没有开发者后台，那个页面也不签发 Token——于是用户
-站在唯一需要 Token 的字段上，点开唯一承诺提供它的链接，落进了一份 860KB 的 API 手册。现在这个
-链接打开 `@BotFather`，也就是 Token 真正的来源，并且文案照实说明。
+站在唯一需要 Token 的字段上，点开唯一承诺提供它的链接，落进了一份 860KB 的 API 手册。该链接
+改为打开 `@BotFather`，也就是 Token 真正的来源，文案也改为照实说明。
 
 ## 细节
 
-- Telegram 的 `console` 改为 `https://t.me/BotFather`。Telegram 自己给这个页面的标题就是
+- Telegram 角上链接改指向 `https://t.me/BotFather`。Telegram 自己给这个页面的标题就是
   「Launch @BotFather」，并说明它用于「创建新的机器人账号并管理已有机器人」。
-- 是文案跟随目标，而不是反过来：该渠道改用自己的 `openBotFather` 文案，而共享的「前往开发者
-  后台」留给确实有后台的渠道。该文案在渲染时读取，而不是存进模块级链接表——`S` 是语言 Provider
-  会整体替换的 live binding，在模块初始化时取值会把语言固定住。
+- 改成文案跟随目标，而不是反过来：该渠道改用自己的 `openBotFather` 文案，而共享的「前往开发者
+  后台」留给确实有后台的渠道。
+- 链接表的键由 `console` 改名为 `credentialSource`，周边注释也不再把这一槽位称作后台——下一个
+  被加进这张表的渠道，读到的键名与说明适用于「凭据由聊天而非网页签发」的情形。
 - 创建步骤折叠区的配套链接由 `https://core.telegram.org/bots/tutorial` 改为
   `https://core.telegram.org/bots/features#botfather`。前者是「From BotFather to 'Hello
   World'」，在讲完取 Token 之后就转去下载 IDE、挑选框架——那是在写一个机器人，而这里没有人在写
   机器人。后者正是 BotFather 指南本身，开篇即 `/newbot` 与它返回的 Token，与折叠区里已有的步骤
   一致。
-- 两处都有测试锁定：角上链接的目标，以及它的文案与目标指的是同一件事。
+- 测试补齐了两处锁定：角上链接的目标，以及它的文案与目标指的是同一件事——两者在同一条断言里
+  一起校验；并改为遍历两套词典，使该文案无法在测试未激活的那种语言里悄悄回退。
+- 设计规格已同步改写（[penguin-harness-design #70](https://github.com/Prism-Shadow/penguin-harness-design/pull/70)）。

--- a/packages/web/src/features/messaging/messaging-binding-editor.tsx
+++ b/packages/web/src/features/messaging/messaging-binding-editor.tsx
@@ -14,12 +14,12 @@
  * channels' field lists differ in length, so controls placed under the fields would sit at
  * a different height in each channel and move on every switch. The explanation lives in
  * collapsed FAQ folds below the save area (`MessagingBindingHelp`), and the channel's
- * leading credential field — where the console values start being pasted — carries the
- * developer-console link at its label's top-right corner (the models-page "get API key"
- * idiom, which puts the link on the field, not in a row of its own). Secrets follow that
- * page's interaction: the field always starts empty, a stored secret shows as a masked
- * line under it with a "clear stored …" checkbox (typing unchecks it; applied on Save),
- * blank keeps the stored value — and clearing requires the channel's connection to be
+ * leading credential field — where the value starts being pasted — carries at its label's
+ * top-right corner a link to wherever that channel issues the credential (the models-page
+ * "get API key" idiom, which puts the link on the field, not in a row of its own). Secrets
+ * follow that page's interaction: the field always starts empty, a stored secret shows as a
+ * masked line under it with a "clear stored …" checkbox (typing unchecks it; applied on
+ * Save), blank keeps the stored value — and clearing requires the channel's connection to be
  * disabled first. The connection switch IS the bind/unbind control — enabling binds the
  * bot to this conversation, turning it off releases it, and the credentials stay saved
  * through both, so several conversations may keep one bot saved and take turns holding it
@@ -66,12 +66,17 @@ import {
 /** How often the visible editor refreshes the runtime status (connects settle within a poll or two). */
 const STATUS_POLL_MS = 3000;
 
-/** Per-channel external links: the walkthrough (setup FAQ fold) and the console where the credential is fetched (field corner). */
-const CHANNEL_LINKS: Record<MessagingChannel, { tutorial: string; console: string }> = {
+/**
+ * Per-channel external links: the walkthrough (setup FAQ fold) and where the channel issues
+ * the credential (field corner). The second is a developer console for some channels and a
+ * chat with a bot for others, so its label belongs to the channel — only the ones that do
+ * have a console reach for the shared `S.messaging.console` wording.
+ */
+const CHANNEL_LINKS: Record<MessagingChannel, { tutorial: string; credentialSource: string }> = {
   feishu: {
     // Feishu's own echo-bot walkthrough: creating a self-built app and its long connection.
     tutorial: "https://open.feishu.cn/document/develop-an-echo-bot/introduction",
-    console: "https://open.feishu.cn/app",
+    credentialSource: "https://open.feishu.cn/app",
   },
   telegram: {
     // The BotFather section of the bot-features page: "a detailed guide to using
@@ -84,7 +89,7 @@ const CHANNEL_LINKS: Record<MessagingChannel, { tutorial: string; console: strin
     tutorial: "https://core.telegram.org/bots/features#botfather",
     // Where the credential is actually issued. Telegram has no web console: the token comes
     // from @BotFather inside the app, and this link is the one that leads there.
-    console: "https://t.me/BotFather",
+    credentialSource: "https://t.me/BotFather",
   },
 };
 
@@ -485,8 +490,8 @@ function StoredSecretRow({
 /**
  * The editor's body, top to bottom: the channel selector, the connection controls (enable
  * toggle + live status, then the two probes, then the hint naming what gates the switch),
- * then the selected channel's credential fields (console link at the credential field's
- * corner, models-style stored-secret row), and last the one saved field that is not a
+ * then the selected channel's credential fields (credential-source link at the credential
+ * field's corner, models-style stored-secret row), and last the one saved field that is not a
  * credential — the one-message-per-line delivery option, which Save persists like the rest. Only the selector and the controls sit above the
  * fields, and everything above the fields is channel-independent in height, so the toggle
  * and the probes hold one vertical position no matter which channel is selected. Hosts
@@ -599,7 +604,7 @@ export function MessagingBindingBody({ b }: { b: MessagingBindingEditorState }) 
             // the reader looking for a web page Telegram has never had. The label names the
             // thing the click actually reaches — Telegram's own page for it is titled
             // "Launch @BotFather".
-            link={<ExternalLink href={links.console} label={S.telegram.openBotFather} />}
+            link={<ExternalLink href={links.credentialSource} label={S.telegram.openBotFather} />}
           >
             <PasswordInput
               size="sm"
@@ -632,7 +637,7 @@ export function MessagingBindingBody({ b }: { b: MessagingBindingEditorState }) 
           <CornerLinkedField
             label={S.feishu.appId}
             required
-            link={<ExternalLink href={links.console} label={S.messaging.console} />}
+            link={<ExternalLink href={links.credentialSource} label={S.messaging.console} />}
           >
             <Input
               size="sm"

--- a/packages/web/src/features/messaging/messaging-binding-editor.tsx
+++ b/packages/web/src/features/messaging/messaging-binding-editor.tsx
@@ -74,8 +74,17 @@ const CHANNEL_LINKS: Record<MessagingChannel, { tutorial: string; console: strin
     console: "https://open.feishu.cn/app",
   },
   telegram: {
-    tutorial: "https://core.telegram.org/bots/tutorial",
-    console: "https://core.telegram.org/bots/api",
+    // The BotFather section of the bot-features page: "a detailed guide to using
+    // @BotFather", opening on /newbot and the token it returns — which is this fold's
+    // steps, one level deeper. NOT /bots/tutorial: that one is "From BotFather to 'Hello
+    // World'", and past its token section it is about downloading an IDE and picking a
+    // framework, i.e. about WRITING a bot. Nobody here is writing one — PenguinHarness is
+    // the bot. The fragment is a plain document anchor present in the served HTML, so it
+    // lands where it says (unlike a hash route, which the server never sees).
+    tutorial: "https://core.telegram.org/bots/features#botfather",
+    // Where the credential is actually issued. Telegram has no web console: the token comes
+    // from @BotFather inside the app, and this link is the one that leads there.
+    console: "https://t.me/BotFather",
   },
 };
 
@@ -585,7 +594,12 @@ export function MessagingBindingBody({ b }: { b: MessagingBindingEditorState }) 
           <CornerLinkedField
             label={S.telegram.botToken}
             required={!facts.secretConfigured}
-            link={<ExternalLink href={links.console} label={S.messaging.console} />}
+            // Not the shared "developer console" label: this one opens @BotFather in the
+            // Telegram app, and a corner link promising a console that does not exist sends
+            // the reader looking for a web page Telegram has never had. The label names the
+            // thing the click actually reaches — Telegram's own page for it is titled
+            // "Launch @BotFather".
+            link={<ExternalLink href={links.console} label={S.telegram.openBotFather} />}
           >
             <PasswordInput
               size="sm"

--- a/packages/web/src/features/messaging/messaging-panel.tsx
+++ b/packages/web/src/features/messaging/messaging-panel.tsx
@@ -5,10 +5,10 @@
  * channel selector switching between the two channels' forms (each independently
  * savable), then the connection controls — the enable/disable toggle (one enabled channel
  * per conversation) with the live status line, both probes, and the hint naming what gates
- * the switch — then the per-channel credential fields with the console link at the field
- * corner and the models-style stored-secret row, and the collapsed FAQ folds below the
- * Save area. There is no unbind action — removing a credential is the secret field's clear
- * checkbox.
+ * the switch — then the per-channel credential fields with the credential-source link at
+ * the field corner and the models-style stored-secret row, and the collapsed FAQ folds
+ * below the Save area. There is no unbind action — removing a credential is the secret
+ * field's clear checkbox.
  *
  * Status polling is gated on `active` (the dock keeps hidden tabs mounted): a hidden tab
  * neither polls nor loses the form state it accumulated.

--- a/packages/web/src/lib/strings-en.ts
+++ b/packages/web/src/lib/strings-en.ts
@@ -1798,6 +1798,12 @@ Scenarios:
     botTokenKeepHint: "Leave empty to keep the saved Bot Token",
     /** The stored-token row's clear checkbox (the models-page clear idiom). */
     clearToken: "Clear stored Bot Token",
+    /**
+     * The Bot Token field's corner link. Telegram has no developer console — the token is
+     * issued by @BotFather inside the app — so this channel names the destination instead
+     * of borrowing the shared "open developer console" label.
+     */
+    openBotFather: "Open @BotFather",
     invalidToken: "The Bot Token looks like <digits>:<secret>, as issued by @BotFather",
     /** Why "send test message" is disabled before the bot has ever been messaged. */
     testMessageNoChat: "Message the bot once in Telegram first, so it knows which chat to send to",

--- a/packages/web/src/lib/strings-en.ts
+++ b/packages/web/src/lib/strings-en.ts
@@ -1830,7 +1830,12 @@ Scenarios:
       feishu: "Feishu",
       telegram: "Telegram",
     },
-    /** Per-channel external links: the tutorial (in the setup FAQ fold) and the console (at the credential field's corner). */
+    /**
+     * Shared link labels: the tutorial (in the setup FAQ fold) and, at the credential field's
+     * corner, the developer console — the latter only for the channels that have one. A
+     * channel whose credential is issued elsewhere names that destination itself (Telegram's
+     * `telegram.openBotFather`).
+     */
     tutorial: "Open tutorial",
     console: "Open developer console",
     /** The connection toggle (flips immediately, using the stored credentials). */

--- a/packages/web/src/lib/strings.ts
+++ b/packages/web/src/lib/strings.ts
@@ -1760,6 +1760,12 @@ Benchmark：
     botTokenKeepHint: "留空保持已保存的 Bot Token 不变",
     /** The stored-token row's clear checkbox (the models-page clear idiom). */
     clearToken: "清除已存 Bot Token",
+    /**
+     * The Bot Token field's corner link. Telegram has no developer console — the token is
+     * issued by @BotFather inside the app — so this channel names the destination instead
+     * of borrowing the shared "open developer console" label.
+     */
+    openBotFather: "打开 @BotFather",
     invalidToken: "Bot Token 形如「数字:密钥」，由 @BotFather 签发",
     /** Why "send test message" is disabled before the bot has ever been messaged. */
     testMessageNoChat: "先在 Telegram 中给机器人发一条消息，机器人才知道要发到哪个会话",

--- a/packages/web/src/lib/strings.ts
+++ b/packages/web/src/lib/strings.ts
@@ -1792,7 +1792,12 @@ Benchmark：
       feishu: "飞书",
       telegram: "Telegram",
     },
-    /** Per-channel external links: the tutorial (in the setup FAQ fold) and the console (at the credential field's corner). */
+    /**
+     * Shared link labels: the tutorial (in the setup FAQ fold) and, at the credential field's
+     * corner, the developer console — the latter only for the channels that have one. A
+     * channel whose credential is issued elsewhere names that destination itself (Telegram's
+     * `telegram.openBotFather`).
+     */
     tutorial: "前往教程",
     console: "前往开发者后台",
     /** The connection toggle (flips immediately, using the stored credentials). */

--- a/packages/web/test/messaging-binding-editor.test.ts
+++ b/packages/web/test/messaging-binding-editor.test.ts
@@ -72,11 +72,26 @@ describe("MessagingBindingBody", () => {
     expect(render(stateOf("telegram"))).not.toContain(S.telegram.intro);
   });
 
-  it("hangs each channel's developer-console link on its credential field's corner", () => {
+  it("hangs each channel's credential source on its credential field's corner", () => {
     // The models dialog's "get API key" idiom: the link sits where the value is pasted, so the
     // reader never has to leave the field to find out where the value comes from.
     expect(render(stateOf("feishu"))).toContain('href="https://open.feishu.cn/app"');
-    expect(render(stateOf("telegram"))).toContain('href="https://core.telegram.org/bots/api"');
+    // Telegram's Bot Token is issued by @BotFather in the app, not by a web console — the
+    // corner link goes there rather than into the API reference it used to point at.
+    const telegram = render(stateOf("telegram"));
+    expect(telegram).toContain('href="https://t.me/BotFather"');
+    expect(telegram).not.toContain("core.telegram.org/bots/api");
+  });
+
+  it("labels that corner link with what it opens, never with a console Telegram has not got", () => {
+    // The defect this pins: a link labelled "open developer console" that landed in the API
+    // manual. Label and target have to name the same thing, so the shared console wording is
+    // used only by the channels that actually have one.
+    const telegram = render(stateOf("telegram"));
+    expect(telegram).toContain(S.telegram.openBotFather);
+    expect(telegram).not.toContain(S.messaging.console);
+    // ...and the channels that do have a console keep it.
+    expect(render(stateOf("feishu"))).toContain(S.messaging.console);
   });
 
   it("offers a stored secret's removal as the clear checkbox, gated on screen while enabled", () => {
@@ -201,7 +216,9 @@ describe("MessagingBindingHelp", () => {
     const telegram = renderToStaticMarkup(
       createElement(MessagingBindingHelp, { channel: "telegram" as MessagingChannel }),
     );
-    expect(telegram).toContain('href="https://core.telegram.org/bots/tutorial"');
+    // The BotFather guide, not "From BotFather to 'Hello World'": the reader of this fold is
+    // creating a bot to paste a token from, not writing one.
+    expect(telegram).toContain('href="https://core.telegram.org/bots/features#botfather"');
     expect(telegram).toContain(S.telegram.setupSteps[0]);
   });
 });

--- a/packages/web/test/messaging-binding-editor.test.ts
+++ b/packages/web/test/messaging-binding-editor.test.ts
@@ -3,14 +3,15 @@
  *
  * Six rules this pins, all of which are invisible to a type checker: the form opens on its
  * FIELDS (the explanation lives in the collapsed FAQ under the save area, not above the first
- * input), each channel's developer-console link rides the credential field's corner, the
- * connection switch — which IS the bind/unbind — carries that sentence as its own tooltip
- * rather than as a line the form would have to make room for, a stored secret is removed by
- * the models-page clear checkbox and that checkbox is gated, on screen, while the channel
- * holds the connection, and a connection error's detail reaches the reader whole rather than
- * as a few words of a shared row.
+ * input), each channel's credential-source link rides the credential field's corner, that
+ * link's label names the place it actually opens, the connection switch — which IS the
+ * bind/unbind — carries that sentence as its own tooltip rather than as a line the form
+ * would have to make room for, a stored secret is removed by the models-page clear checkbox
+ * and that checkbox is gated, on screen, while the channel holds the connection, and a
+ * connection error's detail reaches the reader whole rather than as a few words of a shared
+ * row.
  */
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { MessagingChannel } from "@prismshadow/penguin-server/api";
@@ -21,7 +22,10 @@ import {
   type MessagingChannelFacts,
 } from "../src/features/messaging/messaging-binding-editor";
 import { emptyMessagingForm } from "../src/features/messaging/messaging-binding-form";
-import { S } from "../src/lib/strings";
+import { S, setActiveStrings, zh } from "../src/lib/strings";
+import { en } from "../src/lib/strings-en";
+
+afterEach(() => setActiveStrings(zh));
 
 const DARK: MessagingChannelFacts = {
   secretConfigured: false,
@@ -85,13 +89,20 @@ describe("MessagingBindingBody", () => {
 
   it("labels that corner link with what it opens, never with a console Telegram has not got", () => {
     // The defect this pins: a link labelled "open developer console" that landed in the API
-    // manual. Label and target have to name the same thing, so the shared console wording is
-    // used only by the channels that actually have one.
-    const telegram = render(stateOf("telegram"));
-    expect(telegram).toContain(S.telegram.openBotFather);
-    expect(telegram).not.toContain(S.messaging.console);
-    // ...and the channels that do have a console keep it.
-    expect(render(stateOf("feishu"))).toContain(S.messaging.console);
+    // manual. Both dictionaries, because the label is per-locale and `S` is zh until a test
+    // says otherwise — an assertion against the active dictionary alone would leave English
+    // free to carry the very wording this fixed.
+    for (const dict of [zh, en]) {
+      setActiveStrings(dict);
+      // Label and target in ONE assertion: pinned apart, they pass just as happily with the
+      // right href on the wrong anchor.
+      const telegram = render(stateOf("telegram"));
+      const corner = /<a href="https:\/\/t\.me\/BotFather"[^>]*>([^<]*)<\/a>/.exec(telegram);
+      expect(corner?.[1]).toBe(`${dict.telegram.openBotFather} ↗`);
+      expect(telegram).not.toContain(dict.messaging.console);
+      // ...and the channels that do have a console keep it.
+      expect(render(stateOf("feishu"))).toContain(dict.messaging.console);
+    }
   });
 
   it("offers a stored secret's removal as the clear checkbox, gated on screen while enabled", () => {


### PR DESCRIPTION
The Bot Token field's corner link was labelled **"open developer console"** and pointed at `https://core.telegram.org/bots/api` — the Bot API reference. Telegram has no developer console, and that page issues no tokens. So a user standing on the one field that needs a token, following the one link that offers to supply it, landed in an 860KB API manual with no way to get what they came for.

Branched off `main` and independent of the QQ stack (#501 / #504), where this was found during a link audit but deliberately not fixed.

## What must not survive

A label and a target that disagree. There were three ways to resolve that, and the evidence picks one.

**Keeping the target and relabelling it "API reference" is wrong.** The corner link's whole job in this editor — the models-page "get API key" idiom it copies — is *where does this value come from*. Relabelling would make the copy truthful and the link useless, leaving the field's actual question unanswered.

**So the target moves, and the label follows it.** `https://t.me/BotFather` is where the credential is issued. Telegram's own page for it is titled `Telegram: Launch @BotFather` and describes it as the bot "to create new bot accounts and manage your existing bots" — it serves a real interstitial with an action button and a `tg://resolve?domain=BotFather` hand-off, so it works with or without a desktop client installed.

**And the label changes too, because the interaction is not the one the shared wording describes.** You asked me to check how the corner link behaves for a `t.me` target: `ExternalLink` renders `target="_blank" rel="noreferrer noopener"` with a `↗` glyph, so a click opens a new tab which then offers to launch the app. The `↗` stays accurate — a tab really does open — but "open developer console" does not, in two ways at once: it names a thing Telegram has never had, and it promises a documentation-style destination when the click ends in an app. Telegram's own verb for it is "Launch". So this channel gets `S.telegram.openBotFather` — 打开 @BotFather / Open @BotFather — and the shared `S.messaging.console` stays untouched for the channels that genuinely have a console.

One implementation detail worth flagging, because the obvious version is a bug: the label is chosen **at render**, not stored beside the URL in `CHANNEL_LINKS`. `S` is a `let` the locale provider reassigns (`setActiveStrings`), so a label captured in that module-level table would freeze at whatever language was active when the module first evaluated and never follow a language switch.

## The tutorial half

You asked whether `/bots/tutorial` still reads coherently once `console` changes. It does not, and this is the part I'd have missed by pattern-matching.

`https://core.telegram.org/bots/tutorial` is titled **"From BotFather to 'Hello World'"**. Its headings run: Introduction → Getting Ready → Obtain Your Bot Token → **Download an IDE → Pick a Framework or Library → Create Your Project → Add Framework Dependency → Start Coding**. It is a guide to *writing* a bot. Nobody using this form is writing one — PenguinHarness is the bot; the user only needs a token.

`https://core.telegram.org/bots/features#botfather` is the BotFather section, which opens: *"Below is a detailed guide to using @BotFather, Telegram's tool for creating and managing bots… **Creating a new bot** — Use the `/newbot` command to create a new bot. @BotFather will ask you for a name and username, then generate an authentication token…"* That is this fold's own setup steps, one level deeper, and nothing more.

So the pair now reads coherently: both surfaces are about BotFather, at the level each needs — the corner link is *do it now*, the fold link is *read how*. I also checked `/bots` ("Bots: An introduction for developers", a "What Can You Do with Bots?" overview) and rejected it as marketing.

On the fragment: `#botfather` is a plain document anchor (`<a class="anchor" name="botfather">`) present in the served HTML, so it lands where it says. Worth stating explicitly because the sibling QQ audit found the opposite case — a `#/developer/developer-setting` hash route that the server never sees, which silently landed on a shell page.

## What each URL returned

Checked over the wire, no proxy in the environment, `curl -sSL` recording status-without-redirect / status-after-redirect / body size:

| URL | raw | final | bytes | verdict |
| --- | --- | --- | --- | --- |
| `https://t.me/BotFather` | 200 | 200 | 11162 | **new console target** |
| `https://core.telegram.org/bots/features#botfather` | 200 | 200 | 116925 | **new tutorial target** (anchor confirmed in the served HTML) |
| `https://core.telegram.org/bots/api` | 200 | 200 | 860075 | old console target — resolves, but it is the API reference |
| `https://core.telegram.org/bots/tutorial` | 200 | 200 | 43985 | old tutorial target — resolves, but teaches you to write a bot |
| `https://core.telegram.org/bots` | 200 | 200 | 24954 | considered, rejected as an overview |
| `https://telegram.me/BotFather` | 200 | 200 | 11162 | the legacy alias, byte-identical; `t.me` is the canonical one |

Feishu's two links were audited in the same pass and are healthy and correctly labelled, so they are untouched: `https://open.feishu.cn/app` (200, 9649 bytes) really is a developer console, and `https://open.feishu.cn/document/develop-an-echo-bot/introduction` (200, 7464 bytes) really is its setup walkthrough.

## Tests

The existing corner-link test now asserts the new target and that the API reference is gone. A new test pins the thing that actually broke — that the label and the target name the same thing — by requiring `S.telegram.openBotFather` in the Telegram render and asserting `S.messaging.console` is absent from it, while still requiring it in the Feishu render so the shared wording is not quietly lost. The help-fold test pins the new tutorial URL.

## Verification

Full CI-parity chain from the worktree root on Node v24.18.0, all passing:

- `pnpm install --frozen-lockfile` — exit 0
- `pnpm -r build` — exit 0
- `pnpm typecheck` — exit 0 (8 projects)
- `pnpm test` — exit 0: core 1014, server 1073, web 1361, cli 374, desktop 144, docs 53, landing 69, skills 27
- `pnpm format` then `pnpm format:check` — "All matched files use Prettier code style!"

Diff is 4 files (49 insertions, 6 deletions) plus the changelog pair, confined to the Telegram channel's links, their label, and their tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
