### PR TITLE
fix(landing): draw the same Agent the app draws

### DIFF
--- a/changelog/unreleased/2026-09-01-landing-agent-glyph.md
+++ b/changelog/unreleased/2026-09-01-landing-agent-glyph.md
@@ -1,0 +1,24 @@
+# The landing page draws the same Agent the app does
+
+- **Date:** 2026-09-01
+- **Type:** fix
+- **Scope:** `landing`, `web`
+- **PR:** [#544](https://github.com/Prism-Shadow/penguin-harness/pull/544)
+
+[中文版](2026-09-01-landing-agent-glyph.zh.md)
+
+The landing page's `BotIcon` now carries the Web App's Agent glyph exactly — eyes and smile
+included. The two were the same lucide robot until the app's grew a face
+([#538](https://github.com/Prism-Shadow/penguin-harness/pull/538)), and the page that sells
+the product should not draw its central object a second way.
+
+## Details
+
+- The glyph exists twice on purpose: the landing page carries no icon dependency, so there is
+  no module for the two to share. It is one `<path>` on both sides now, so the two are
+  literally the same string.
+- `packages/landing/test/agent-glyph-sync.test.ts` reads both sources as text and fails when
+  only one of them moves — this glyph had already drifted once, in a hand-copied literal on
+  the new-chat page, and a copy nobody checks is what drifts next.
+- Only the Agent mark differed. The landing set's history, users and clock glyphs are already
+  the same drawings the app uses.

--- a/changelog/unreleased/2026-09-01-landing-agent-glyph.md
+++ b/changelog/unreleased/2026-09-01-landing-agent-glyph.md
@@ -3,7 +3,7 @@
 - **Date:** 2026-09-01
 - **Type:** fix
 - **Scope:** `landing`, `web`
-- **PR:** [#544](https://github.com/Prism-Shadow/penguin-harness/pull/544)
+- **PR:** [#579](https://github.com/Prism-Shadow/penguin-harness/pull/579)
 
 [中文版](2026-09-01-landing-agent-glyph.zh.md)
 

--- a/changelog/unreleased/2026-09-01-landing-agent-glyph.zh.md
+++ b/changelog/unreleased/2026-09-01-landing-agent-glyph.zh.md
@@ -3,7 +3,7 @@
 - **Date:** 2026-09-01
 - **Type:** fix
 - **Scope:** `landing`, `web`
-- **PR:** [#544](https://github.com/Prism-Shadow/penguin-harness/pull/544)
+- **PR:** [#579](https://github.com/Prism-Shadow/penguin-harness/pull/579)
 
 [English](2026-09-01-landing-agent-glyph.md)
 

--- a/changelog/unreleased/2026-09-01-landing-agent-glyph.zh.md
+++ b/changelog/unreleased/2026-09-01-landing-agent-glyph.zh.md
@@ -1,0 +1,21 @@
+# 官网首页与应用画同一个智能体
+
+- **Date:** 2026-09-01
+- **Type:** fix
+- **Scope:** `landing`, `web`
+- **PR:** [#544](https://github.com/Prism-Shadow/penguin-harness/pull/544)
+
+[English](2026-09-01-landing-agent-glyph.md)
+
+官网的 `BotIcon` 改为与 Web App 的智能体字形完全一致——眼睛和笑嘴都在。两边本来就是同一个
+lucide 机器人，直到应用那边加上了五官（[#538](https://github.com/Prism-Shadow/penguin-harness/pull/538)）；
+售卖这个产品的页面不该把产品的核心对象画成第二种样子。
+
+## 细节
+
+- 这个字形有意存在两份：官网刻意不引入任何图标依赖，两边没有可共用的模块。现在两边都是单个
+  `<path>`，因此是字面上完全相同的一串。
+- `packages/landing/test/agent-glyph-sync.test.ts` 以文本方式读取两处来源，只动其中一处就会失
+  败——这个字形已经漂移过一次（新对话页示例文件夹里那份手抄的字面量），没人核对的副本必然会有
+  下一次。
+- 只有智能体这一枚不一致。官网图标集里的 history、users、clock 本来就与应用是同一套画法。

--- a/packages/landing/src/components/icons.tsx
+++ b/packages/landing/src/components/icons.tsx
@@ -274,12 +274,16 @@ export function FeatherIcon(props: IconProps) {
   );
 }
 
+/**
+ * Agent glyph, byte-identical to the Web App's AGENT_GROUP_ICON
+ * (packages/web/src/components/ui/group-list.tsx): the product and the page that sells it must
+ * not draw the same thing two ways. Kept as ONE path rather than this file's usual element mix
+ * so the two are literally the same string — test/agent-glyph-sync.test.ts fails when they drift.
+ */
 export function BotIcon(props: IconProps) {
   return (
     <Icon {...props}>
-      <path d="M12 8V4H8" />
-      <rect x="4" y="8" width="16" height="12" rx="2" />
-      <path d="M2 14h2M20 14h2M15 13v2M9 13v2" />
+      <path d="M12 8V4H8M6 8h12a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2zM2 14h2M20 14h2M9 13h.01M15 13h.01M10 16.5s.8 1 2 1 2-1 2-1" />
     </Icon>
   );
 }

--- a/packages/landing/test/agent-glyph-sync.test.ts
+++ b/packages/landing/test/agent-glyph-sync.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Landing ↔ Web App agent-glyph sync: the page that sells the product and the product itself
+ * draw the Agent with the same mark, and there is no shared module to draw it from — the
+ * landing page deliberately carries zero icon dependencies, so the path exists twice.
+ *
+ * A copy is exactly what drifts: this glyph was hand-copied once before (the new-chat page's
+ * example folder) and quietly stayed on the old drawing the day it was redrawn. Both sides are
+ * read as text rather than imported, because text is what the duplication actually is.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const webGlyphSource = join(
+  __dirname,
+  "..",
+  "..",
+  "web",
+  "src",
+  "components",
+  "ui",
+  "group-list.tsx",
+);
+const landingIconsSource = join(__dirname, "..", "src", "components", "icons.tsx");
+
+/** `export const AGENT_GROUP_ICON = "…"`, however prettier has wrapped it. */
+function webAgentGlyph(): string | null {
+  const source = readFileSync(webGlyphSource, "utf8");
+  return /export const AGENT_GROUP_ICON\s*=\s*"([^"]+)"/.exec(source)?.[1] ?? null;
+}
+
+/** The single `<path d="…">` of the landing set's BotIcon. */
+function landingBotGlyph(): string | null {
+  const source = readFileSync(landingIconsSource, "utf8");
+  const body = /export function BotIcon\([\s\S]*?\n}/.exec(source)?.[0] ?? "";
+  const paths = [...body.matchAll(/<path d="([^"]+)"/g)].map((m) => m[1]);
+  return paths.length === 1 ? (paths[0] ?? null) : null;
+}
+
+describe("landing ↔ Web App agent glyph", () => {
+  it("finds both sides", () => {
+    expect(webAgentGlyph()).not.toBeNull();
+    // null also means BotIcon stopped being a single path, which is what makes it comparable.
+    expect(landingBotGlyph()).not.toBeNull();
+  });
+
+  it("draws the same Agent", () => {
+    expect(landingBotGlyph()).toBe(webAgentGlyph());
+  });
+});

--- a/packages/web/src/components/ui/group-list.tsx
+++ b/packages/web/src/components/ui/group-list.tsx
@@ -31,6 +31,10 @@ export const FOLDER_OPEN_ICON =
  * nav): a robot head with an antenna, two ears, two eyes and a smile — lucide's `bot` with the
  * mouth added. The face is the point: an Agent is the thing in this product a person talks to,
  * and the friendliest mark on the rail should be the one that stands for it.
+ *
+ * The landing page draws the same Agent from its own copy of this string (`BotIcon` in
+ * packages/landing/src/components/icons.tsx — it carries no icon dependency to share one
+ * with); redraw this and redraw that. Its agent-glyph-sync test fails if only one moves.
  */
 export const AGENT_GROUP_ICON =
   "M12 8V4H8M6 8h12a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2zM2 14h2M20 14h2M9 13h.01M15 13h.01M10 16.5s.8 1 2 1 2-1 2-1";


### PR DESCRIPTION
## Summary

The landing page's `BotIcon` was lucide's plain bot; the Web App's Agent glyph grew eyes and a smile in [#538](https://github.com/Prism-Shadow/penguin-harness/pull/538). Same robot, two drawings — on the page whose whole job is to show what the product is. The landing one is now byte-identical to `AGENT_GROUP_ICON`.

It renders in three places: the pillars card backdrop (128px at stroke 1.25), a features card backdrop (104px), and a 14px tab chip. The dot eyes are what let the smile carry the expression at the large faint size, which is why the app's exact string was taken rather than adding a mouth to the local one.

**The duplication stays, and gets a check instead of a promise.** The landing page carries no icon dependency by design, so there is no module for the two to share — the path exists twice on purpose. `packages/landing/test/agent-glyph-sync.test.ts` reads both sources as text and fails when only one of them moves. That guard is not hypothetical: this glyph had already drifted once, in a hand-copied literal on the new-chat page, which sat on the old drawing under a comment claiming it was the same mark.

Only the Agent mark differed. The landing set's `HistoryIcon`, `UsersIcon` and `ClockIcon` are already the same drawings the app uses.

## Verification

- `pnpm -r build`, `pnpm typecheck` — clean
- `pnpm test` — green across all packages (landing: 10 files / 71 tests, including the 2 new ones)
- `pnpm format` + `pnpm format:check` — clean
- The sync test was confirmed to fail on a one-character change to either side, then pass again

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzjnF5MeHHx8BSLLV9prwm
