### PR TITLE
fix(tooling): a test run takes half the machine, not all of it

### DIFF
--- a/changelog/unreleased/2026-08-28-vitest-concurrency.md
+++ b/changelog/unreleased/2026-08-28-vitest-concurrency.md
@@ -1,0 +1,20 @@
+# A test run takes half the machine, not all of it
+
+- **Date:** 2026-08-28
+- **Type:** fix
+- **Scope:** `tooling`
+
+[中文版](2026-08-28-vitest-concurrency.zh.md)
+
+`pnpm test` could open up to 28 heavy Node processes on an 8-core host, and did: two concurrency limits multiplied. `pnpm -r` runs the workspace's packages four at a time by default, and each package's vitest then sized its own pool from the CPU count — vitest's default is `cores - 1`. The forks are not small either. The server suite runs with `isolate: false`, so each of its forks holds the whole app graph — server, core, SQLite — resident for as long as it lives.
+
+The result is a test run that competes with everything else on the host for the last of the memory. On a developer's own machine that is their PenguinHarness server; on a shared one it is somebody else's work. Either way the kernel picks the loser, and it is not the test run.
+
+Both axes are bounded now, because bounding one is not enough — they multiply:
+
+- Packages run **one at a time** (`--workspace-concurrency=1` on the root `test` script).
+- Each pool takes **half the available cores**, never fewer than one (`vitest.shared.ts`, spread into every package's vitest config).
+
+`availableParallelism()` rather than the raw CPU count: inside a container it reports the share this process may actually use, which is the number the bound is about. `VITEST_MAX_FORKS` overrides it for a machine that is genuinely idle — a CI runner, or a laptop with nothing else on it — where using everything there is is the point.
+
+Running one package's tests directly (`pnpm --filter … test`) is unchanged apart from the pool bound.

--- a/changelog/unreleased/2026-08-28-vitest-concurrency.zh.md
+++ b/changelog/unreleased/2026-08-28-vitest-concurrency.zh.md
@@ -1,0 +1,20 @@
+# 一次测试只占半台机器，而不是整台
+
+- **Date:** 2026-08-28
+- **Type:** fix
+- **Scope:** `tooling`
+
+[English](2026-08-28-vitest-concurrency.md)
+
+在一台 8 核主机上，`pnpm test` 最多能开出 28 个重量级 Node 进程——而且确实开了：两个并发上限相乘。`pnpm -r` 默认同时跑 4 个包，而每个包的 vitest 又按 CPU 数决定自己的进程池大小（vitest 的默认值是 `核数 - 1`）。这些 fork 还都不小：server 那套测试以 `isolate: false` 运行，因此它的每一个 fork 在整个生命周期内都常驻着完整的应用模块图——server、core、SQLite。
+
+结果就是一次测试运行会和主机上其他一切争抢最后那点内存。在开发者自己的机器上，被抢的是他自己的 PenguinHarness 服务端；在共享主机上，被抢的是别人的工作。无论哪种，内核挑出来杀掉的都不会是测试进程。
+
+现在两个维度都设了上限——只限制其中一个不够，因为它们是相乘的：
+
+- 包**一次只跑一个**（根 `test` 脚本上的 `--workspace-concurrency=1`）。
+- 每个进程池最多取**可用核数的一半**，且不少于 1（`vitest.shared.ts`，展开进每个包的 vitest 配置）。
+
+用 `availableParallelism()` 而非裸 CPU 数：在容器里它报告的是本进程真正可以使用的份额，而那正是这个上限所关心的数字。机器确实闲置时——CI runner，或者一台没跑别的东西的笔记本——可用 `VITEST_MAX_FORKS` 覆盖，那种场合的要点本来就是把资源用满。
+
+直接跑单个包的测试（`pnpm --filter … test`）除了进程池上限之外没有变化。

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "typecheck": "pnpm -r typecheck",
-    "test": "pnpm -r test",
+    "test": "pnpm -r --workspace-concurrency=1 test",
     "test:e2e": "pnpm --filter @prismshadow/penguin-core test:e2e",
     "build": "pnpm -r build && pnpm link:cli",
     "link:cli": "pnpm --dir packages/cli link --global || echo '[link:cli] pnpm global directory not configured; skipping the global penguin link (run pnpm setup once first)'",

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -31,9 +31,11 @@
  * keeps 0 so a flake introduced there is seen the first time.
  */
 import { defineConfig } from "vitest/config";
+import { boundedPool } from "../../vitest.shared.js";
 
 export default defineConfig({
   test: {
+    ...boundedPool,
     environment: "node",
     testTimeout: process.platform === "win32" ? 120_000 : 5_000,
     retry: process.platform === "win32" ? 2 : process.platform === "darwin" ? 1 : 0,

--- a/packages/docs/vitest.config.ts
+++ b/packages/docs/vitest.config.ts
@@ -5,6 +5,7 @@
  * environment with no plugins suffices.
  */
 import { defineConfig } from "vitest/config";
+import { boundedPool } from "../../vitest.shared.js";
 
 export default defineConfig({
   test: { environment: "node" },

--- a/packages/landing/vitest.config.ts
+++ b/packages/landing/vitest.config.ts
@@ -4,6 +4,7 @@
  * Tests cover pure modules only, so no plugins and a node environment suffice.
  */
 import { defineConfig } from "vitest/config";
+import { boundedPool } from "../../vitest.shared.js";
 
 export default defineConfig({
   test: { environment: "node" },

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -38,9 +38,11 @@
  * would otherwise stay installed for every later file in the same worker.
  */
 import { defineConfig } from "vitest/config";
+import { boundedPool } from "../../vitest.shared.js";
 
 export default defineConfig({
   test: {
+    ...boundedPool,
     environment: "node",
     isolate: false,
     restoreMocks: true,

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -4,9 +4,11 @@
  * plugin types, and tests don't need the plugin anyway.
  */
 import { defineConfig } from "vitest/config";
+import { boundedPool } from "../../vitest.shared.js";
 
 export default defineConfig({
   test: {
+    ...boundedPool,
     environment: "node",
     // Only run unit tests under test/; e2e/ (Playwright, has its own test:e2e) is excluded from vitest.
     include: ["test/**/*.test.ts"],

--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -1,0 +1,40 @@
+/**
+ * How much of the machine a test run is allowed to take.
+ *
+ * Two multipliers used to compound. `pnpm -r test` runs the workspace's packages
+ * concurrently (pnpm's default is 4 at a time), and each package's vitest then opens a pool
+ * of its own sized from the CPU count (vitest's default is `cores - 1`). On an 8-core host
+ * that is up to 28 forks, and they are not small: the server suite runs with `isolate:
+ * false`, so every fork holds the whole app graph — server, core, SQLite — resident for as
+ * long as it lives. A developer's own PenguinHarness server, or anyone else's work on a
+ * shared host, is then competing with a test run for the last of the memory, and the kernel
+ * picks the loser.
+ *
+ * So the run takes half the machine and leaves the other half alone. The package axis is
+ * pinned to one at a time in the root `test` script, and this is the other axis: half the
+ * available cores, never fewer than one. Bounding only one of the two is not enough — they
+ * multiply.
+ *
+ * `VITEST_MAX_FORKS` overrides it for a machine that is genuinely idle (a CI runner, a
+ * laptop with nothing else on it), where the whole point is to use everything there is.
+ */
+import os from "node:os";
+
+/** The pool bound, resolved once per config load. */
+export function maxForks(): number {
+  const override = Number(process.env.VITEST_MAX_FORKS);
+  if (Number.isInteger(override) && override > 0) return override;
+  // `availableParallelism` and not `cpus().length`: inside a container it reports the share
+  // this process may actually use, which is the number the bound is about.
+  return Math.max(1, Math.floor(os.availableParallelism() / 2));
+}
+
+/**
+ * The pool settings every package's vitest config spreads in. `forks` rather than threads is
+ * each config's own decision (the server suite needs a per-process `process.env`); this only
+ * says how many of whatever pool it chose may exist at once.
+ */
+export const boundedPool = {
+  maxWorkers: maxForks(),
+  poolOptions: { forks: { maxForks: maxForks() }, threads: { maxThreads: maxForks() } },
+} as const;


### PR DESCRIPTION
Draft: raised after a `pnpm test` run on a shared 8-core host starved the PenguinHarness server running on it.

## What multiplied

`pnpm -r` runs the workspace's packages **four at a time** by default, and each package's vitest then sized **its own** pool from the CPU count — vitest's default is `cores - 1`. On an 8-core host that is `4 × 7 = 28` forks, and they are not small: the server suite runs with `isolate: false` precisely so a fork keeps the whole app graph — server, core, SQLite — resident for as long as it lives.

Nothing in either default is wrong on its own. The product of the two is.

## The bound

Both axes, because bounding one leaves the other free to multiply:

| Axis | Before | After |
| --- | --- | --- |
| Packages at once (`pnpm -r`) | 4 | 1 |
| Forks per pool (vitest) | `cores - 1` | `⌊available / 2⌋`, min 1 |

`vitest.shared.ts` at the repo root holds the second one and every package's config spreads it in, so the ceiling is one number in one place rather than five that have to agree. It reads `availableParallelism()` rather than the raw CPU count — inside a container that is the share this process may actually use — and `VITEST_MAX_FORKS` lifts it for a host that is genuinely idle, which is what a CI runner is.

Running one package directly (`pnpm --filter … test`) is unchanged apart from the pool bound.

## Cost

Wall clock. `pnpm test` is now serial across the eight packages where it was four-wide, and each package uses half the cores it did. That is the trade the title states: a test run that finishes later and leaves the host usable, instead of one that finishes sooner and takes something else down with it.

If that is the wrong trade for CI, the lever is already there — set `VITEST_MAX_FORKS` and drop `--workspace-concurrency=1` in the workflow rather than in the default.

## Verification

Deliberately narrow, since running the whole suite is the thing this is about: `pnpm --filter @prismshadow/penguin-docs test` (53) and `packages/server test/machines.test.ts` (29) to prove the shared config loads in both a plain and a heavily-customised config, plus `format:check`. The bound resolves to 4 on this 8-core host.
