### PR TITLE
fix(server,web): the Session list learns of Sessions it did not make, on this server and on machines

### DIFF
--- a/changelog/unreleased/2026-08-30-sessions-list-live.md
+++ b/changelog/unreleased/2026-08-30-sessions-list-live.md
@@ -1,0 +1,15 @@
+# The Session list learns of Sessions it did not make, on this server and on machines
+
+- **Date:** 2026-08-30
+- **Type:** fix
+- **Scope:** `server`, `web`
+
+[中文版](2026-08-30-sessions-list-live.zh.md)
+
+A Session started by the CLI (or by another tab, a schedule, an agent spawning a child) did not appear in the list until the page was reloaded, and a Session running on a machine kept whatever status the last fetch had returned — often "running" long after it had stopped, discovered only by opening it.
+
+## Details
+
+- The server now announces every Session creation on the user channel (`session_created`, to the Project's owner and members), and a title set through `PATCH /api/sessions/:id` — the CLI's `--title`, a rename from another tab — the same way a generated title already was (`session_title`). Until now only a schedule firing was announced, which is why a scheduled Session appeared at once and a CLI one did not.
+- The list reloads on `session_created`: a row it did not make can only be fetched, not conjured, since a row needs its title, Workspace and counts.
+- The list now opens the user event stream of **each reachable machine** as well as this server's, through the same-origin proxy. A Session on a machine changes state on that machine's server, and only its stream says so; the list was assembled from every machine but listened to one. Streams follow the reachable set — closed for a machine that drops out, opened for one that comes up — and a machine's `web_updated` is ignored: that is the machine's web, not this window's.

--- a/changelog/unreleased/2026-08-30-sessions-list-live.md
+++ b/changelog/unreleased/2026-08-30-sessions-list-live.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-30
 - **Type:** fix
 - **Scope:** `server`, `web`
+- **PR:** [#557](https://github.com/Prism-Shadow/penguin-harness/pull/557)
 
 [中文版](2026-08-30-sessions-list-live.zh.md)
 

--- a/changelog/unreleased/2026-08-30-sessions-list-live.zh.md
+++ b/changelog/unreleased/2026-08-30-sessions-list-live.zh.md
@@ -1,0 +1,15 @@
+# Session 列表能得知不是它自己创建的 Session,本 server 与机器上皆然
+
+- **Date:** 2026-08-30
+- **Type:** fix
+- **Scope:** `server`, `web`
+
+[English](2026-08-30-sessions-list-live.md)
+
+由 CLI(或另一个标签页、定时任务、agent 派生的子 Session)启动的 Session,要到刷新页面才会出现在列表里;运行在机器上的 Session 则一直停留在上次拉取时的状态——常常早已停止却仍显示"运行中",点进去才发现。
+
+## 细节
+
+- server 现在把每一次 Session 创建都通告到用户频道(`session_created`,发给 Project 的所有者与成员);通过 `PATCH /api/sessions/:id` 设置的标题——CLI 的 `--title`、另一个标签页的重命名——也和自动生成的标题一样通告(`session_title`)。此前只有定时任务触发会被通告,这正是定时 Session 能立刻出现而 CLI 的不能的原因。
+- 列表收到 `session_created` 即重新加载:不是它创建的行只能拉取、无法凭空造出,因为一行需要标题、Workspace 和计数。
+- 列表现在除本 server 外,还通过同源代理打开**每台可达机器**的用户事件流。机器上的 Session 是在那台机器的 server 上变化状态的,只有它的事件流会说;列表本来就汇总了每台机器,却只听其中一台。事件流跟随可达集合——机器掉线即关闭、上线即打开——并忽略机器的 `web_updated`:那是机器的 web,不是这个窗口的。

--- a/changelog/unreleased/2026-08-30-sessions-list-live.zh.md
+++ b/changelog/unreleased/2026-08-30-sessions-list-live.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-30
 - **Type:** fix
 - **Scope:** `server`, `web`
+- **PR:** [#557](https://github.com/Prism-Shadow/penguin-harness/pull/557)
 
 [English](2026-08-30-sessions-list-live.md)
 

--- a/packages/server/src/api/types.ts
+++ b/packages/server/src/api/types.ts
@@ -2254,13 +2254,18 @@ export type ServerEvent =
   | { type: "hello" }
   /** The served web assets were hot-swapped by a platform upgrade: clients reload to pick them up. */
   | { type: "web_updated"; rev: string }
-  /** New session registered (pushed over the parent session's channel for subagent sessions): frontend refreshes the list in place. */
+  /**
+   * A Session now exists. On the user channel for every creation — the CLI, another tab,
+   * a schedule, an agent spawning a child — so the list learns about rows it did not make;
+   * and on the parent Session's channel for a subagent, so a tab watching the parent run
+   * refreshes in place. `source` is absent for a user-created Session, as it is on the row.
+   */
   | {
       type: "session_created";
       projectId: string;
       agentId: string;
       sessionId: string;
-      source: SessionSource;
+      source?: SessionSource;
     }
   | ScheduleServerEvent
   | GoalServerEvent;

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -166,6 +166,13 @@ export interface AppDeps {
   config: ServerConfig;
   db: DatabaseSync;
   sessionsRepo: SessionsRepo;
+  /**
+   * Publishes a user-level event to everyone who can see a Project — its owner and members
+   * with GET /api/events open. For a route that changes what the list shows (a rename) as
+   * much as for the runtime's state flips: the list has no other way to learn of a change
+   * it did not make itself.
+   */
+  notifyProjectUsers: (projectId: string, event: ServerEvent) => void;
   prefsRepo: UiPrefsRepo;
   /** Admin-level server-global settings (currently the proxy switches and address). */
   serverSettingsRepo: ServerSettingsRepo;
@@ -923,6 +930,7 @@ export function buildAppDeps(
     traceIndex,
     proxyEnv,
     controlEnv,
+    notifyProjectUsers,
     // List rows carry the ENABLED channel's indicator (saved-but-dark configs stay off
     // the row); a point query per row keeps the repo out of the service. An unknown
     // stored channel reads as none (same defensive skip as the bridge and the routes).
@@ -959,6 +967,7 @@ export function buildAppDeps(
     config,
     db,
     sessionsRepo,
+    notifyProjectUsers,
     prefsRepo,
     serverSettingsRepo,
     authService,

--- a/packages/server/src/http/routes/sessions.ts
+++ b/packages/server/src/http/routes/sessions.ts
@@ -592,6 +592,14 @@ export function sessionsRoutes(deps: AppDeps): Hono<AppEnv> {
       // Manual renaming takes priority over auto-generation: TitleGenerator only ever replaces the fallback title it wrote itself, never a manual rename.
       deps.sessionsRepo.updateTitle(row.sessionId, title);
       updated = { ...updated, title };
+      // The list learns of a rename it did not make — the CLI's `--title`, another tab —
+      // the same way it learns of a generated one: the generator publishes this exact
+      // event, and the row handler is already listening for it.
+      deps.notifyProjectUsers(row.projectId, {
+        type: "session_title",
+        sessionId: row.sessionId,
+        title,
+      });
     }
     if (approvalMode !== undefined) {
       // Takes effect immediately: a running approve callback re-reads the DB on every decision.

--- a/packages/server/src/services/session-service.ts
+++ b/packages/server/src/services/session-service.ts
@@ -23,6 +23,7 @@ import type {
   SessionCategoryCounts,
   SessionInfo,
   SessionSource,
+  ServerEvent,
 } from "../api/types.js";
 import { HttpError, isMissingCredential, modelCredentialMissing } from "../http/errors.js";
 import { badRequest } from "../http/validate.js";
@@ -66,6 +67,14 @@ export interface SessionServiceDeps {
    * agents can drive the harness back through the CLI/API.
    */
   controlEnv?: (ctx: ControlEnvContext) => Record<string, string>;
+  /**
+   * Tells every user of a Project that a Session now exists. The list only ever learns
+   * about rows it did not create itself from this: a Session started by the CLI, by
+   * another tab, by a schedule, or by an agent spawning a child sat invisible until the
+   * next full reload without it. Optional so the service keeps unit-testing without a
+   * channel registry; absent means nobody is told.
+   */
+  notifyProjectUsers?: (projectId: string, event: ServerEvent) => void;
   /**
    * The channel of the Session's ENABLED messaging binding, or null when none is enabled
    * (SessionInfo.messagingChannel, the sidebar row's per-channel indicator — saved-but-
@@ -400,6 +409,17 @@ export class SessionService {
     };
     this.deps.sessions.insert(row);
     this.deps.manager.adopt(row, session);
+    // After the insert: a reader who reacts by fetching the list must find the row there.
+    this.deps.notifyProjectUsers?.(args.projectId, {
+      type: "session_created",
+      projectId: args.projectId,
+      agentId: args.agentId,
+      sessionId: row.sessionId,
+      ...(() => {
+        const source = this.deps.sources.get(session.sessionId);
+        return source ? { source } : {};
+      })(),
+    });
     return this.toInfo(row, false);
   }
 

--- a/packages/server/test/session-created-events.test.ts
+++ b/packages/server/test/session-created-events.test.ts
@@ -1,0 +1,109 @@
+/**
+ * `session_created` on the user channel: the list learns about rows it did not make.
+ *
+ * A Session created by the CLI, by another tab, by a schedule or by an agent spawning a
+ * child went through the same route as one created from the list — and the list never
+ * heard about it, because nothing announced it. `session_state` and `session_title` cannot
+ * stand in: both act on a row the list already holds and ignore an unknown id. So this
+ * event is the one thing that makes a Session appear without a reload, and the audience
+ * rule is the same as for the state events: the Project's owner and members, nobody else.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type {
+  ProjectCreateResponse,
+  ServerEvent,
+  SessionCreateResponse,
+} from "../src/api/types.js";
+import { userChannelKey } from "../src/http/routes/events.js";
+import { apiClient, createTestApp, provisionUser } from "./helpers.js";
+import type { TestApp } from "./helpers.js";
+
+/** A client that has GET /api/events open: what the publish side checks for. */
+function inbox(t: TestApp, userId: string): ServerEvent[] {
+  const events: ServerEvent[] = [];
+  t.deps.channels.get(userChannelKey(userId)).subscribe((evt) => {
+    if (evt.event === "server_event") events.push(JSON.parse(evt.data) as ServerEvent);
+  });
+  return events;
+}
+
+const created = (events: ServerEvent[]) =>
+  events.flatMap((e) => (e.type === "session_created" ? [e] : []));
+
+describe("session_created on the user channel", () => {
+  let t: TestApp;
+  let owner: ReturnType<typeof apiClient>;
+  let projectId: string;
+  let boxes: { owner: ServerEvent[]; member: ServerEvent[]; stranger: ServerEvent[] };
+
+  beforeEach(async () => {
+    t = await createTestApp();
+    const a = await provisionUser(t.app, "owner");
+    await provisionUser(t.app, "member");
+    await provisionUser(t.app, "stranger");
+    owner = apiClient(t.app, a.cookie);
+    const res = (await (
+      await owner.post("/api/projects", { projectId: "owner-live", name: "project" })
+    ).json()) as ProjectCreateResponse;
+    projectId = res.project.projectId;
+    await owner.post(`/api/projects/${projectId}/members`, { userId: "member" });
+    await owner.put(`/api/projects/${projectId}/models`, {
+      defaultModel: { provider: "anthropic", modelId: "claude-sonnet-4-6" },
+      models: [{ provider: "anthropic", modelId: "claude-sonnet-4-6", contextWindow: 128000 }],
+    });
+    boxes = {
+      owner: inbox(t, "owner"),
+      member: inbox(t, "member"),
+      stranger: inbox(t, "stranger"),
+    };
+  });
+
+  afterEach(async () => {
+    await t.cleanup();
+  });
+
+  it("reaches the Project's owner and members with the new row's ids, and nobody else", async () => {
+    const res = (await (
+      await owner.post(`/api/projects/${projectId}/agents/default_agent/sessions`, {})
+    ).json()) as SessionCreateResponse;
+    const sessionId = res.session.sessionId;
+
+    for (const who of ["owner", "member"] as const) {
+      const got = created(boxes[who]);
+      expect(got, who).toHaveLength(1);
+      expect(got[0]).toMatchObject({ projectId, agentId: "default_agent", sessionId });
+      // A user-created Session has no source marker, on the row or in the event.
+      expect(got[0]).not.toHaveProperty("source");
+    }
+    expect(created(boxes.stranger)).toHaveLength(0);
+  });
+
+  it("is published after the row is in place, so a reader who reloads on it finds the row", async () => {
+    let seenAtPublish: boolean | null = null;
+    t.deps.channels.get(userChannelKey("owner")).subscribe((evt) => {
+      if (evt.event !== "server_event") return;
+      const ev = JSON.parse(evt.data) as ServerEvent;
+      if (ev.type === "session_created") {
+        seenAtPublish = t.deps.sessionsRepo.findById(ev.sessionId) !== null;
+      }
+    });
+    await owner.post(`/api/projects/${projectId}/agents/default_agent/sessions`, {});
+    expect(seenAtPublish).toBe(true);
+  });
+
+  it("a title set by PATCH is announced too — the CLI's --title, another tab's rename", async () => {
+    const res = (await (
+      await owner.post(`/api/projects/${projectId}/agents/default_agent/sessions`, {})
+    ).json()) as SessionCreateResponse;
+    const sessionId = res.session.sessionId;
+    await owner.patch(`/api/sessions/${sessionId}`, { title: "made by the CLI" });
+    const titles = (events: ServerEvent[]) =>
+      events.flatMap((e) => (e.type === "session_title" ? [e] : []));
+    for (const who of ["owner", "member"] as const) {
+      expect(titles(boxes[who]), who).toEqual([
+        { type: "session_title", sessionId, title: "made by the CLI" },
+      ]);
+    }
+    expect(titles(boxes.stranger)).toHaveLength(0);
+  });
+});

--- a/packages/web/src/api/sse.ts
+++ b/packages/web/src/api/sse.ts
@@ -70,7 +70,15 @@ export function openSessionStream(sessionId: string, handlers: StreamHandlers): 
   return subscribe(apiUrl(path, machineForSession(sessionId)), handlers);
 }
 
-/** Subscribes to the user-level server event stream (GET /api/events; reserved for scheduled-task notifications). */
-export function openUserEvents(handlers: StreamHandlers): StreamConnection {
-  return subscribe("/api/events", handlers);
+/**
+ * Subscribes to the user-level server event stream (GET /api/events) — this server's, or a
+ * machine's through the same-origin proxy. A Session on a machine changes state on THAT
+ * machine's server, and only its stream says so; the list is assembled from every reachable
+ * machine, so its liveness has to be too.
+ */
+export function openUserEvents(
+  handlers: StreamHandlers,
+  machineId: string | null = null,
+): StreamConnection {
+  return subscribe(apiUrl("/api/events", machineId), handlers);
 }

--- a/packages/web/src/state/sessions.tsx
+++ b/packages/web/src/state/sessions.tsx
@@ -778,11 +778,24 @@ export function applyUserEvent(
   store: SessionsStore,
   ev: ServerEvent,
   onWebUpdated: () => void,
+  /** The machine the event came from; null for this server. */
+  source: string | null = null,
 ): void {
   // The served web assets were hot-swapped (dev watch-push / platform upgrade): reload so this
-  // window runs the new code.
+  // window runs the new code. Only this server's word counts: a machine's web being pushed is
+  // that machine's affair, and this window is not running it.
   if (ev.type === "web_updated") {
-    onWebUpdated();
+    if (source === null) onWebUpdated();
+    return;
+  }
+  // A Session now exists that this list did not create — the CLI, another tab, a schedule, an
+  // agent spawning a child, on this server or on a machine. Nothing short of a fetch can put
+  // the row in place with everything a row needs (title, workspace, counts), so reload; the
+  // same answer schedule_fired gives below, for the same reason.
+  if (ev.type === "session_created") {
+    if (source !== null || ev.projectId === store.getState().projectId) {
+      void store.getState().reload();
+    }
     return;
   }
   // A Session changed run state. This is what keeps every row honest: a tab subscribes to the
@@ -816,8 +829,12 @@ export function applyUserEvent(
   // so it appears immediately. schedule_queued doesn't change the list (the target Session
   // already exists), so it is ignored, as is every other Session-scoped event.
   if (ev.type !== "schedule_fired") return;
-  // The event carries projectId: a trigger from another Project is unrelated to the current list.
-  if (ev.projectId === store.getState().projectId) void store.getState().reload();
+  // The event carries projectId: a trigger from another Project is unrelated to the current
+  // list. A machine's Project ids are its own and never match this server's, so for a machine
+  // the reload is unconditional — its rows in this list are exactly what the trigger touched.
+  if (source !== null || ev.projectId === store.getState().projectId) {
+    void store.getState().reload();
+  }
 }
 
 export function SessionsProvider({ children }: { children: ReactNode }) {
@@ -1007,6 +1024,28 @@ export function SessionsProvider({ children }: { children: ReactNode }) {
   }, [store]);
 
   const { pageState, countsByAgent, machineIds } = state;
+
+  // One more stream per reachable machine: a Session there changes state on that machine's
+  // server, and this server never hears of it. Keyed on the reachable set, so a machine that
+  // drops out has its stream closed and one that comes up gets one — the forward it rides on
+  // is raised by the same probe that publishes machineIds. EventSource reconnects on its own
+  // while a forward is briefly down.
+  const reachableKey = machineIds.join(",");
+  useEffect(() => {
+    const ids = reachableKey === "" ? [] : reachableKey.split(",");
+    const conns = ids.map((machineId) =>
+      openUserEvents(
+        {
+          onOmniMessage: () => undefined,
+          onServerEvent: (ev) => applyUserEvent(store, ev, () => undefined, machineId),
+        },
+        machineId,
+      ),
+    );
+    return () => {
+      for (const conn of conns) conn.close();
+    };
+  }, [store, reachableKey]);
   const sources = useMemo<(string | null)[]>(() => [null, ...machineIds], [machineIds]);
 
   // Loaded only when EVERY source has answered: one machine's first page arriving does not

--- a/packages/web/test/session-status-events.test.ts
+++ b/packages/web/test/session-status-events.test.ts
@@ -394,3 +394,84 @@ describe("other user-channel events keep their behaviour", () => {
     expect(reloads).toBe(1);
   });
 });
+
+describe("session_created on the user channel", () => {
+  const created = (projectId: string): ServerEvent => ({
+    type: "session_created",
+    projectId,
+    agentId: "default_agent",
+    sessionId: "session-new",
+  });
+  const counting = () => {
+    const store = storeWith();
+    let reloads = 0;
+    store.setState({
+      reload: async () => {
+        reloads += 1;
+      },
+    });
+    return { store, count: () => reloads };
+  };
+
+  it("reloads the list: a row this list did not make can only be fetched, not conjured", () => {
+    // The CLI, another tab, a schedule, an agent's child — none of them put a row here, and
+    // session_state / session_title on an unknown id are ignored by design. This is the one
+    // event that makes such a Session appear before the next manual reload.
+    const { store, count } = counting();
+    applyUserEvent(store, created("proj"), neverReload);
+    expect(count()).toBe(1);
+  });
+
+  it("ignores another Project's creation on this server", () => {
+    const { store, count } = counting();
+    applyUserEvent(store, created("other"), neverReload);
+    expect(count()).toBe(0);
+  });
+
+  it("reloads for a machine's creation whatever its Project id: those ids are the machine's own", () => {
+    const { store, count } = counting();
+    applyUserEvent(store, created("remote-project"), neverReload, "kUkIyqU-1GOfXgKD");
+    expect(count()).toBe(1);
+  });
+});
+
+describe("events from a machine's stream", () => {
+  const REMOTE = "kUkIyqU-1GOfXgKD";
+
+  it("move a remote row's state exactly like a local one", () => {
+    // A Session on a machine changes state on THAT server; its stream is the only place the
+    // flip is announced. The row is keyed by Session id alone, so the source does not matter
+    // for the update itself.
+    const store = storeWith(session("s-remote", { status: "idle" }));
+    applyUserEvent(store, stateEvent("s-remote", "running", STARTED), neverReload, REMOTE);
+    expect(rowOf(store, "s-remote").status).toBe("running");
+  });
+
+  it("never reload this window for a machine's web_updated: that is the machine's web, not ours", () => {
+    const store = storeWith();
+    let reloaded = false;
+    applyUserEvent(store, { type: "web_updated", rev: "abc" }, () => (reloaded = true), REMOTE);
+    expect(reloaded).toBe(false);
+    applyUserEvent(store, { type: "web_updated", rev: "abc" }, () => (reloaded = true));
+    expect(reloaded).toBe(true);
+  });
+
+  it("reload on a machine's schedule_fired regardless of Project id", () => {
+    const store = storeWith();
+    let reloads = 0;
+    store.setState({
+      reload: async () => {
+        reloads += 1;
+      },
+    });
+    const fired: ServerEvent = {
+      type: "schedule_fired",
+      projectId: "remote-project",
+      agentId: "default_agent",
+      name: "nightly",
+      sessionId: "s-1",
+    };
+    applyUserEvent(store, fired, neverReload, REMOTE);
+    expect(reloads).toBe(1);
+  });
+});


### PR DESCRIPTION
Top of the machines line, on `fix/workspace-file-urls-follow-machine` (#554): #450 ← #544 ← #549 ← #552 ← #553 ← #554 ← **#557**.

Reported as two things: a CLI-started Session does not show up until the page is reloaded, and a Session's status (running) is stale until you open it. One gap behind both.

## What the list listened to

The list is assembled from every reachable machine, but it listened to **one** `/api/events` — this server's (`sse.ts`), with no stream per machine and no polling of machine rows. And on that one stream, nothing announced a creation at all: the user-channel vocabulary was `session_state` / `session_title` / `resync_required` / `schedule_fired` / `web_updated`. `session_created` existed only for subagents, on the *parent Session's* channel, and the web never handled it. `setStatus`/`setTitle` on an id the list does not hold are no-ops by design.

So:
- a Session created by the CLI (which goes through the server API — `run.ts`/`chat.ts` are all `client.request(...)`), by another tab, or by an agent's child: no event, no row, until a reload. A scheduled one appeared at once only because `schedule_fired` triggers a reload.
- a Session on a machine: its `session_state` flips are published by *that* machine's server, which nobody here had a stream to. The row kept whatever the last fetch said.

## Fix

**Server** (platform layer, hot-pushable):
- `SessionService.createSession` publishes `session_created` on the user channel after the insert (audience = Project owner + members, like the state events). `source` is now optional on the event, as it is on the row.
- `PATCH /api/sessions/:id` with a title publishes `session_title` — the CLI's `--title`, a rename from another tab — the same event the title generator already publishes. `notifyProjectUsers` is now on `AppDeps` for routes.

**Web**:
- `applyUserEvent` takes a `source` (machine id or null). `session_created` → reload (a row it did not make can only be fetched; the same answer `schedule_fired` gives). A machine's `web_updated` is ignored — that is the machine's web, not this window's. `schedule_fired`/`session_created` from a machine reload unconditionally: machine Project ids are the machine's own and never match this server's.
- One `openUserEvents` per reachable machine through the same-origin proxy (`/server/<id>/api/events`), keyed on the reachable set: closed for a machine that drops out, opened for one that comes up. `EventSource` reconnects on its own across a brief forward outage.

## Verification

- Server: new `session-created-events.test.ts` (3): creation reaches owner and member with the row's ids and no `source` for a user-created Session, not a stranger; it is published after the row is in place; a PATCHed title reaches owner and member. `session-state-events.test.ts` still green.
- Web: `session-status-events.test.ts` +6: `session_created` reloads for this Project, not another, and for a machine regardless of Project id; a machine's `session_state` moves the row; a machine's `web_updated` never reloads this window while this server's does; a machine's `schedule_fired` reloads.
- **End to end** (built server + web, Playwright): a window open on `/chat`, a second client creating a Session through the API exactly as the CLI does and PATCHing a title — the row appeared in the open window in 3ms and the title in 5ms, with zero page loads.
- Server 1701 / web 1787 tests pass; both typechecks, `format:check`, `git diff --check` clean.

## Not verified end to end

The per-machine stream needs a second server reached through the machines connect flow to exercise; covered at the unit level, and the endpoint is the same `/api/events` the proxy already streams (SSE through the proxy is what the Session stream on a machine uses today). Worth a live check on the reporter's setup: a Session on `kamiya-prism` finishing should flip its row in the Windows window without opening it.

