### PR TITLE
docs(skills): record what the #528-#534 batch caught in the dev skill

### DIFF
--- a/.agents/skills/penguin-harness-dev/SKILL.md
+++ b/.agents/skills/penguin-harness-dev/SKILL.md
@@ -51,6 +51,12 @@ Run the whole chain in exactly three cases: the change spans the repo widely eno
 
 `ci-windows` runs the same minus `format:check`, plus `scripts/test-installer.ps1`. Two failures there are known and are not your diff: a bare `Failed` worker crash, and an `environment.test.ts` truncation-timing assertion — rerun before debugging. An `EBUSY` on removing a directory that is some child process's cwd is real, not a flake.
 
+**A fake that is kinder than the real thing hides the bug it was written for.** Transports are faked at a seam here — `createSocket`, `createClient`, a stubbed `globalThis.fetch` — and the half that drifts is the failure contract, not the happy path. A fake that hands back a fresh cursor where the adapter returns the one it was given, or that resolves where production parks, passes a test whose subject is exactly that path. Write the fake's failure branches from the adapter's, not from what the assertions need.
+
+**A structural assertion that was already true at the base commit is not a test.** Reading source text in a test is house style here (20 web test files do it), which makes it easy to assert a shape the file already had. Replay each new assertion against `git show <base>:<path>` and keep the ones that fail there.
+
+The local server suite drops a few tests under full parallel load — they time out and pass on their own. Rerun the file alone before blaming the diff.
+
 Once the evidence you chose passes, commit and push to the current branch without asking. Force-pushes and reverting someone else's commits still need confirmation.
 
 ## Record and ship
@@ -61,6 +67,7 @@ Every change ships a changelog entry, in both languages, in `changelog/unrelease
 - H1, then the metadata block in fixed order — `Date` / `Type` / `Scope` / `PR` / `Issue` / `Breaking` — then the counterpart link, then a lead paragraph and bespoke sections. Field names and values stay English in both files so one `grep` covers the tree.
 - Omit an inapplicable field entirely. Placeholders are what stop `grep -rl 'Breaking:' changelog/` from being an exact query.
 - `Breaking` present ⇒ a `## Compatibility` / `## 兼容性` section stating what breaks and the migration step.
+- Section headings are translated, not carried across: `## Details` → `## 细节`, `## Compatibility` → `## 兼容性`, bespoke ones naturally, in the same order and count. An English heading in the `.zh.md` is the most common way the pair stops mirroring.
 
 `changelog/README.md` is the full spec. Read it rather than pattern-matching a neighbouring entry.
 
@@ -70,7 +77,7 @@ Every change ships a changelog entry, in both languages, in `changelog/unrelease
 
 **Numbers are links, and half of them are issues.** A bare `#N` does not render as a link in Markdown. Worse, this repository's bug reports and its PRs share one numbering space: `#83`, `#85`, `#102`, `#136`–`#140`, `#150`, `#170`, `#215`, `#218`, `#229`, `#239` are issues. Classify before writing — `gh api repos/Prism-Shadow/penguin-harness/issues/N --jq 'if .pull_request then "PR" else "ISSUE" end'` — and route them to `Issue`, not `PR`. A cross-repo reference names its repo: `agenthub [#162](https://github.com/Prism-Shadow/agenthub/pull/162)`.
 
-The PR number exists only once the PR is open: open it, then add the links in a follow-up commit on the same branch.
+The PR number exists only once the PR is open: open it, then add the links in a follow-up commit on the same branch. `PR` is the field that actually gets forgotten — `grep -L 'PR:' changelog/unreleased/*.md` before asking for review.
 
 An entry ships **inside the PR that makes the change** — there is no separate aggregate PR. Released version folders are frozen. `RELEASE.md` is written at release preparation and must be committed **before** the tag — the workflow reads it from the tag's own checkout.
 
@@ -95,6 +102,7 @@ Release screenshots are captured, not mocked up: drive the app through the Playw
 - A provider group is split only when the vendor genuinely has separate endpoints or billing paths (Qwen Token Plan vs Pay-As-You-Go). One endpoint serving several key types is one group.
 - `resolveModelEnv` mirrors AgentHub's exact routing; a lookalike id must stay unroutable.
 - Adding a model touches the catalog test's exact-order assertions, `packages/web/src/features/models/protocol-path.ts` when the client's request path is not `/chat/completions`, the provider glyph map, and the bilingual `models` / `configuration` docs.
+- **Moving the default reaches further than adding a model.** `defaultProjectConfig()` in `packages/core/src/state/project-config.ts` holds it, and six documented first-run commands pin it by hand — `README.md`, `README.zh.md`, and `quickstart-cli` / `quickstart-sdk` in both languages — each ending `--set-default`, which writes `default_model`. Leave them on the old id and the documented first run silently undoes the change on every fresh install. The `models` and `configuration` samples carry it in two places that must move together, the `default_model` line and the `[[models]]` row it names (a default naming no entry is rejected on load), and `packages/skills/skills/penguin-sdk/SKILL.md` states it in prose.
 
 Existing Projects never migrate automatically: presets are copied into `.project_config.toml` at creation and nothing rewrites them. Users pick changes up through the models page's explicit "sync presets", which appends and updates catalog-owned fields but never deletes and never touches the stored default. Say so in the entry.
 

