### PR TITLE
fix(web): preserve benchmark selection after navigation

### DIFF
--- a/changelog/unreleased/2026-08-27-benchmark-selection-persistence.md
+++ b/changelog/unreleased/2026-08-27-benchmark-selection-persistence.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-27
 - **Type:** fix
 - **Scope:** `web`
+- **PR:** [#515](https://github.com/Prism-Shadow/penguin-harness/pull/515)
 - **Issue:** [#181](https://github.com/Prism-Shadow/penguin-harness/issues/181)
 
 [中文版](2026-08-27-benchmark-selection-persistence.zh.md)

--- a/changelog/unreleased/2026-08-27-benchmark-selection-persistence.md
+++ b/changelog/unreleased/2026-08-27-benchmark-selection-persistence.md
@@ -1,0 +1,15 @@
+# Preserve benchmark selection across navigation
+
+- **Date:** 2026-08-27
+- **Type:** fix
+- **Scope:** `web`
+- **Issue:** [#181](https://github.com/Prism-Shadow/penguin-harness/issues/181)
+
+[中文版](2026-08-27-benchmark-selection-persistence.zh.md)
+
+The Benchmark page now keeps the selected Agent and Benchmark in the URL, so returning from a Session trace restores the previous view for the current project.
+
+## Details
+
+- Selecting a benchmark updates `agentId` and `benchmarkId` query parameters.
+- A matching selection is restored after the page mounts again.

--- a/changelog/unreleased/2026-08-27-benchmark-selection-persistence.zh.md
+++ b/changelog/unreleased/2026-08-27-benchmark-selection-persistence.zh.md
@@ -1,0 +1,15 @@
+# 在导航后保留 Benchmark 选择
+
+- **Date:** 2026-08-27
+- **Type:** fix
+- **Scope:** `web`
+- **Issue:** [#181](https://github.com/Prism-Shadow/penguin-harness/issues/181)
+
+[English](2026-08-27-benchmark-selection-persistence.md)
+
+Benchmark 页面现在会将选中的 Agent 和 Benchmark 保存在 URL 中，因此从 Session trace 返回时可以恢复当前项目之前的视图。
+
+## 细节
+
+- 选择 Benchmark 时更新 `agentId` 和 `benchmarkId` 查询参数。
+- 页面重新挂载后恢复匹配的选择。

--- a/changelog/unreleased/2026-08-27-benchmark-selection-persistence.zh.md
+++ b/changelog/unreleased/2026-08-27-benchmark-selection-persistence.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-27
 - **Type:** fix
 - **Scope:** `web`
+- **PR:** [#515](https://github.com/Prism-Shadow/penguin-harness/pull/515)
 - **Issue:** [#181](https://github.com/Prism-Shadow/penguin-harness/issues/181)
 
 [English](2026-08-27-benchmark-selection-persistence.md)

--- a/packages/web/src/features/benchmark/benchmark-page.tsx
+++ b/packages/web/src/features/benchmark/benchmark-page.tsx
@@ -36,6 +36,7 @@ import { ChartFrame, useChartWidth } from "../usage/chart-svg";
 import { modelSeries, scoreScale, scoreValues, seriesValues } from "./benchmark-metrics";
 import type { EvaluationSeries } from "./benchmark-metrics";
 import { BenchmarkCaseBrowser } from "./benchmark-case-browser";
+import { benchmarkSelectionFromSearch, benchmarkSelectionSearch } from "./benchmark-selection";
 
 interface Selection {
   agentId: string;
@@ -50,6 +51,7 @@ function AgentNode({
   defaultOpen,
   selection,
   onSelect,
+  initialBenchmarkId,
 }: {
   projectId: string;
   agentId: string;
@@ -58,6 +60,7 @@ function AgentNode({
   defaultOpen: boolean;
   selection: Selection | null;
   onSelect: (sel: Selection) => void;
+  initialBenchmarkId: string | null;
 }) {
   const [open, setOpen] = useState(defaultOpen);
   const [benchmarks, setBenchmarks] = useState<BenchmarkSummary[] | null>(null);
@@ -67,9 +70,13 @@ function AgentNode({
     if (!open || benchmarks) return;
     api
       .listBenchmarks(projectId, agentId)
-      .then((data) => setBenchmarks(data.benchmarks))
+      .then((data) => {
+        setBenchmarks(data.benchmarks);
+        const initial = data.benchmarks.find((b) => b.id === initialBenchmarkId);
+        if (initial) onSelect({ agentId, benchmark: initial });
+      })
       .catch((e: unknown) => setError(apiErrorText(e)));
-  }, [open, benchmarks, projectId, agentId]);
+  }, [open, benchmarks, projectId, agentId, initialBenchmarkId, onSelect]);
 
   return (
     <li className="pt-2.5">
@@ -502,8 +509,9 @@ export function BenchmarkPage() {
   const { currency } = useTheme();
   const projectId = currentProject?.projectId ?? null;
   // ?agentId= deep link (entered from the "Benchmark" tab on the Agent settings page): only the target Agent is expanded by default.
-  const [searchParams] = useSearchParams();
-  const focusAgentId = searchParams.get("agentId");
+  const [searchParams, setSearchParams] = useSearchParams();
+  const savedSelection = benchmarkSelectionFromSearch(searchParams.toString());
+  const focusAgentId = savedSelection?.agentId ?? searchParams.get("agentId");
   const [selection, setSelection] = useState<Selection | null>(null);
   const [caseStatements, setCaseStatements] = useState<BenchmarkCaseSummary[] | null>(null);
   const [caseError, setCaseError] = useState<string | null>(null);
@@ -513,6 +521,16 @@ export function BenchmarkPage() {
   useEffect(() => {
     setSelection(null);
   }, [projectId]);
+
+  useEffect(() => {
+    if (!selection) return;
+    const next = benchmarkSelectionSearch({
+      agentId: selection.agentId,
+      benchmarkId: selection.benchmark.id,
+    });
+    if (searchParams.toString() === next.slice(1)) return;
+    setSearchParams(next, { replace: true });
+  }, [selection, searchParams, setSearchParams]);
 
   useEffect(() => {
     setCaseStatements(null);
@@ -562,6 +580,9 @@ export function BenchmarkPage() {
                 defaultOpen={focusAgentId === null || focusAgentId === a.agentId}
                 selection={selection}
                 onSelect={setSelection}
+                initialBenchmarkId={
+                  savedSelection?.agentId === a.agentId ? savedSelection.benchmarkId : null
+                }
               />
             ))}
           </ul>

--- a/packages/web/src/features/benchmark/benchmark-selection.ts
+++ b/packages/web/src/features/benchmark/benchmark-selection.ts
@@ -1,0 +1,18 @@
+export interface BenchmarkSelection {
+  agentId: string;
+  benchmarkId: string;
+}
+
+export function benchmarkSelectionFromSearch(search: string): BenchmarkSelection | null {
+  const params = new URLSearchParams(search);
+  const agentId = params.get("agentId");
+  const benchmarkId = params.get("benchmarkId");
+  return agentId && benchmarkId ? { agentId, benchmarkId } : null;
+}
+
+export function benchmarkSelectionSearch(selection: BenchmarkSelection): string {
+  const params = new URLSearchParams();
+  params.set("agentId", selection.agentId);
+  params.set("benchmarkId", selection.benchmarkId);
+  return `?${params.toString()}`;
+}

--- a/packages/web/test/benchmark-selection.test.ts
+++ b/packages/web/test/benchmark-selection.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import {
+  benchmarkSelectionFromSearch,
+  benchmarkSelectionSearch,
+} from "../src/features/benchmark/benchmark-selection";
+
+describe("benchmark selection URL state", () => {
+  it("round-trips the selected agent and benchmark", () => {
+    const selection = { agentId: "agent a", benchmarkId: "benchmark/1" };
+    expect(benchmarkSelectionFromSearch(benchmarkSelectionSearch(selection))).toEqual(selection);
+  });
+
+  it("ignores incomplete selections", () => {
+    expect(benchmarkSelectionFromSearch("?agentId=agent-only")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #181.

The Benchmark page lost its selected Agent and Benchmark after navigating to a Session trace and returning through the sidebar.

## Changes

- Persist the selected Agent and Benchmark as `agentId` and `benchmarkId` query parameters.
- Restore a matching Benchmark selection when the page mounts again.
- Add a focused URL state regression test.
- Add the required English and Chinese changelog entries.

## Tests

- `pnpm --filter @prismshadow/penguin-web exec vitest run test/benchmark-selection.test.ts`
- `pnpm --filter @prismshadow/penguin-web exec tsc --noEmit -p tsconfig.json`
- `pnpm --filter @prismshadow/penguin-web build`
- `pnpm exec prettier --check packages/web/src/features/benchmark/benchmark-page.tsx packages/web/src/features/benchmark/benchmark-selection.ts packages/web/test/benchmark-selection.test.ts`
- `git diff --check`

All listed checks passed. The local environment uses Node 22 while the repository declares Node >=24; pnpm emitted the repository engine warning, but the checks completed successfully.

## Compatibility / Known limitations

The selection is encoded in the URL and remains backward compatible with bare `/benchmark` links. If the referenced Agent or Benchmark no longer exists, the page keeps its existing empty state.
