### PR TITLE
fix(web): copy works on a plain-HTTP origin, and the check means it happened

### DIFF
--- a/changelog/unreleased/2026-08-27-copy-on-plain-http.md
+++ b/changelog/unreleased/2026-08-27-copy-on-plain-http.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-27
 - **Type:** fix
 - **Scope:** `web`
+- **PR:** [#523](https://github.com/Prism-Shadow/penguin-harness/pull/523)
 - **Issue:** [#468](https://github.com/Prism-Shadow/penguin-harness/issues/468)
 
 [中文版](2026-08-27-copy-on-plain-http.zh.md)

--- a/changelog/unreleased/2026-08-27-copy-on-plain-http.md
+++ b/changelog/unreleased/2026-08-27-copy-on-plain-http.md
@@ -1,0 +1,18 @@
+# Copy works on a plain-HTTP origin, and the check means it happened
+
+- **Date:** 2026-08-27
+- **Type:** fix
+- **Scope:** `web`
+- **Issue:** [#468](https://github.com/Prism-Shadow/penguin-harness/issues/468)
+
+[中文版](2026-08-27-copy-on-plain-http.zh.md)
+
+Every copy control in the Web App — a reply, a user message, a code block, a Session id, an Agent State path, a terminal selection — reached for the async Clipboard API alone, which browsers expose only in a secure context. On a plain-HTTP origin that is not localhost, the shape a non-loopback `HOST` bind serves, the write was a no-op while the button still flashed its check and announced a copy to screen readers: the text went nowhere and the control said it had landed. The write gained a fallback through a hidden textarea and the document's own copy command, and the check now waits for the write to report that it succeeded.
+
+## Details
+
+- The fallback was put in one module that every copy control and the terminal call, so a copy affordance cannot reintroduce the silent no-op by reaching for `navigator.clipboard` on its own — a test asserts no other module under `packages/web/src` writes to it.
+- The textarea the fallback borrows is fixed-positioned and transparent rather than placed off-screen: `select()` scrolls its target into view, and a textarea below the fold would jump the page on every copy.
+- The absent-API path reaches the document's copy command without suspending, inside the click's own task, because that command is only honoured while a user gesture is in progress.
+- A copy the browser refuses outright — permission denied on an origin where the Clipboard API does exist — leaves the control idle instead of showing the check, so the copy can be retried rather than being reported as done.
+- Terminal paste was left as it was: `Ctrl+V`, `Ctrl+Shift+V` and `Shift+Insert` ride the browser's native paste event, which involves no clipboard permission.

--- a/changelog/unreleased/2026-08-27-copy-on-plain-http.zh.md
+++ b/changelog/unreleased/2026-08-27-copy-on-plain-http.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-27
 - **Type:** fix
 - **Scope:** `web`
+- **PR:** [#523](https://github.com/Prism-Shadow/penguin-harness/pull/523)
 - **Issue:** [#468](https://github.com/Prism-Shadow/penguin-harness/issues/468)
 
 [English](2026-08-27-copy-on-plain-http.md)

--- a/changelog/unreleased/2026-08-27-copy-on-plain-http.zh.md
+++ b/changelog/unreleased/2026-08-27-copy-on-plain-http.zh.md
@@ -1,0 +1,18 @@
+# 纯 HTTP 源下复制可用，对勾代表复制真的发生了
+
+- **Date:** 2026-08-27
+- **Type:** fix
+- **Scope:** `web`
+- **Issue:** [#468](https://github.com/Prism-Shadow/penguin-harness/issues/468)
+
+[English](2026-08-27-copy-on-plain-http.md)
+
+Web App 里的每一个复制控件——回复、用户消息、代码块、Session id、Agent State 路径、终端选区——都只走异步 Clipboard API，而浏览器仅在安全上下文中提供它。在非 localhost 的纯 HTTP 源上（也就是把 `HOST` 绑到非回环地址后所提供的形态），写入是一次空操作，按钮却照样闪出对勾、并向屏幕阅读器播报已复制：文本哪儿也没去，控件却说它到位了。这次为写入补上了经隐藏 textarea 与文档自带复制命令的回退路径，对勾也改为等写入报告成功之后才出现。
+
+## 细节
+
+- 回退被放进一个模块，所有复制控件和终端都调用它，因此新的复制入口无法再各自去碰 `navigator.clipboard` 而重新引入这次的静默空操作——一个测试断言 `packages/web/src` 下再无其他模块向它写入。
+- 回退借用的 textarea 采用 fixed 定位加透明，而不是挪到屏幕外：`select()` 会把目标滚动进视野，放在首屏之下的 textarea 会让每次复制都跳动一次页面。
+- API 缺失这条路径不经挂起、就在点击自身的任务内到达文档的复制命令，因为该命令只在用户手势进行中才被接受。
+- 浏览器彻底拒绝的复制——在确实提供 Clipboard API 的源上被拒权限——让控件停在空闲态而不显示对勾，于是可以重试，而不是被报告为已完成。
+- 终端粘贴维持原样：`Ctrl+V`、`Ctrl+Shift+V` 与 `Shift+Insert` 走浏览器原生 paste 事件，不涉及剪贴板权限。

--- a/packages/web/src/components/ui/copy-button.tsx
+++ b/packages/web/src/components/ui/copy-button.tsx
@@ -2,8 +2,9 @@
  * Copy-to-clipboard button and the hook behind it — the single place the app's "copy"
  * affordance and its feedback live, so every copy control behaves the same:
  *
- *   - the write is optimistic (an insecure context or denied permission must not leave the
- *     control stuck), matching the clipboard convention used across the chat views;
+ *   - the feedback follows the WRITE: the check appears only once the text has actually
+ *     reached the clipboard (writeClipboard reports that), so a copy the browser refused
+ *     never reads as one that succeeded;
  *   - the feedback is ALWAYS shown AT THE BUTTON, and it is the icon alone: copy swaps to
  *     the check for COPIED_MS and the tooltip flips to "已复制" (#312 — no transient
  *     "已复制" text is rendered, and the feedback never replaces an unrelated label/title
@@ -13,6 +14,7 @@
  *     region beside itself — that is the screen-reader half of the same feedback.
  */
 import { useEffect, useRef, useState } from "react";
+import { writeClipboard } from "../../lib/clipboard";
 import { S } from "../../lib/strings";
 import { STAT_ICONS } from "../../lib/stat-icons";
 import { GlyphIcon } from "./glyph-icon";
@@ -20,15 +22,10 @@ import { GlyphIcon } from "./glyph-icon";
 /** How long the copied state (check icon + flipped tooltip) stays after a click. */
 const COPIED_MS = 1500;
 
-/** Best-effort clipboard write (never throws; no-op where the API is unavailable). */
-export function writeClipboard(text: string): void {
-  void navigator.clipboard?.writeText(text);
-}
-
 /**
- * Transient "just copied" flag: `flash()` writes the text and turns `copied` on for
- * COPIED_MS. Exposed for the caller whose copy trigger is not a plain CopyButton
- * (e.g. a text button rendering CopyCheckGlyph next to its label); most callers
+ * Transient "just copied" flag: `flash()` writes the text and, if the write landed, turns
+ * `copied` on for COPIED_MS. Exposed for the caller whose copy trigger is not a plain
+ * CopyButton (e.g. a text button rendering CopyCheckGlyph next to its label); most callers
  * should use CopyButton directly.
  */
 export function useCopied(): { copied: boolean; flash: (text: string) => void } {
@@ -47,13 +44,17 @@ export function useCopied(): { copied: boolean; flash: (text: string) => void } 
     [],
   );
   const flash = (text: string) => {
-    writeClipboard(text);
-    setCopied(true);
-    if (resetTimer.current !== null) clearTimeout(resetTimer.current);
-    resetTimer.current = setTimeout(() => {
-      resetTimer.current = null;
-      setCopied(false);
-    }, COPIED_MS);
+    void writeClipboard(text).then((ok) => {
+      // A refused write shows nothing rather than a check: the control returns to idle, so
+      // the copy can simply be retried — there is no state to be stuck in.
+      if (!ok) return;
+      setCopied(true);
+      if (resetTimer.current !== null) clearTimeout(resetTimer.current);
+      resetTimer.current = setTimeout(() => {
+        resetTimer.current = null;
+        setCopied(false);
+      }, COPIED_MS);
+    });
   };
   return { copied, flash };
 }

--- a/packages/web/src/features/terminal/terminal-view.tsx
+++ b/packages/web/src/features/terminal/terminal-view.tsx
@@ -16,6 +16,7 @@ import "@xterm/xterm/css/xterm.css";
 // Types only (erased at compile time): the xterm runtime stays behind loadXterm() below.
 import type { ITheme, Terminal as XTerminal } from "@xterm/xterm";
 import { TerminalOpcode, decodeFrame, encodeFrame, encodeResize } from "./terminal-frames";
+import { writeClipboard } from "../../lib/clipboard";
 import { useTheme } from "../../state/theme";
 
 /**
@@ -256,7 +257,7 @@ export function TerminalView({ ensure, onStatus, onInfo, onTitle, className }: T
       const copySelection = (): void => {
         const selection = term.getSelection();
         if (!selection) return;
-        void navigator.clipboard?.writeText(selection).catch(() => {});
+        void writeClipboard(selection);
         term.clearSelection();
       };
       /** Async-clipboard paste (the paths where no native paste event exists). */

--- a/packages/web/src/lib/clipboard.ts
+++ b/packages/web/src/lib/clipboard.ts
@@ -1,0 +1,50 @@
+/**
+ * Clipboard writes for the whole Web App — the one place that knows the async Clipboard
+ * API is not always there.
+ *
+ * `navigator.clipboard` is secure-context-only: it is `undefined` on a plain-HTTP origin
+ * that is not localhost, which is exactly the shape a non-loopback `HOST` bind serves (a
+ * LAN address, a remote install reached at `http://<host>:7364`). Reaching straight for
+ * it there writes nothing at all, so every copy affordance goes through this fallback
+ * instead.
+ */
+
+/**
+ * Copies `text`, resolving to whether it actually reached the clipboard. Never throws, and
+ * never reports a write it did not make — the callers show their "copied" feedback on this
+ * result.
+ *
+ * The fallback selects a hidden textarea and asks the document to copy it. That command is
+ * only honoured while the browser considers a user gesture in progress, which the
+ * secure-context path preserves: with `navigator.clipboard` absent, reading `.writeText`
+ * off it throws before the first `await` suspends, so the `catch` still runs inside the
+ * click's own task. A rejected write (permission denied on an otherwise fine origin) has
+ * already suspended by then and may find the gesture spent — it reports `false` rather
+ * than a copy that did not happen.
+ */
+export async function writeClipboard(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    const ta = document.createElement("textarea");
+    ta.value = text;
+    // Out of layout (fixed + transparent) rather than off-screen: `select()` scrolls
+    // whatever it selects into view, and a textarea placed below the fold would jump the
+    // page on every copy.
+    ta.setAttribute("readonly", "");
+    ta.style.position = "fixed";
+    ta.style.top = "0";
+    ta.style.left = "0";
+    ta.style.opacity = "0";
+    document.body.appendChild(ta);
+    try {
+      ta.select();
+      return document.execCommand("copy");
+    } catch {
+      return false;
+    } finally {
+      ta.remove();
+    }
+  }
+}

--- a/packages/web/test/clipboard.test.ts
+++ b/packages/web/test/clipboard.test.ts
@@ -1,0 +1,199 @@
+/**
+ * writeClipboard unit tests: the copy path that has to work on the origins this app is
+ * actually served from.
+ *
+ * `navigator.clipboard` is secure-context-only, so it is absent on every plain-HTTP origin
+ * that is not localhost — a LAN bind, a remote install opened at `http://<host>:7364`. The
+ * cases below pin both halves of that: the fallback copies rather than silently doing
+ * nothing, and it reports honestly when even the fallback is refused, because the callers
+ * gate their "copied" check on that answer.
+ *
+ * Two things beyond the return value matter. The fallback's `execCommand` is only honoured
+ * while a user gesture is in progress, so the absent-API path must reach it **without
+ * suspending** — a `writeClipboard(...)` that only got there on a later microtask would
+ * pass a naive assertion and fail in a browser. And the textarea it borrows must leave no
+ * trace in the document whichever way the attempt ends.
+ *
+ * The last test pins the seam against the source text: a copy affordance that reaches for
+ * `navigator.clipboard.writeText` on its own would reintroduce exactly the silent no-op
+ * this module exists to prevent, and nothing in a node-only suite would notice
+ * (context-menu.test.ts convention).
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { writeClipboard } from "../src/lib/clipboard";
+
+interface FakeTextarea {
+  value: string;
+  attributes: Record<string, string>;
+  style: Record<string, string>;
+  selectCount: number;
+  removed: boolean;
+  setAttribute(name: string, value: string): void;
+  select(): void;
+  remove(): void;
+}
+
+interface FakeDocument {
+  areas: FakeTextarea[];
+  appended: FakeTextarea[];
+  execCalls: string[];
+}
+
+/** Installs a `document` whose copy command answers `copy()`, and reports what it saw. */
+function stubDocument(copy: () => boolean): FakeDocument {
+  const state: FakeDocument = { areas: [], appended: [], execCalls: [] };
+  const doc = {
+    createElement(tag: string): FakeTextarea {
+      expect(tag).toBe("textarea");
+      const area: FakeTextarea = {
+        value: "",
+        attributes: {},
+        style: {},
+        selectCount: 0,
+        removed: false,
+        setAttribute(name, value) {
+          area.attributes[name] = value;
+        },
+        select() {
+          area.selectCount += 1;
+        },
+        remove() {
+          area.removed = true;
+        },
+      };
+      state.areas.push(area);
+      return area;
+    },
+    body: {
+      appendChild(area: FakeTextarea) {
+        state.appended.push(area);
+        return area;
+      },
+    },
+    execCommand(command: string): boolean {
+      state.execCalls.push(command);
+      return copy();
+    },
+  };
+  vi.stubGlobal("document", doc);
+  return state;
+}
+
+/** Installs a `navigator` with no `clipboard` — what a non-secure origin serves. */
+function stubInsecureNavigator(): void {
+  vi.stubGlobal("navigator", {});
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("writeClipboard", () => {
+  it("uses the async Clipboard API where it exists, and touches no textarea", async () => {
+    const writeText = vi.fn(async () => {});
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    const doc = stubDocument(() => true);
+
+    await expect(writeClipboard("hello")).resolves.toBe(true);
+    expect(writeText).toHaveBeenCalledWith("hello");
+    expect(doc.areas).toHaveLength(0);
+  });
+
+  it("copies through the fallback when the Clipboard API is absent", async () => {
+    stubInsecureNavigator();
+    const doc = stubDocument(() => true);
+
+    await expect(writeClipboard("reply text")).resolves.toBe(true);
+    expect(doc.execCalls).toEqual(["copy"]);
+    const area = doc.areas[0];
+    expect(area?.value).toBe("reply text");
+    expect(area?.selectCount).toBe(1);
+    expect(doc.appended).toHaveLength(1);
+  });
+
+  it("keeps the fallback's textarea out of layout so selecting it cannot scroll the page", async () => {
+    stubInsecureNavigator();
+    const doc = stubDocument(() => true);
+
+    await writeClipboard("x");
+    const area = doc.areas[0];
+    expect(area?.attributes.readonly).toBe("");
+    expect(area?.style.position).toBe("fixed");
+    expect(area?.style.opacity).toBe("0");
+  });
+
+  it("reaches the fallback without suspending, so the click's gesture is still live", () => {
+    stubInsecureNavigator();
+    const doc = stubDocument(() => true);
+
+    // Deliberately not awaited: the copy command has to have run by the time the call
+    // returns, not on some later turn of the microtask queue.
+    void writeClipboard("x");
+    expect(doc.execCalls).toEqual(["copy"]);
+  });
+
+  it("falls back when the Clipboard API rejects", async () => {
+    vi.stubGlobal("navigator", {
+      clipboard: {
+        writeText: async () => {
+          throw new Error("NotAllowedError");
+        },
+      },
+    });
+    const doc = stubDocument(() => true);
+
+    await expect(writeClipboard("x")).resolves.toBe(true);
+    expect(doc.execCalls).toEqual(["copy"]);
+  });
+
+  it("reports a refused copy rather than one that did not happen", async () => {
+    stubInsecureNavigator();
+    stubDocument(() => false);
+
+    await expect(writeClipboard("x")).resolves.toBe(false);
+  });
+
+  it("reports false and cleans up when the copy command itself throws", async () => {
+    stubInsecureNavigator();
+    const doc = stubDocument(() => {
+      throw new Error("blocked");
+    });
+
+    await expect(writeClipboard("x")).resolves.toBe(false);
+    expect(doc.areas[0]?.removed).toBe(true);
+  });
+
+  it("removes the textarea after a successful copy too", async () => {
+    stubInsecureNavigator();
+    const doc = stubDocument(() => true);
+
+    await writeClipboard("x");
+    expect(doc.areas[0]?.removed).toBe(true);
+  });
+});
+
+const SRC = resolve(dirname(fileURLToPath(import.meta.url)), "../src");
+const CLIPBOARD_MODULE = join(SRC, "lib", "clipboard.ts");
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) return sourceFiles(full);
+    return /\.tsx?$/.test(entry.name) ? [full] : [];
+  });
+}
+
+describe("clipboard writes go through one seam", () => {
+  it("has no other module writing to navigator.clipboard", () => {
+    const offenders = sourceFiles(SRC)
+      .filter((file) => file !== CLIPBOARD_MODULE)
+      .filter((file) =>
+        /navigator\s*\.\s*clipboard[\s\S]{0,40}?writeText/.test(readFileSync(file, "utf8")),
+      )
+      .map((file) => relative(SRC, file));
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What this changes

Every copy control in the Web App — a reply, a user message, a code block, a Session id, an Agent State path, a terminal selection — went through the async Clipboard API alone. Browsers expose that API only in a **secure context**, so on a plain-HTTP origin that is not localhost `navigator.clipboard` is `undefined`, the optional-chained write in `writeClipboard` was a no-op, and because the "copied" state was set unconditionally the button still flashed its check, flipped its tooltip to 已复制 and announced a copy to screen readers. The text went nowhere and the control said it had landed.

That origin shape is not exotic here: `HOST` is a documented knob (`packages/docs/content/configuration.zh.md`), and the machines feature installs this server on another box that is then opened at `http://<host>:7364`. `packages/server/src/hmr/routes.ts` already gates on exactly this condition for the hot APIs. Desktop and local `localhost` are secure contexts, which is why it does not reproduce locally.

The fix is the fallback this repo already ships in two other places — `packages/landing/src/components/copy-button.tsx` and `packages/docs/src/components/copy-markdown-button.tsx` both fall back to a hidden textarea plus `document.execCommand("copy")`; the Web App was the one that did not. It moves to `packages/web/src/lib/clipboard.ts` so the copy controls and the terminal share one seam.

Closes https://github.com/Prism-Shadow/penguin-harness/issues/468

### Two decisions worth a look

**The check now waits for the write.** The current header comment states the opposite as a deliberate choice — "the write is optimistic (an insecure context or denied permission must not leave the control stuck)". This PR reverses it: with the fallback in place the insecure-context case succeeds, and the case that remains — an outright refusal on an origin where the API does exist — is one where a check is simply false. A refused copy leaves the control idle, which reads as "nothing happened" and invites a retry; it is not a stuck state, so the original concern is not reintroduced.

**The absent-API path must not suspend.** `document.execCommand("copy")` is only honoured while a user gesture is in progress. Reading `.writeText` off an undefined `clipboard` throws *before* the first `await` suspends, so the `catch` still runs inside the click's own task — the insecure-context path, the one that needs the gesture, keeps it. A rejected `writeText` (permission denied on an otherwise fine origin) has already suspended and may find the gesture spent; it reports `false` rather than a copy that did not happen. There is a test pinning the non-suspending part, since a version that only got there on a later microtask would pass a naive assertion and fail in a browser.

### Out of scope

Two adjacent gaps found while investigating, both pre-existing and both separate work: a turn that is still streaming has no copy control (`task_stats` is only inserted at task end), and a subagent conversation has none at all (nested sessions produce no `task_stats`, and `assistant_text` deliberately attaches no `MessageMeta`). Terminal *paste* is untouched — it rides the browser's native paste event and needs no clipboard permission.

## Verification

Node 24, in a fresh worktree after `pnpm install --frozen-lockfile` and `pnpm build`:

- `pnpm --filter @prismshadow/penguin-web test` → 112 files, 1541 tests passed (9 of them the new `test/clipboard.test.ts`).
- `pnpm --filter @prismshadow/penguin-web typecheck` → clean.
- `pnpm format:check` → clean. `git diff --check` → clean.

The new suite covers: the secure-context path (no textarea touched), the fallback copying with the API absent, the textarea being fixed-positioned/transparent so `select()` cannot scroll the page, the fallback being reached without suspending, a rejected `writeText` falling back, a refused copy reporting `false`, and the textarea being removed on every path. A last test scans `packages/web/src` and asserts no module other than `lib/clipboard.ts` writes to `navigator.clipboard` — the node-only suite would otherwise never notice a new copy affordance reintroducing the silent no-op.

Not verified in a browser on a real LAN origin; the behaviour rests on the Clipboard API's documented secure-context rule and on the same fallback the landing site has been shipping.

## Checklist

- [x] Changelog entry pair under `changelog/unreleased/` — `2026-08-27-copy-on-plain-http.md` and its `.zh.md` counterpart.
- [x] Docs updated where this changes documented behavior (no documented behavior changes).
- [x] No API key, bot token or other credential in the diff, the logs, or the screenshots.