--- a/changelog/unreleased/2026-08-28-dev-skill-review-notes.md
+++ b/changelog/unreleased/2026-08-28-dev-skill-review-notes.md
@@ -1,0 +1,26 @@
+# The dev skill records the traps a six-PR batch walked into
+
+- **Date:** 2026-08-28
+- **Type:** process
+- **Scope:** `skills`
+
+[中文版](2026-08-28-dev-skill-review-notes.zh.md)
+
+`.agents/skills/penguin-harness-dev/SKILL.md` gained four notes, each written from a defect that
+reached review in the batch that shipped
+[#528](https://github.com/Prism-Shadow/penguin-harness/pull/528)–[#534](https://github.com/Prism-Shadow/penguin-harness/pull/534).
+
+## Details
+
+- Moving the default model is called out as reaching further than adding one: six documented
+  first-run commands pin it by hand with `--set-default`, so leaving them on the old id undoes
+  the change on every fresh install, and the `models` / `configuration` samples carry it in two
+  places that have to move together.
+- The changelog contract names the two fields that are actually missed — `PR`, with the `grep`
+  that finds an entry without one, and the translated section headings, an English heading in a
+  `.zh.md` being the common way a pair stops mirroring.
+- The verification section warns that a fake written from the happy path hides the bug it was
+  meant to catch, since what drifts from the real adapter is the failure contract.
+- It also warns that a structural assertion true at the base commit is not a test, with the
+  replay that tells them apart, and records that the local server suite drops a few tests under
+  full parallel load and passes them alone.

--- a/changelog/unreleased/2026-08-28-dev-skill-review-notes.zh.md
+++ b/changelog/unreleased/2026-08-28-dev-skill-review-notes.zh.md
@@ -1,0 +1,23 @@
+# 开发 Skill 记下一批 PR 踩过的坑
+
+- **Date:** 2026-08-28
+- **Type:** process
+- **Scope:** `skills`
+
+[English](2026-08-28-dev-skill-review-notes.md)
+
+`.agents/skills/penguin-harness-dev/SKILL.md`新增四条说明，每一条都来自
+[#528](https://github.com/Prism-Shadow/penguin-harness/pull/528)–[#534](https://github.com/Prism-Shadow/penguin-harness/pull/534)
+这一批中被 review 拦下的缺陷。
+
+## 细节
+
+- 点明「改默认模型」比「加一个模型」波及更广：六处首次运行命令用 `--set-default` 手写了它，
+  旧 id 留在那里就会在每个全新安装上把改动撤销；`models` 与 `configuration` 的示例又在两处
+  携带它，必须一起改。
+- changelog 契约点名两个真正会被遗漏的字段——`PR`，并给出找出缺失条目的 `grep`；以及需要翻译的
+  小节标题，`.zh.md` 里留着英文标题正是中英不再逐节对应的常见方式。
+- 验证一节提醒：只照着正常路径写的 fake 会掩盖它本该抓住的缺陷，因为与真实适配器产生偏差的正是
+  失败契约。
+- 同一节还提醒：在基线提交上就已成立的结构性断言不是测试，并给出区分二者的回放方法；另记下服务端
+  测试套件在完全并行下会掉几个用例、单独跑则通过。


### PR DESCRIPTION
Four notes in `.agents/skills/penguin-harness-dev/SKILL.md`, each written from a defect that reached review in the batch that shipped #528–#534 rather than from a rule that seemed like a good idea.

## What changed

**Changing the built-in model catalog** gains a bullet distinguishing *moving the default* from *adding a model*. `defaultProjectConfig()` holds it, and six documented first-run commands pin it by hand — `README.md`, `README.zh.md`, and `quickstart-cli` / `quickstart-sdk` in both languages — each ending `--set-default`, which writes `default_model`. #534 changed the default and left all six naming the old id, so the documented first run undid the change on every fresh install. The bullet also names the second half people miss: the `models` and `configuration` samples carry the id in the `default_model` line *and* in the `[[models]]` row it must name, and a sample whose default names no entry is rejected on load.

**Record and ship** gains the two fields that are actually missed. `PR` was absent from three of the six entries in that batch, so the existing sentence about adding it in a follow-up commit now ends with the `grep -L 'PR:' changelog/unreleased/*.md` that finds one. And a new bullet says section headings are translated rather than carried across — #529 shipped `## Details` and `## Compatibility` verbatim in its `.zh.md`, which is the common way a pair stops mirroring.

**Verify what you changed** gains two traps and one flake.

- A fake written from the happy path hides the bug it was written for. #533's WeChat drain returned an *advancing* cursor on an empty poll where the real adapter returns the one it was given, so the test whose subject was exactly that path passed while a week of backlog would have been relayed as live traffic. What drifts from the adapter is the failure contract.
- A structural assertion true at the base commit is not a test. Source-reading tests are house style here, and both #529's `<ConfirmModal` presence check and #532's `toastSuccess` check were already true before their features existed. Replaying each new assertion against `git show <base>:<path>` separates them.
- The local server suite drops a few tests under full parallel load and passes them alone — worth one line so the next person does not bisect their own diff.

## Verification

`pnpm format` + `pnpm format:check` clean, `git diff --check` clean. Markdown only, which is the whole of what the skill's own table asks for on a `.agents/` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkRWxw1GMWn7tPKbUQWmqM