### PR TITLE
Qwen 3.8 Flash in the TokenDance group

### DIFF
--- a/changelog/unreleased/2026-08-27-catalog-tokendance-qwen38-flash.md
+++ b/changelog/unreleased/2026-08-27-catalog-tokendance-qwen38-flash.md
@@ -1,0 +1,28 @@
+# Qwen 3.8 Flash joins the TokenDance group
+
+- **Date:** 2026-08-27
+- **Type:** feature
+- **Scope:** `core`
+
+[中文版](2026-08-27-catalog-tokendance-qwen38-flash.zh.md)
+
+The built-in catalog now carries `qwen3.8-flash` under TokenDance, at that gateway's own rates:
+CNY 0.8 input, 2.7 output, 0.1 cache hit per million tokens, over a 1M-token context window, with
+image input.
+
+The same upstream id already sat in the Qwen pay-as-you-go group at Qwen's direct list price
+(CNY 1 / 3 / 0.1). Both rows stay: one model reached two ways, priced by whoever is selling it,
+and the gateway is the cheaper of the two on input and output.
+
+## Details
+
+- Context window and the vision flag come from TokenDance's public catalog API
+  (`GET https://tokendance.space/gateway/v1/models`, no credential required), the same source
+  the rest of the group is verified against.
+- The row is not discounted: its catalog `description` carries no bracketed 限时 tag, unlike
+  `qwen3.8-max` in the same group, so its list price and its billed rate coincide.
+- It advertises the widest protocol set in the group — `openai:chat-completions`,
+  `openai:responses` and `anthropic:messages`. The `openai-chat` pin is this group's convention
+  rather than a constraint of the id, which the entry says so nobody later reads it as forced.
+- `cache_write` carries the input price, the convention the whole TokenDance block already runs
+  on: the gateway publishes an input price and a cache-hit price with no separate cache-write fee.

--- a/changelog/unreleased/2026-08-27-catalog-tokendance-qwen38-flash.md
+++ b/changelog/unreleased/2026-08-27-catalog-tokendance-qwen38-flash.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-27
 - **Type:** feature
 - **Scope:** `core`
