### PR TITLE
fix(ci): desktop ships the Web App

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,7 +272,13 @@ jobs:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup
         with:
-          build: "@prismshadow/penguin-desktop..."
+          # The web package is not a dependency of the desktop package (the app carries its
+          # build by an electron-builder file mapping, not an import), so `desktop...` alone
+          # leaves it unbuilt — and the mapping then silently packs nothing.
+          build: "@prismshadow/penguin-desktop...,@prismshadow/penguin-web"
+
+      - name: Preflight the packed tree's inputs
+        run: node packages/desktop/scripts/preflight.mjs
 
       - name: Build unpacked runtime
         env:

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -271,6 +271,11 @@ jobs:
 
           "EVSIGN_CLIENT=$client" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
+      # The same check the local pack scripts run: electron-builder skips an absent
+      # `from:` source in silence, and a tree without the web build is a 404 app.
+      - name: Preflight the packed tree's inputs
+        run: node packages/desktop/scripts/preflight.mjs
+
       - name: Build packages
         env:
           EVSIGN_REQUIRE: ${{ runner.os == 'Windows' && inputs.require_windows_signing && 'true' || 'false' }}

--- a/changelog/unreleased/2026-08-30-ci-runtime-web-dist.md
+++ b/changelog/unreleased/2026-08-30-ci-runtime-web-dist.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-30
 - **Type:** fix
 - **Scope:** `ci`, `desktop`, `tooling`
