### PR TITLE
test(server): the terminal stream suite kills each test's shells before the next

### DIFF
--- a/changelog/unreleased/2026-08-30-terminal-stream-test-isolation.md
+++ b/changelog/unreleased/2026-08-30-terminal-stream-test-isolation.md
@@ -1,0 +1,9 @@
+# The terminal stream suite kills each test's shells before the next test
+
+- **Date:** 2026-08-30
+- **Type:** process
+- **Scope:** `server`, `tooling`
+
+[中文版](2026-08-30-terminal-stream-test-isolation.zh.md)
+
+`terminal-stream.test.ts` shares one app across its tests and opened fourteen `/bin/sh` shells that nothing closed, against a registry that caps a user at twelve live shells. It fit under the cap only when enough earlier shells had exited on their own, so it passed on one runner and answered `429` on a slower one. Each test's terminals are now deleted after it, and the next test waits until the registry reports none alive.

--- a/changelog/unreleased/2026-08-30-terminal-stream-test-isolation.md
+++ b/changelog/unreleased/2026-08-30-terminal-stream-test-isolation.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-30
 - **Type:** process
 - **Scope:** `server`, `tooling`
+- **PR:** [#558](https://github.com/Prism-Shadow/penguin-harness/pull/558)
 
 [中文版](2026-08-30-terminal-stream-test-isolation.zh.md)
 

--- a/changelog/unreleased/2026-08-30-terminal-stream-test-isolation.zh.md
+++ b/changelog/unreleased/2026-08-30-terminal-stream-test-isolation.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-30
 - **Type:** process
 - **Scope:** `server`, `tooling`
+- **PR:** [#558](https://github.com/Prism-Shadow/penguin-harness/pull/558)
 
 [English](2026-08-30-terminal-stream-test-isolation.md)
 

--- a/changelog/unreleased/2026-08-30-terminal-stream-test-isolation.zh.md
+++ b/changelog/unreleased/2026-08-30-terminal-stream-test-isolation.zh.md
@@ -1,0 +1,9 @@
+# 终端流测试套件在下一条测试开始前杀掉上一条的 shell
+
+- **Date:** 2026-08-30
+- **Type:** process
+- **Scope:** `server`, `tooling`
+
+[English](2026-08-30-terminal-stream-test-isolation.md)
+
+`terminal-stream.test.ts` 的所有测试共用一个 app,一共开了十四个没人关闭的 `/bin/sh`,而注册表限制每个用户最多十二个存活 shell。只有当前面足够多的 shell 恰好自行退出时才装得下,于是它在一台 runner 上通过、在更慢的一台上答 `429`。现在每条测试结束后删除它的终端,下一条测试等注册表报告没有存活的再开始。

--- a/packages/server/test/terminal-stream.test.ts
+++ b/packages/server/test/terminal-stream.test.ts
@@ -7,7 +7,7 @@
  * and hostile-input tolerance. These are the promises the web dock and /terminal page are
  * built on.
  */
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { serve } from "@hono/node-server";
 import type { Server as HttpServer } from "node:http";
 import { WebSocket } from "ws";
@@ -57,6 +57,31 @@ beforeAll(async () => {
     // viewer is too far behind) is only observable through this line.
     log: (line) => serverLogs.push(line),
   });
+});
+
+/**
+ * Every test's shells are killed before the next one starts. The suite shares one app, and
+ * the terminal registry caps a user at MAX_TERMINALS_PER_USER LIVE shells: fourteen tests
+ * each opening a /bin/sh that nothing closes only fit under that cap when enough earlier
+ * shells happened to exit first — which is why the suite passed on one runner and answered
+ * 429 on a slower one. A kill is a signal, not an exit, so this waits for the registry to
+ * report none alive rather than trusting the DELETE.
+ */
+afterEach(async () => {
+  if (IS_WINDOWS) return;
+  const listed = (await (await api.get("/api/terminals")).json()) as {
+    terminals: TerminalInfoJson[];
+  };
+  for (const terminal of listed.terminals) await api.delete(`/api/terminals/${terminal.id}`);
+  const deadline = Date.now() + 5000;
+  for (;;) {
+    const now = (await (await api.get("/api/terminals")).json()) as {
+      terminals: TerminalInfoJson[];
+    };
+    if (!now.terminals.some((terminal) => terminal.alive)) return;
+    if (Date.now() > deadline) throw new Error("terminals from the previous test are still alive");
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
 });
 
 afterAll(async () => {


### PR DESCRIPTION
The suite shares one app (`beforeAll`) and opens fourteen `/bin/sh` shells that nothing closes, against `MAX_TERMINALS_PER_USER = 12` live shells. It fits under the cap only when enough earlier shells have exited on their own — so it passed on ubuntu and answered `429` (`expected 429 to be 201`) on the macOS runner for #550, on a diff that does not touch the server.

An `afterEach` deletes every terminal and waits until the registry reports none alive (a DELETE only signals; `alive` flips when the pty exits). Suite green 3/3 locally with it.