### PR TITLE
fix(skills): a hot-pushed bundle finds the skill library through the installation that loaded it

### DIFF
--- a/changelog/unreleased/2026-08-30-pushed-skills-root.md
+++ b/changelog/unreleased/2026-08-30-pushed-skills-root.md
@@ -1,0 +1,14 @@
+# A hot-pushed bundle finds the skill library through the installation that loaded it
+
+- **Date:** 2026-08-30
+- **Type:** fix
+- **Scope:** `skills`
+
+[中文版](2026-08-30-pushed-skills-root.zh.md)
+
+The skill library was located one directory above the module reading it — the package's own `skills/`, and equally the desktop app's `<app>/skills` beside `<app>/dist`. A hot-pushed bundle runs out of `<root>/hmr/store/<kind>/` and carries no library beside it, so the lookup named a `store/skills` that never exists, and a pushed version booting a **fresh** data root died on its first skill scan (`ENOENT … store/skills`) while a root whose default Project already existed never noticed. Every remote install from the Machines page is such a fresh root.
+
+## Details
+
+- The library root is now resolved once, on first use, from the first of these that exists: `PENGUIN_SKILLS_DIR`; the package's own `../skills`; and, relative to the process entry (`process.argv[1]`), the installation's shipped copy — `<program>/lib/node_modules/@prismshadow/penguin-skills/skills` for an installed program, `<app>/skills` for the desktop app. When none exists the package layout is used as before.
+- `resolveSkillsRoot` is exported and unit-tested for each layout.

--- a/changelog/unreleased/2026-08-30-pushed-skills-root.md
+++ b/changelog/unreleased/2026-08-30-pushed-skills-root.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-30
 - **Type:** fix
 - **Scope:** `skills`