+- **PR:** [#517](https://github.com/Prism-Shadow/penguin-harness/pull/517)
 
 [中文版](2026-08-27-catalog-tokendance-qwen38-flash.zh.md)
 

--- a/changelog/unreleased/2026-08-27-catalog-tokendance-qwen38-flash.zh.md
+++ b/changelog/unreleased/2026-08-27-catalog-tokendance-qwen38-flash.zh.md
@@ -1,0 +1,18 @@
+# TokenDance 分组新增 Qwen 3.8 Flash
+
+- **Date:** 2026-08-27
+- **Type:** feature
+- **Scope:** `core`
+
+[English](2026-08-27-catalog-tokendance-qwen38-flash.md)
+
+内置模型目录在 TokenDance 下新增 `qwen3.8-flash`，按该网关自己的价格：每百万 Token 输入 0.8 元、输出 2.7 元、缓存命中 0.1 元，上下文窗口 100 万 Token，支持图片输入。
+
+同一个上游 id 早已存在于 Qwen 按量付费分组中，用的是 Qwen 官方直连价（1 / 3 / 0.1 元）。两条都保留：同一个模型有两条到达路径，价格由卖它的一方决定，而网关在输入与输出上都更便宜。
+
+## 细节
+
+- 上下文窗口与视觉标记取自 TokenDance 的公开目录接口（`GET https://tokendance.space/gateway/v1/models`，无需凭据），与该分组其余各行的核对来源一致。
+- 该行没有折扣：其目录 `description` 中没有方括号的「限时」标记——这一点与同组的 `qwen3.8-max` 不同——因此列表价与实际计费一致。
+- 它声明的协议集是本组最宽的：`openai:chat-completions`、`openai:responses` 与 `anthropic:messages`。`openai-chat` 是本分组的约定，而非该 id 唯一能走的形态，条目里写明了这一点，以免日后被误读成硬性限制。
+- `cache_write` 承载输入价，这是整个 TokenDance 区块既有的约定：该网关只公布输入价与缓存命中价，没有单独的缓存写入费。

--- a/changelog/unreleased/2026-08-27-catalog-tokendance-qwen38-flash.zh.md
+++ b/changelog/unreleased/2026-08-27-catalog-tokendance-qwen38-flash.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-27
 - **Type:** feature
 - **Scope:** `core`
+- **PR:** [#517](https://github.com/Prism-Shadow/penguin-harness/pull/517)
 
 [English](2026-08-27-catalog-tokendance-qwen38-flash.md)
 

--- a/packages/core/src/state/model-catalog.ts
+++ b/packages/core/src/state/model-catalog.ts
@@ -4,7 +4,8 @@
  * Data verified as of 2026-07-10 (Qwen Token Plan entries: 2026-07-20; MiniMax: 2026-08-03;
  * DeepSeek, Gemini 3.7, GLM-5.3 and the whole OpenAI line-up (direct + OpenRouter):
  * 2026-08-18; the direct Anthropic group: 2026-08-20; the DeepSeek V4 Flash Vision Exp rows:
- * 2026-08-21; the TokenDance group: 2026-08-25, its glm-5.3-flash row: 2026-08-26; the
+ * 2026-08-21; the TokenDance group: 2026-08-25, its glm-5.3-flash row: 2026-08-26 and its
+ * qwen3.8-flash row: 2026-08-27; the
  * GLM-5.3 Flash rows (direct + OpenRouter) and qwen3.8-flash: 2026-08-26 — per each
  * provider's docs).
  * Docs: packages/docs/content/models.{zh,en}.md (site path /docs/models) documents the
@@ -1021,6 +1022,28 @@ export const MODEL_CATALOG: ModelCatalogEntry[] = [
     provider: "tokendance",
     contextWindow: 1048576,
     pricing: cny(2, 20, 100),
+    supportsVision: true,
+    clientType: "openai-chat",
+    baseUrl: TOKENDANCE_BASE_URL,
+  },
+  {
+    // The gateway's own rate undercuts Qwen's direct list price for the same id (CNY 0.8 vs 1
+    // input, 2.7 vs 3 output, cache hit the same 0.1), which is the whole reason both rows
+    // exist: the pair is one model reached two ways, priced by whoever is selling it.
+    //
+    // Its supported_protocols is the widest in this group — openai:chat-completions,
+    // openai:responses AND anthropic:messages — so the openai-chat pin here is the group's
+    // convention rather than the only shape the id serves, unlike glm-5.3-flash above where
+    // it is forced. Natively multimodal per the catalog entry, and this group's openai-chat
+    // client forwards image_url parts, so image input works on this path.
+    //
+    // Not discounted: unlike qwen3.8-max below, its catalog `description` carries no
+    // bracketed 限时 tag, so list price and billed rate coincide.
+    modelId: "qwen3.8-flash",
+    displayName: "Qwen 3.8 Flash",
+    provider: "tokendance",
+    contextWindow: 1000000,
+    pricing: cny(0.1, 0.8, 2.7),
     supportsVision: true,
     clientType: "openai-chat",
     baseUrl: TOKENDANCE_BASE_URL,

--- a/packages/core/src/state/model-catalog.ts
+++ b/packages/core/src/state/model-catalog.ts
@@ -5,9 +5,8 @@
  * DeepSeek, Gemini 3.7, GLM-5.3 and the whole OpenAI line-up (direct + OpenRouter):
  * 2026-08-18; the direct Anthropic group: 2026-08-20; the DeepSeek V4 Flash Vision Exp rows:
  * 2026-08-21; the TokenDance group: 2026-08-25, its glm-5.3-flash row: 2026-08-26 and its
- * qwen3.8-flash row: 2026-08-27; the
- * GLM-5.3 Flash rows (direct + OpenRouter) and qwen3.8-flash: 2026-08-26 — per each
- * provider's docs).
+ * qwen3.8-flash row: 2026-08-27; the GLM-5.3 Flash rows (direct + OpenRouter) and the
+ * direct qwen3.8-flash: 2026-08-26 — per each provider's docs).
  * Docs: packages/docs/content/models.{zh,en}.md (site path /docs/models) documents the
  * provider groups and credential resolution described here.
  *

--- a/packages/core/test/model-catalog.test.ts
+++ b/packages/core/test/model-catalog.test.ts
@@ -303,6 +303,7 @@ describe("model-catalog", () => {
       ["glm-5.3", 1000000, false],
       ["glm-5.3-flash", 1000000, true],
       ["kimi-k3", 1048576, true],
+      ["qwen3.8-flash", 1000000, true],
       ["qwen3.8-max", 1000000, true],
     ]);
     for (const m of td) {
@@ -322,6 +323,20 @@ describe("model-catalog", () => {
     expect([tdFlash.cache_read, tdFlash.cache_write, tdFlash.output]).toEqual([
       0.032857, 0.114286, 0.4,
     ]);
+    // qwen3.8-flash at 0.1 / 0.8 / 2.7 CNY, undiscounted. The same id also sits in the
+    // qwen-pay-as-you-go group at Qwen's own 0.1 / 1 / 3, and the pair is the point: one
+    // model reached two ways, priced by whoever is selling it, so the two rows must not
+    // silently converge.
+    const tdQwenFlash = td.find((m) => m.modelId === "qwen3.8-flash")!.pricing!;
+    expect([tdQwenFlash.cache_read, tdQwenFlash.cache_write, tdQwenFlash.output]).toEqual([
+      0.014286, 0.114286, 0.385714,
+    ]);
+    const payggFlash = MODEL_CATALOG.find(
+      (m) => m.provider === "qwen-pay-as-you-go" && m.modelId === "qwen3.8-flash",
+    )!.pricing!;
+    expect(payggFlash.cache_write).toBeGreaterThan(tdQwenFlash.cache_write);
+    expect(payggFlash.output).toBeGreaterThan(tdQwenFlash.output);
+    expect(payggFlash.cache_read).toEqual(tdQwenFlash.cache_read);
     const qpayg = MODEL_CATALOG.filter((m) => m.provider === "qwen-pay-as-you-go");
     expect(qpayg.map((m) => [m.modelId, m.supportsVision])).toEqual([
       ["deepseek-v4-flash-0731", false],


### PR DESCRIPTION
Adds `qwen3.8-flash` to the TokenDance group at that gateway's own rates: **CNY 0.8 input, 2.7
output, 0.1 cache hit** per million tokens, over a 1M-token context window, with image input.

## The pair, and why both rows stay

The same upstream id already sits in the Qwen pay-as-you-go group at Qwen's direct list price
(CNY 1 / 3 / 0.1). That is not a duplicate — it is one model reached two ways, priced by whoever is
selling it, and the gateway is cheaper on input and output while matching the cache-hit rate. The
test asserts that relation rather than the numbers alone, so a later edit that quietly makes the
two rows identical fails instead of passing.

## Where the facts come from

- **Prices**: the gateway's own published CNY rates, supplied by the maintainer. Stored through
  `cny()` like every other row, so switching the cost center to CNY shows exactly those figures
  back.
- **Context window and vision flag**: `GET https://tokendance.space/gateway/v1/models` — the public,
  credential-free catalog API the rest of this group is already verified against. It reports
  `context_length: 1000000` and a natively multimodal description.
- **Not discounted**: its catalog `description` carries no bracketed 限时 tag, unlike `qwen3.8-max`
  in the same group (currently 八折). So its list price and its billed rate coincide, which is what
  the group's block comment requires a row to state either way.

## Two things the entry says on purpose

- **`cache_write` carries the input price.** The whole TokenDance block runs on this: the gateway
  publishes an input price and a cache-hit price with no separate cache-write fee.
- **The `openai-chat` pin is a convention here, not a constraint.** This id advertises the widest
  protocol set in the group — `openai:chat-completions`, `openai:responses` *and*
  `anthropic:messages` — where `glm-5.3-flash` above is pinned because its list is
  `openai:chat-completions` alone. Recording the difference keeps the next reader from taking the
  pin as forced.

Row position follows the group's dictionary order by upstream id, which puts it before
`qwen3.8-max`; the file header's dated verification log gains the row's own date.

## Verification

`pnpm -r build`, `pnpm typecheck`, `pnpm test` and `pnpm format` + `pnpm format:check` all pass on
Node 24 — 8 packages, 0 failures (core 1021, server 1341, cli 383, web 1478, desktop 144).

`packages/core/test/model-catalog.test.ts` gained the row to the group's ordered id/context/vision
list, its exact stored USD triple (`0.014286 / 0.114286 / 0.385714`, i.e. the CNY figures at the
catalog's 7:1 convention), and the comparison against the pay-as-you-go row above. The suite's
standing checks — three-bucket pricing present and positive, positive integer context window,
`openai-chat` + the TokenDance base URL for every row in the group — cover the new entry
automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