+- **PR:** [#545](https://github.com/Prism-Shadow/penguin-harness/pull/545)
 
 [中文版](2026-08-30-ci-runtime-web-dist.zh.md)
 

--- a/changelog/unreleased/2026-08-30-ci-runtime-web-dist.md
+++ b/changelog/unreleased/2026-08-30-ci-runtime-web-dist.md
@@ -1,0 +1,15 @@
+# The unpacked runtime artifact carries the Web App, and packing without it fails
+
+- **Date:** 2026-08-30
+- **Type:** fix
+- **Scope:** `ci`, `desktop`, `tooling`
+
+[中文版](2026-08-30-ci-runtime-web-dist.zh.md)
+
+CI's `penguin-runtime-*` artifact — the unpacked desktop tree built for hot-update use — shipped without `web-dist` since the job was introduced: its build filter named the desktop package and its dependencies, the web package is not one of them (the app carries the web build by an electron-builder file mapping, not an import), and electron-builder skips an absent `from:` source in silence. A machine running that tree answered 404 on every page unless its data root held a hot-pushed web version to restore. GitHub Release installers build the whole workspace first and were never affected.
+
+## Details
+
+- The `runtime` job builds `@prismshadow/penguin-web` alongside the desktop package.
+- The desktop `pack*` scripts, the `runtime` job and the release matrix run `scripts/preflight.mjs` before electron-builder, so packing without a web build fails with the fix named.
+- `verify-packed-cli.mjs`, CI's check of the packed tree, also requires `web-dist/index.html`.

--- a/changelog/unreleased/2026-08-30-ci-runtime-web-dist.zh.md
+++ b/changelog/unreleased/2026-08-30-ci-runtime-web-dist.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-30
 - **Type:** fix
 - **Scope:** `ci`, `desktop`, `tooling`
+- **PR:** [#545](https://github.com/Prism-Shadow/penguin-harness/pull/545)
 
 [English](2026-08-30-ci-runtime-web-dist.md)
 

--- a/changelog/unreleased/2026-08-30-ci-runtime-web-dist.zh.md
+++ b/changelog/unreleased/2026-08-30-ci-runtime-web-dist.zh.md
@@ -1,0 +1,15 @@
+# 未打包的 runtime artifact 带上 Web App,缺少它时打包直接失败
+
+- **Date:** 2026-08-30
+- **Type:** fix
+- **Scope:** `ci`, `desktop`, `tooling`
+
+[English](2026-08-30-ci-runtime-web-dist.md)
+
+CI 的 `penguin-runtime-*` artifact——为热更新用途构建的未打包桌面树——自该 job 引入起就没有 `web-dist`:它的构建 filter 只包含 desktop 包及其依赖,而 web 包不在其中(应用是靠 electron-builder 的文件映射带上 web 构建的,不是 import),electron-builder 又会静默跳过不存在的 `from:` 源。跑这份树的机器,除非数据根里有可还原的热推 web 版本,否则每个页面都答 404。GitHub Release 安装包先构建整个 workspace,从未受影响。
+
+## 细节
+
+- `runtime` job 在构建 desktop 包的同时构建 `@prismshadow/penguin-web`。
+- 桌面的 `pack*` 脚本、`runtime` job 和发布矩阵都在 electron-builder 之前运行 `scripts/preflight.mjs`,没有 web 构建就打包会直接失败并给出修法。
+- CI 检查打包树的 `verify-packed-cli.mjs` 同样要求 `web-dist/index.html`。

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -29,8 +29,10 @@ directories:
 # Everything the app runs, and nothing else. The two mapped entries are the assets the
 # bundled server looks up relative to its own location: `skills/` is written next to dist/
 # by scripts/build-assets.mjs (a source run needs it there too), while web-dist comes
-# straight from the web package — no build order between the two packages guarantees it
-# exists before this one builds, but it always does by the time anything is packed.
+# straight from the web package. No build order between the two packages guarantees it
+# exists before this one builds, and electron-builder skips an absent `from:` source in
+# silence, so the pack scripts run scripts/preflight.mjs first and verify-packed-cli.mjs
+# checks the packed tree for it.
 files:
   - dist/**/*
   - "!dist/**/*.map"

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -10,10 +10,10 @@
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "test": "vitest run --passWithNoTests",
     "start": "node scripts/preflight.mjs && electron .",
-    "pack": "electron-builder",
-    "pack:linux": "electron-builder --linux",
-    "pack:mac": "electron-builder --mac",
-    "pack:win": "electron-builder --win"
+    "pack": "node scripts/preflight.mjs && electron-builder",
+    "pack:linux": "node scripts/preflight.mjs && electron-builder --linux",
+    "pack:mac": "node scripts/preflight.mjs && electron-builder --mac",
+    "pack:win": "node scripts/preflight.mjs && electron-builder --win"
   },
   "devDependencies": {
     "@prismshadow/penguin-cli": "workspace:*",

--- a/packages/desktop/scripts/preflight.mjs
+++ b/packages/desktop/scripts/preflight.mjs
@@ -1,8 +1,10 @@
 /**
- * Dev preflight for `pnpm --dir packages/desktop start` (and the root `pnpm desktop`):
- * verify everything a source run needs, and fail with the actual fix instead of a bare
- * ENOENT from the utilityProcess fork or an empty skill library. A source run loads the
- * same bundles a packaged app does, so all of them have to exist first.
+ * Preflight for `pnpm --dir packages/desktop start` (and the root `pnpm desktop`) and for
+ * every `pack*` script: verify everything a source run needs, and fail with the actual fix
+ * instead of a bare ENOENT from the utilityProcess fork or an empty skill library. A source
+ * run loads the same bundles a packaged app does, so all of them have to exist first — and
+ * a pack needs the same set, because electron-builder copies what exists and says nothing
+ * about a `from:` source that does not (the web build above all).
  */
 import { createRequire } from "node:module";
 import fs from "node:fs";

--- a/packages/desktop/scripts/verify-packed-cli.mjs
+++ b/packages/desktop/scripts/verify-packed-cli.mjs
@@ -67,7 +67,11 @@ if (dirs.length === 0) {
 }
 
 for (const app of dirs) {
-  for (const rel of ["bin/penguin", "bin/penguin.cmd", "dist/penguin.js"]) {
+  // The Web App travels by a `from: ../web/dist` mapping that electron-builder skips
+  // WITHOUT complaint when the source is absent — a pack run before the web build shipped
+  // an app whose every page was a 404. The shell now refuses to start such a build
+  // (src/web-dist.ts); this catches it before anything is uploaded.
+  for (const rel of ["bin/penguin", "bin/penguin.cmd", "dist/penguin.js", "web-dist/index.html"]) {
     const file = path.join(app, ...rel.split("/"));
     if (!fs.existsSync(file)) {
       problems.push(`${app}: ${rel} is missing from the packed app.`);


### PR DESCRIPTION
Split out of #544 so it lands on `main` independently of the machines stack.

## What was wrong

CI's `runtime` job (the unpacked `penguin-runtime-*` tree meant for hot-update use, introduced in #298) has shipped without `web-dist` since it was introduced. The job's build filter is `@prismshadow/penguin-desktop...` — desktop and its dependencies — and `penguin-web` is not a dependency: the app carries the web build via an electron-builder `from: ../web/dist → web-dist` file mapping, and electron-builder skips an absent `from:` source without a word.

A machine running that tree answers 404 on every page — unless its data root has a hot-pushed web version, which `HmrHost.restore()` serves from memory in preference to the disk dist. That is why nobody noticed: every machine it was used on had been pushed to. It surfaced the first time one ran on a fresh data root.

GitHub Release installers go through `desktop-build.yml`, which runs `pnpm -r build` first; I checked v0.2.9's mac zip and `Resources/app/web-dist/` is there (55 files). Releases were never affected.

## Fix

- `ci.yml` `runtime`: build `@prismshadow/penguin-web` too, and run `preflight.mjs` (which already requires `../web/dist/index.html`) before electron-builder.
- `packages/desktop/package.json` `pack*` scripts and `desktop-build.yml`: same preflight before electron-builder, so every packing path has the same guard.
- `verify-packed-cli.mjs`: the packed-tree check also requires `web-dist/index.html`, so a regression turns the job red instead of uploading.

Runtime-side diagnostics for the same condition (the shell pinning and checking its web-dist, the server naming its dist at startup, hmr restore refusing a web version without `index.html`) stay in #544 with the `--dev` work that found this.

## Verification

- `pnpm format:check`, `git diff --check` — clean.
- `node packages/desktop/scripts/preflight.mjs` passes in a built checkout.
- The `runtime (windows-latest)` job on this PR is the real test: it must now produce a tree with `web-dist/index.html`, and `verify-packed-cli.mjs` fails otherwise.