+- **PR:** [#548](https://github.com/Prism-Shadow/penguin-harness/pull/548)
 
 [中文版](2026-08-30-pushed-skills-root.zh.md)
 

--- a/changelog/unreleased/2026-08-30-pushed-skills-root.zh.md
+++ b/changelog/unreleased/2026-08-30-pushed-skills-root.zh.md
@@ -1,0 +1,14 @@
+# 热推的 bundle 通过加载它的安装找到技能库
+
+- **Date:** 2026-08-30
+- **Type:** fix
+- **Scope:** `skills`
+
+[English](2026-08-30-pushed-skills-root.md)
+
+技能库原先按"读它的模块所在目录的上一级"定位——即包自身的 `skills/`,桌面应用里也是 `<app>/dist` 旁边的 `<app>/skills`。热推的 bundle 运行在 `<root>/hmr/store/<kind>/` 里,旁边没有库,于是查找指向一个永远不存在的 `store/skills`;推送版本在**全新**数据根上首次启动时,第一次扫描技能就崩溃(`ENOENT … store/skills`),而默认 Project 早已存在的根则毫无察觉。Machines 页面的每一次远程安装都是这样的全新根。
+
+## 细节
+
+- 库根目录现在在首次使用时解析一次,取以下第一个存在的:`PENGUIN_SKILLS_DIR`;包自身的 `../skills`;以及相对进程入口(`process.argv[1]`)的安装自带副本——已安装程序为 `<program>/lib/node_modules/@prismshadow/penguin-skills/skills`,桌面应用为 `<app>/skills`。都不存在时沿用包布局。
+- `resolveSkillsRoot` 导出并对每种布局做了单元测试。

--- a/changelog/unreleased/2026-08-30-pushed-skills-root.zh.md
+++ b/changelog/unreleased/2026-08-30-pushed-skills-root.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-30
 - **Type:** fix
 - **Scope:** `skills`
+- **PR:** [#548](https://github.com/Prism-Shadow/penguin-harness/pull/548)
 
 [English](2026-08-30-pushed-skills-root.md)
 

--- a/packages/skills/src/index.ts
+++ b/packages/skills/src/index.ts
@@ -99,8 +99,62 @@ export function parseSkillFrontmatter(content: string): SkillMetadata | null {
   };
 }
 
-/** Root directory of library files: the package's `skills/` (both dist/ and src/ sit one level below the package root, so one level up reaches it). */
-const SKILLS_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "skills");
+/**
+ * Where the library's files are, tried in order and the first that exists taken:
+ *
+ * 1. `PENGUIN_SKILLS_DIR` — an explicit location.
+ * 2. `<this file>/../skills` — the package's own `skills/` (dist/ and src/ both sit one level
+ *    below the package root), and equally the desktop app, whose bundle is `<app>/dist/…`
+ *    beside a `<app>/skills` copy.
+ * 3. Relative to the process entry (`process.argv[1]`): a hot-pushed bundle runs out of
+ *    `<root>/hmr/store/<kind>/` and carries no library beside it, so candidate 2 names a
+ *    `store/skills` that never exists — but the entry that loaded it names the installation.
+ *    `<program>/lib/dist/penguin-hmr.js` puts the shipped copy at
+ *    `<program>/lib/node_modules/@prismshadow/penguin-skills/skills`; a desktop app's
+ *    `<app>/dist/server.js` puts it at `<app>/skills`.
+ *
+ * Without 3, a pushed version booting a FRESH data root — a remote install from the Machines
+ * page, above all — died on its first skill scan with `ENOENT … store/skills`, while a root
+ * whose default Project already existed never noticed. Resolved once, on first use.
+ */
+export function resolveSkillsRoot(opts: {
+  env: NodeJS.ProcessEnv;
+  here: string;
+  entry: string | undefined;
+  exists: (dir: string) => boolean;
+}): string {
+  const explicit = opts.env.PENGUIN_SKILLS_DIR?.trim();
+  const packaged = path.resolve(opts.here, "..", "skills");
+  const candidates = [
+    ...(explicit ? [explicit] : []),
+    packaged,
+    ...(opts.entry
+      ? [
+          path.resolve(
+            path.dirname(opts.entry),
+            "..",
+            "node_modules",
+            "@prismshadow",
+            "penguin-skills",
+            "skills",
+          ),
+          path.resolve(path.dirname(opts.entry), "..", "skills"),
+        ]
+      : []),
+  ];
+  return candidates.find((dir) => opts.exists(dir)) ?? packaged;
+}
+
+let skillsRoot: string | null = null;
+function SKILLS_ROOT_DIR(): string {
+  skillsRoot ??= resolveSkillsRoot({
+    env: process.env,
+    here: path.dirname(fileURLToPath(import.meta.url)),
+    entry: process.argv[1],
+    exists: (dir) => fs.existsSync(dir),
+  });
+  return skillsRoot;
+}
 
 /** Character rule for Skill names (directory names): prevents path traversal (exported for the server's archive-install validation). */
 export const SKILL_NAME_PATTERN = /^[A-Za-z0-9_-]+$/;
@@ -139,7 +193,7 @@ function readSkillFiles(dir: string): Record<string, string> | undefined {
  * SKILL.md links to) are collected into `files`, omitted when there are none.
  */
 function readSkillDir(name: string): LibrarySkill | undefined {
-  const dir = path.join(SKILLS_ROOT, name);
+  const dir = path.join(SKILLS_ROOT_DIR(), name);
   let content: string;
   try {
     content = fs.readFileSync(path.join(dir, "SKILL.md"), "utf8");
@@ -171,7 +225,7 @@ function readSkillDir(name: string): LibrarySkill | undefined {
 /** Reads all Skills in the library (one per subdirectory under `skills/`), sorted by name. */
 export function loadLibrarySkills(): LibrarySkill[] {
   const skills: LibrarySkill[] = [];
-  for (const entry of fs.readdirSync(SKILLS_ROOT, { withFileTypes: true })) {
+  for (const entry of fs.readdirSync(SKILLS_ROOT_DIR(), { withFileTypes: true })) {
     if (!entry.isDirectory()) continue;
     const skill = readSkillDir(entry.name);
     if (skill) skills.push(skill);

--- a/packages/skills/test/skills.test.ts
+++ b/packages/skills/test/skills.test.ts
@@ -16,6 +16,7 @@ import {
   loadPreinstalledSkills,
   loadSkillGroups,
   parseSkillFrontmatter,
+  resolveSkillsRoot,
   type LibrarySkill,
   type SkillGroupInfo,
 } from "../src/index.js";
@@ -477,5 +478,55 @@ describe("parseSkillFrontmatter", () => {
       version: 1,
       updated: "",
     });
+  });
+});
+
+describe("resolveSkillsRoot", () => {
+  const here = "/root/hmr/store/cli";
+  const shipped = path.resolve("/opt/penguin/lib/node_modules/@prismshadow/penguin-skills/skills");
+
+  it("takes the package's own skills/ when it exists (source, npm, desktop app)", () => {
+    const root = resolveSkillsRoot({
+      env: {},
+      here: "/pkg/dist",
+      entry: "/pkg/dist/server.js",
+      exists: (dir) => dir === path.resolve("/pkg/skills"),
+    });
+    expect(root).toBe(path.resolve("/pkg/skills"));
+  });
+
+  it("a hot-pushed bundle falls through to the installation its entry names", () => {
+    // store/cli/x.mjs has no skills beside it; penguin-hmr.js does, via node_modules.
+    const root = resolveSkillsRoot({
+      env: {},
+      here,
+      entry: "/opt/penguin/lib/dist/penguin-hmr.js",
+      exists: (dir) => dir === shipped,
+    });
+    expect(root).toBe(shipped);
+  });
+
+  it("a pushed bundle inside the desktop app finds <app>/skills through the shell's entry", () => {
+    const root = resolveSkillsRoot({
+      env: {},
+      here,
+      entry: "/app/dist/server.js",
+      exists: (dir) => dir === path.resolve("/app/skills"),
+    });
+    expect(root).toBe(path.resolve("/app/skills"));
+  });
+
+  it("PENGUIN_SKILLS_DIR wins, and nothing existing falls back to the package layout", () => {
+    expect(
+      resolveSkillsRoot({
+        env: { PENGUIN_SKILLS_DIR: "/srv/skills" },
+        here,
+        entry: undefined,
+        exists: () => true,
+      }),
+    ).toBe("/srv/skills");
+    expect(resolveSkillsRoot({ env: {}, here, entry: undefined, exists: () => false })).toBe(
+      path.resolve(here, "..", "skills"),
+    );
   });
 });


### PR DESCRIPTION
On `main`, independent of the machines stack.

## What was wrong

`packages/skills` located its library one directory above its own module (`<here>/../skills`). That is right for the package and for the desktop app (`<app>/dist` → `<app>/skills`), and wrong for a hot-pushed bundle, which runs out of `<root>/hmr/store/<kind>/` — the lookup named `store/skills`, which never exists. A pushed version booting a fresh root died on its first skill scan:

```
ENOENT: no such file or directory, scandir '…/.penguin-dev/data/hmr/store/skills'
```

A root whose default Project already existed never hit the scan, which is why it went unnoticed.

## Fix

`resolveSkillsRoot` tries, in order: `PENGUIN_SKILLS_DIR`; the package's own `../skills`; then, relative to `process.argv[1]`, the installation's shipped copy — `<program>/lib/node_modules/@prismshadow/penguin-skills/skills` for `penguin-hmr.js`, `<app>/skills` for the desktop app's `dist/server.js`. First existing wins; resolved once on first use. Exported and unit-tested per layout (4 new cases).

Platform-layer: the change ships inside the pushed bundle, no runtime involved.

## Verification

- `pnpm --filter @prismshadow/penguin-skills test` — 31 passed; typecheck clean
- `docs` `skills-sync.test.ts` — 3 passed (library table unchanged)
- Live: the dev-profile server on a fresh `~/.penguin-dev/data` started and served after this change, where it had crashed before.

