### PR TITLE
feat: initialize linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,12 @@ jobs:
       - name: Code style (Prettier)
         run: pnpm format:check
 
+      # oxlint gates a deliberately small rule set (see .oxlintrc.json): the import rules
+      # the repo is already clean under. Prettier formats imports but never merges them,
+      # so nothing caught a module being imported twice in one file until now.
+      - name: Lint (oxlint)
+        run: pnpm lint
+
       # A workflow that does not parse produces a run with zero jobs and no annotation
       # anywhere useful -- the failure this very file shipped once, over a double-quoted
       # string in a ${{ }} expression, where only single quotes are legal. Cheap to catch.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "plugins": ["import"],
+
+  // Every rule is off unless it is named below. oxlint's default `correctness` category
+  // reports ~127 findings here — unused variables, useless spreads, control characters in
+  // the terminal's regexes (deliberate), generators that never yield (test doubles). Each
+  // is its own conversation, and a gate that starts noisy gets ignored or disabled, so
+  // this one starts at what the repo is already clean under and tightens from there.
+  "categories": { "correctness": "off" },
+
+  "rules": {
+    // The rule this linter was added for: prettier formats import statements but never
+    // merges them, so a module imported twice in one file went unnoticed indefinitely.
+    // A value import beside an `import type` from the same module is still fine.
+    "import/no-duplicates": "error",
+    "import/no-self-import": "error",
+    "import/no-empty-named-blocks": "error"
+  },
+  "ignorePatterns": [
+    "**/dist/**",
+    "**/build/**",
+    "**/node_modules/**",
+    "packages/desktop/release/**",
+    "packages/landing/.blog-assets/**",
+    "packages/web/dist-app/**"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "lint": "oxlint",
     "typecheck": "pnpm -r typecheck",
     "test": "pnpm -r test",
     "test:e2e": "pnpm --filter @prismshadow/penguin-core test:e2e",
@@ -30,6 +31,7 @@
     "@types/node": "^24.0.0",
     "concurrently": "^10.0.4",
     "esbuild": "^0.28.1",
+    "oxlint": "^1.81.0",
     "prettier": "^3.9.4",
     "tsx": "^4.20.0",
     "typescript": "^5.6.0",

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -56,11 +56,10 @@
  */
 import { spawn } from "node:child_process";
 import { createInterface } from "node:readline";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync, realpathSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { realpathSync } from "node:fs";
 import { VERSION, compareVersions, normalizeVersion } from "@prismshadow/penguin-core";
 import type { Command } from "commander";
 import type { InstallerSource, Messages } from "../i18n.js";

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -37,6 +37,7 @@ import {
   tracesDir,
   type AgentState,
   type ModelRef,
+  type ModelEntry,
   type ProjectConfig,
 } from "./state/index.js";
 import { GenerativeModel, ToolCallIdAllocator, effectiveMaxContextLength } from "./llm/index.js";
@@ -92,7 +93,6 @@ import type {
   ToolDefinition,
   VisionDescriberService,
 } from "./interfaces/index.js";
-import type { ModelEntry } from "./state/index.js";
 
 /**
  * Maximum subagent spawn depth. Currently capped at 1 level (a subagent cannot spawn

--- a/packages/core/src/environment/tools/subagent/session.ts
+++ b/packages/core/src/environment/tools/subagent/session.ts
@@ -33,8 +33,7 @@
  * need for a separate synchronous hard-kill path (its command sessions are reaped by their own
  * exit fallback); `killHard` is equivalent to `kill`.
  */
-import type { OmniMessage } from "../../../omnimessage/index.js";
-import type { ApprovalDecision, ToolCallPayload } from "../../../omnimessage/index.js";
+import type { OmniMessage, ApprovalDecision, ToolCallPayload } from "../../../omnimessage/index.js";
 import type {
   ApproveFn,
   RunCutoff,

--- a/packages/core/test/background-execution.test.ts
+++ b/packages/core/test/background-execution.test.ts
@@ -10,11 +10,13 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { Environment } from "../src/environment/index.js";
 import { armCommandDoneReport } from "../src/environment/tools/exec-command.js";
-import { ManagedSession } from "../src/environment/tools/command/index.js";
+import {
+  ManagedSession,
+  DEFAULT_EMPTY_POLL_YIELD_MS,
+} from "../src/environment/tools/command/index.js";
 import { createSubagentTool } from "../src/environment/tools/run-subagent.js";
 import { createInputSubagentTool } from "../src/environment/tools/input-subagent.js";
 import { SubagentSessionManager } from "../src/environment/tools/subagent/index.js";
-import { DEFAULT_EMPTY_POLL_YIELD_MS } from "../src/environment/tools/command/index.js";
 import { ContextEngine } from "../src/engine/context-engine.js";
 import {
   requestEnd,

--- a/packages/core/test/engine.test.ts
+++ b/packages/core/test/engine.test.ts
@@ -32,6 +32,9 @@ import type {
   GenerativeModelParameters,
   LLMInterface,
   LLMOutcome,
+  ApproveFn,
+  EnvironmentInterface,
+  ToolPermission,
 } from "../src/interfaces/index.js";
 import type {
   OmniMessage,
@@ -45,7 +48,6 @@ import { ContextEngine, reconnectDelayMs } from "../src/engine/context-engine.js
 
 import { parseUserSteeringText } from "../src/omnimessage/markers/index.js";
 import { imagesToScratchpadPaths } from "../src/internal/session-support.js";
-import type { ApproveFn, EnvironmentInterface, ToolPermission } from "../src/interfaces/index.js";
 
 /** A real 1x1 PNG data URL: the non-vision fold actually decodes and writes it to disk. */
 const PNG_DATA_URL =

--- a/packages/core/test/mcp-tools.test.ts
+++ b/packages/core/test/mcp-tools.test.ts
@@ -1,6 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
-import { createServer, type Server } from "node:http";
-import type { IncomingHttpHeaders } from "node:http";
+import { createServer, type IncomingHttpHeaders, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
 import { mkdtemp, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";

--- a/packages/core/test/memory.test.ts
+++ b/packages/core/test/memory.test.ts
@@ -8,7 +8,6 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
-import type { SystemConfig } from "../src/index.js";
 import { systemConfigPath } from "../src/state/paths.js";
 import {
   DEFAULT_AGENT_ID,
@@ -34,6 +33,7 @@ import {
   workspaceMemoryKeyForRealPath,
   type AgentState,
   type SessionMemory,
+  type SystemConfig,
 } from "../src/index.js";
 import { stubProviderKeys } from "./provider-keys.js";
 

--- a/packages/server/src/auth/service.ts
+++ b/packages/server/src/auth/service.ts
@@ -12,9 +12,8 @@ import type { UserInfo } from "../api/types.js";
 import { HttpError } from "../http/errors.js";
 import type { UserRow, UsersRepo } from "../db/repos/users.js";
 import { sessionTokenHash } from "../db/repos/auth-sessions.js";
-import type { SessionViaValue } from "../db/repos/auth-sessions.js";
+import type { SessionViaValue, AuthSessionsRepo } from "../db/repos/auth-sessions.js";
 import type { AuthRuntimeState } from "./runtime-state.js";
-import type { AuthSessionsRepo } from "../db/repos/auth-sessions.js";
 import { SCRYPT_COST, hashPassword, verifyPassword } from "./password.js";
 
 export const MIN_PASSWORD_LENGTH = 8;

--- a/packages/server/src/hmr/host.ts
+++ b/packages/server/src/hmr/host.ts
@@ -70,13 +70,12 @@ import fsp from "node:fs/promises";
 import path from "node:path";
 import zlib from "node:zlib";
 import { pathToFileURL } from "node:url";
-import type { Instance, Json } from "@prismshadow/penguin-core/kernel";
+import type { Instance, Json, AnyIface, AnyImpl } from "@prismshadow/penguin-core/kernel";
 import { boot, initialDoc, upgrade } from "@prismshadow/penguin-core/kernel";
 import { HotResources } from "./resources.js";
 import type { Manifest } from "./manifest.js";
 import type { PlatformApi } from "../hmr/platform.js";
 import { packagedPlatform } from "../hmr/platform.js";
-import type { AnyIface, AnyImpl } from "@prismshadow/penguin-core/kernel";
 
 /**
  * The contract every platform bundle must satisfy — packaged or pushed. `context` is the

--- a/packages/server/src/http/routes/plugins.ts
+++ b/packages/server/src/http/routes/plugins.ts
@@ -18,8 +18,9 @@ import {
   listInstalledHooks,
   listInstalledSkills,
   removeHook,
+  libraryPlugin,
+  loadPluginGroups,
 } from "@prismshadow/penguin-core";
-import { libraryPlugin, loadPluginGroups } from "@prismshadow/penguin-core";
 import type {
   AgentHooksResponse,
   AgentPluginsInstallResponse,

--- a/packages/server/src/http/routes/skills.ts
+++ b/packages/server/src/http/routes/skills.ts
@@ -21,8 +21,9 @@ import {
   removeSkill,
   replaceSkillDirectory,
   skillsDir,
+  parseSkillFrontmatter,
+  PLUGIN_NAME_PATTERN,
 } from "@prismshadow/penguin-core";
-import { parseSkillFrontmatter, PLUGIN_NAME_PATTERN } from "@prismshadow/penguin-core";
 import type { AgentSkillsResponse } from "../../api/types.js";
 import type { AppEnv } from "../../auth/middleware.js";
 import type { AppDeps } from "../../app.js";

--- a/packages/server/src/runtime/schedule-store.ts
+++ b/packages/server/src/runtime/schedule-store.ts
@@ -11,8 +11,11 @@ import { stringify as stringifyToml } from "smol-toml";
 import { atomicWriteFile, resolveModelRef, scheduleDir } from "@prismshadow/penguin-core";
 import type { ProjectConfig } from "@prismshadow/penguin-core";
 import { cacheable, statMtime } from "../internal/mtime-gate.js";
-import type { ScheduleDefinition } from "./schedule-file.js";
-import { parseScheduleFile, type ScheduleParseResult } from "./schedule-file.js";
+import {
+  parseScheduleFile,
+  type ScheduleDefinition,
+  type ScheduleParseResult,
+} from "./schedule-file.js";
 
 export interface ScheduleFileEntry {
   name: string;

--- a/packages/server/src/services/agent-service.ts
+++ b/packages/server/src/services/agent-service.ts
@@ -28,8 +28,6 @@ import {
   scheduleDir,
   skillsDir,
   systemConfigPath,
-} from "@prismshadow/penguin-core";
-import {
   comparePluginVersions,
   loadLibraryPlugins,
   parseSkillFrontmatter,

--- a/packages/server/test/directory-skills.test.ts
+++ b/packages/server/test/directory-skills.test.ts
@@ -14,8 +14,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { skillsDir } from "@prismshadow/penguin-core";
-import { librarySkill } from "@prismshadow/penguin-core";
+import { skillsDir, librarySkill } from "@prismshadow/penguin-core";
 import type {
   AgentCreateResponse,
   AgentSkillsResponse,

--- a/packages/server/test/extension.test.ts
+++ b/packages/server/test/extension.test.ts
@@ -10,9 +10,8 @@ import { HotResources } from "../src/hmr/resources.js";
 import { packagedPlatform } from "../src/hmr/platform.js";
 import { PENGUIN_FAMILY, RUNTIME_INTERFACES_RESOURCE_ID } from "../src/hmr/capabilities.js";
 import { EXTENSIONS_RESOURCE_ID, ExtensionHost, extensionHostFrom } from "../src/extension/host.js";
-import type { PenguinContext, PenguinInterface } from "../src/extension/index.js";
+import type { PenguinContext, PenguinInterface, WorkflowFactory } from "../src/extension/index.js";
 import { instantiateWorkflows, WorkflowFactories } from "../src/extension/workflow.js";
-import type { WorkflowFactory } from "../src/extension/index.js";
 
 function emptyIface(): PenguinInterface {
   // The registry, not a bare Map: that IS the surface an extension gets (see platform.ts).

--- a/packages/server/test/session-fork.test.ts
+++ b/packages/server/test/session-fork.test.ts
@@ -21,11 +21,10 @@ import type {
   ProjectCreateResponse,
   SessionForkResponse,
 } from "../src/api/types.js";
-import { apiClient, createTestApp, provisionUser, writeTraceFile } from "./helpers.js";
+import { apiClient, createTestApp, provisionUser, writeTraceFile, waitFor } from "./helpers.js";
 import type { TestApp } from "./helpers.js";
 import type { SessionRow } from "../src/db/repos/sessions.js";
 import type { RuntimeSession } from "../src/runtime/session-manager.js";
-import { waitFor } from "./helpers.js";
 
 const SID = "session-2026-08-14-10-00-00-aabbcc01";
 

--- a/packages/server/test/session-processes.test.ts
+++ b/packages/server/test/session-processes.test.ts
@@ -9,8 +9,7 @@
  *   - 404 for foreign/unknown sessions (the shared resolveSession semantics).
  */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import type { BackgroundCommandInfo, OmniMessage } from "@prismshadow/penguin-core";
-import type { ApproveFn } from "@prismshadow/penguin-core";
+import type { BackgroundCommandInfo, OmniMessage, ApproveFn } from "@prismshadow/penguin-core";
 import type { SessionProcessesResponse } from "../src/api/types.js";
 import type { SessionRow } from "../src/db/repos/sessions.js";
 import type { RuntimeSession } from "../src/runtime/session-manager.js";

--- a/packages/server/test/session-subagents.test.ts
+++ b/packages/server/test/session-subagents.test.ts
@@ -13,13 +13,14 @@
  */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { toolCall, withOrigin } from "@prismshadow/penguin-core";
-import type { BackgroundSubagentInfo, OmniMessage } from "@prismshadow/penguin-core";
-import { ApprovalRegistry } from "../src/runtime/approvals.js";
 import type {
+  BackgroundSubagentInfo,
+  OmniMessage,
   ApproveFn,
   SubagentMessageOptions,
   SubagentMessageOutcome,
 } from "@prismshadow/penguin-core";
+import { ApprovalRegistry } from "../src/runtime/approvals.js";
 import type { ServerEvent, SubagentMessageResponse } from "../src/api/types.js";
 import type { SessionRow } from "../src/db/repos/sessions.js";
 import type { RuntimeSession } from "../src/runtime/session-manager.js";

--- a/packages/server/test/skills.test.ts
+++ b/packages/server/test/skills.test.ts
@@ -14,8 +14,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { strToU8, unzipSync, zipSync } from "fflate";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { skillsDir } from "@prismshadow/penguin-core";
-import { librarySkill, loadPreinstalledPlugins } from "@prismshadow/penguin-core";
+import { skillsDir, librarySkill, loadPreinstalledPlugins } from "@prismshadow/penguin-core";
 import type {
   AgentCreateResponse,
   AgentsResponse,

--- a/packages/web/src/features/agents/agents-page.tsx
+++ b/packages/web/src/features/agents/agents-page.tsx
@@ -52,7 +52,7 @@ import { AgentAvatar } from "../../components/ui/agent-avatar";
 import { GlyphIcon } from "../../components/ui/glyph-icon";
 import { UpdatePill } from "../../components/ui/update-dot";
 import { TodoNotice } from "../../components/ui/todo-notice";
-import { GEAR_ICON, HOOK_ICON, PLUGIN_ICON } from "../../components/ui/icons";
+import { CloseIcon, GEAR_ICON, HOOK_ICON, PLUGIN_ICON } from "../../components/ui/icons";
 import { STAT_ICONS } from "../../lib/stat-icons";
 import { DRAFT_SESSION_ID } from "../chat/chat-page";
 import { parkActiveDraft } from "../chat/draft-sessions";
@@ -64,7 +64,6 @@ import {
   fileToBase64,
 } from "./snapshot-file";
 import { HiddenFileInput } from "../../components/ui/hidden-file-input";
-import { CloseIcon } from "../../components/ui/icons";
 import { WorkspaceSelect } from "../chat/workspace-select";
 import { SkillPickList } from "../skills/skill-pick-list";
 import type { PickableItem } from "../skills/skill-pick-list";

--- a/packages/web/src/features/chat/chat-page.tsx
+++ b/packages/web/src/features/chat/chat-page.tsx
@@ -108,9 +108,10 @@ import { MessagingPanel } from "../messaging/messaging-panel";
 import { DockPanel } from "../dock/dock-panel";
 import { useDockMount } from "../dock/use-dock-mount";
 import { panelLabel } from "../dock/panel-meta";
-import { adoptDockScope } from "../dock/dock-state";
+// importing it also registers the global Ctrl+` hotkey with the app bundle
 import { setDockCwd } from "../dock/dock-terminal";
 import {
+  adoptDockScope,
   dockViews,
   dockVersion,
   isTabShown,
@@ -119,7 +120,6 @@ import {
   subscribeDock,
   type PanelKind,
 } from "../dock/dock-state";
-import "../dock/dock-terminal"; // registers the global Ctrl+` hotkey with the app bundle
 import { terminalApiSupported, subscribeTerminals } from "../terminal/terminal-list";
 import { advancePanelTaskScope, createPanelTaskScope } from "./panel-task-scope";
 import { useSessionDraft } from "./use-session-draft";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       esbuild:
         specifier: ^0.28.1
         version: 0.28.1
+      oxlint:
+        specifier: ^1.81.0
+        version: 1.81.0
       prettier:
         specifier: ^3.9.4
         version: 3.9.4
@@ -1073,6 +1076,128 @@ packages:
 
   '@nodable/entities@2.2.0':
     resolution: {integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==}
+
+  '@oxlint/binding-android-arm-eabi@1.81.0':
+    resolution: {integrity: sha512-IcCRsXiedJoJopY6mpZUBEeVFsUrutmrG7dZ87zMuKJlhg70Ora9bBl1WcCxZQtyI10YpnVdEso5oCg7YcfSHw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxlint/binding-android-arm64@1.81.0':
+    resolution: {integrity: sha512-GRrIPyTGVhx3L3h+0T5xT2A0jFAcdPv4+IfuXpGDLIdl6XeYhgg/zw72A5ILZoUgRqZuM8F1y+V/gfDriXSxzQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxlint/binding-darwin-arm64@1.81.0':
+    resolution: {integrity: sha512-qNQ9tXRgLuKbqSV1S2h9h4KPHjbovO7RRR2/enUOtHzTkFZ7B9X5zqqHJua8dRyc7dBy7Aoyq5pqTSLFVcAzGQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint/binding-darwin-x64@1.81.0':
+    resolution: {integrity: sha512-q0QTm32jWga2Gv4j7IaVZN0jYMi9UV73sWVgFtDA4iIfqwMCLLZ3ve+9KwfYtsaKZSgQhmPaogeZWqDZpcY1Pw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint/binding-freebsd-x64@1.81.0':
+    resolution: {integrity: sha512-/+8wVWDXEC7wHVAhOc59Fw/SkMc1arLkFD8iQCaSsmzenK1X4doFqquL9H1wrtGUzaiycVqkf/sSpcILK6W1UA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.81.0':
+    resolution: {integrity: sha512-4xt422FEgioRq9hAL4Tq7fujGUWnc8z1BJ+Oi8RN8vB8axaP+sdK6a2xdlcQCCYnJg9QMuMFS0AucuIFx/EacA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm-musleabihf@1.81.0':
+    resolution: {integrity: sha512-u3vna8KdGplH4DRCW9K54D68fcMo7IxVrkCJWwXnIhwtBdnDnYrmzOUA/XjmBlPpcLsgw9Z5BNdY4za9+Dj+MQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-gnu@1.81.0':
+    resolution: {integrity: sha512-3j9k+gsYsE7nv71GWotXsqsa2l9/aJenD7dVHNt/CBvsb0SgRjSMnHFeP59IXUAl1wvVFhqGl2wJNMwWU3UBlA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-arm64-musl@1.81.0':
+    resolution: {integrity: sha512-k5iAp3dNxW0/uDCBY+WSm8jKB2szu7SkEQZdgRRpDXvuDd69vvDcqhB3A/pWCfCwXyenjNjFn9Td1fVoyAc+Yg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-ppc64-gnu@1.81.0':
+    resolution: {integrity: sha512-TFqLja3uYmVSte6nof9GWrex9Z8WgdZrNiLC6Te5rXGDqXB2y4j/26iFhwosXiAFqDhE9JJVuuCkDKLwptTn1g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-gnu@1.81.0':
+    resolution: {integrity: sha512-UEcySvGS0NOVo7h7n7CYyJL9+6gFAh7Zc/ToDXVScFvzHSTIxtzkMVU30rmQ6+nQ1LF+UdiRDdJajpDu+OylLg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-musl@1.81.0':
+    resolution: {integrity: sha512-H+diDbhD00+wI1IRP8Kz88x/lat+DgtoBJzoTthS16xkTJGNaEkfb8gzmd1rzc/2uDQQMl7GNl+JFUacVeWxIA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-s390x-gnu@1.81.0':
+    resolution: {integrity: sha512-8znJ/5TekjOKg1j1Acho4PJMdiAHLtlcXuWEiipOhAMV6rQcXdmDdXCbheyDczN6TjBwiNfjcP81k4AthrKRzw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-gnu@1.81.0':
+    resolution: {integrity: sha512-Q2Wj70yFsvn5QjlmifFzbj4H+kJy53bwqc41o1fzoM7MpLV1NIbhg/LpWXRfC6KOkSAdUx1Wd8VJsdPmhp/HRA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-musl@1.81.0':
+    resolution: {integrity: sha512-cPInHp/ddEe5qkyK2IiyQ8Q3Mp2oLLEhhsGgTK2oZx4L6+llGam1H1yBvJZ7qHfOXj8N3hxBS8sj4tO+gtFlIg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-openharmony-arm64@1.81.0':
+    resolution: {integrity: sha512-0CQxSX4ajqm07AHBf5U33qQzXKdd7wtq/oTL/7vpY6RNNuxrRi8W4bqUV1Jyu/vj+9KmxQyDhxfeVX1nQL6kfg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxlint/binding-win32-arm64-msvc@1.81.0':
+    resolution: {integrity: sha512-l0hbeISm9673hVrrQU8j/p2M7YH9Ouoj7p7E/QM55NTrKVLP+P3PF8hLu+OY+x0VtGRW+ggiQKZqmdYps9H+TA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint/binding-win32-ia32-msvc@1.81.0':
+    resolution: {integrity: sha512-ksqPP5jbFXcYreEQ7zdJh06rJQBymCTyGRCdaXjfcf2aG4f8KxUWY5wcgYHmaTK+FJ4bPG5sUAdOX+6trnH1JA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxlint/binding-win32-x64-msvc@1.81.0':
+    resolution: {integrity: sha512-IZuUCwGw9emG5JtCp+fYGB+Z4OWEoeEcM8R5BA1pYw63/ieYFVdcU2ylxTpHbVHSenZnsYE+ZZ20uHAJszQ4cA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
 
   '@peculiar/asn1-schema@2.8.0':
     resolution: {integrity: sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==}
@@ -3163,6 +3288,19 @@ packages:
       zod:
         optional: true
 
+  oxlint@1.81.0:
+    resolution: {integrity: sha512-HyrJYqeoOCL0iqaLEzGewGT48ZX99P3hxYh8udAF9RGGIghSamkXE4ClUyBpEDNqasamThgmlPbuMOe7SAZmHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=7.0.2001'
+      vite-plus: '*'
+    peerDependenciesMeta:
+      oxlint-tsgolint:
+        optional: true
+      vite-plus:
+        optional: true
+
   p-cancelable@2.1.1:
     resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
     engines: {node: '>=8'}
@@ -4755,6 +4893,63 @@ snapshots:
   '@noble/hashes@2.2.0': {}
 
   '@nodable/entities@2.2.0': {}
+
+  '@oxlint/binding-android-arm-eabi@1.81.0':
+    optional: true
+
+  '@oxlint/binding-android-arm64@1.81.0':
+    optional: true
+
+  '@oxlint/binding-darwin-arm64@1.81.0':
+    optional: true
+
+  '@oxlint/binding-darwin-x64@1.81.0':
+    optional: true
+
+  '@oxlint/binding-freebsd-x64@1.81.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.81.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-musleabihf@1.81.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-gnu@1.81.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-musl@1.81.0':
+    optional: true
+
+  '@oxlint/binding-linux-ppc64-gnu@1.81.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-gnu@1.81.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-musl@1.81.0':
+    optional: true
+
+  '@oxlint/binding-linux-s390x-gnu@1.81.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-gnu@1.81.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-musl@1.81.0':
+    optional: true
+
+  '@oxlint/binding-openharmony-arm64@1.81.0':
+    optional: true
+
+  '@oxlint/binding-win32-arm64-msvc@1.81.0':
+    optional: true
+
+  '@oxlint/binding-win32-ia32-msvc@1.81.0':
+    optional: true
+
+  '@oxlint/binding-win32-x64-msvc@1.81.0':
+    optional: true
 
   '@peculiar/asn1-schema@2.8.0':
     dependencies:
@@ -7383,6 +7578,28 @@ snapshots:
     optionalDependencies:
       ws: 8.21.0
       zod: 4.4.3
+
+  oxlint@1.81.0:
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.81.0
+      '@oxlint/binding-android-arm64': 1.81.0
+      '@oxlint/binding-darwin-arm64': 1.81.0
+      '@oxlint/binding-darwin-x64': 1.81.0
+      '@oxlint/binding-freebsd-x64': 1.81.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.81.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.81.0
+      '@oxlint/binding-linux-arm64-gnu': 1.81.0
+      '@oxlint/binding-linux-arm64-musl': 1.81.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.81.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.81.0
+      '@oxlint/binding-linux-riscv64-musl': 1.81.0
+      '@oxlint/binding-linux-s390x-gnu': 1.81.0
+      '@oxlint/binding-linux-x64-gnu': 1.81.0
+      '@oxlint/binding-linux-x64-musl': 1.81.0
+      '@oxlint/binding-openharmony-arm64': 1.81.0
+      '@oxlint/binding-win32-arm64-msvc': 1.81.0
+      '@oxlint/binding-win32-ia32-msvc': 1.81.0
+      '@oxlint/binding-win32-x64-msvc': 1.81.0
 
   p-cancelable@2.1.1: {}
 


### PR DESCRIPTION
> **Draft.** Based on `main`.

The repo has prettier and nothing else. Prettier formats import statements but never merges them, so **a module imported twice in the same file passed every gate** — 22 of them had accumulated across six packages, most from adding one more name to an import that already existed a few lines up:

```ts
import { Component, Use } from "@prismshadow/penguin-core/kernel";
import { Interface } from "@prismshadow/penguin-core/kernel";
```

## The linter

[oxlint](https://oxc.rs/docs/guide/usage/linter) — one dev dependency, no plugin graph, no config beyond `.oxlintrc.json`, and it runs over the whole repo in under a second. `pnpm lint`, wired into the existing `style` CI job beside the Prettier check.

Three rules are errors, all from the import plugin:

| rule | findings before this PR |
|---|---|
| `import/no-duplicates` | 22 |
| `import/no-self-import` | 0 |
| `import/no-empty-named-blocks` | 0 |

## Why the gate is this small

Everything else is off, including oxlint's default `correctness` category. That category reports ~127 findings here, and they are not one problem:

- 43 `no-unused-vars` — some dead, some deliberately-kept constants;
- 38 `unicorn/no-useless-spread` — stylistic;
- 12 `require-yield` — generators that never yield, all test doubles;
- 8 `no-control-regex` — the terminal's escape parsing, which is the point;
- 6 `no-unsafe-optional-chaining`, 13 `import/no-cycle`, and a tail of others.

Each is its own conversation, and a gate that starts noisy gets ignored or switched off. This one starts at what the repo already satisfies, so it can only be broken by new code, and tightens from there. `import/no-cycle` is the most interesting candidate to add next.

## The 22 fixes

Merged into one statement per module. Where a file already wrote inline `type` specifiers, the separate `import type` line folds into it; a value import beside an `import type` is otherwise left alone — that pair is used ~110 times in `packages/server` alone and reads as intended, and the rule agrees.

One judgement call: `chat-page.tsx` had `import { setDockCwd } from "../dock/dock-terminal"` and, ten lines later, `import "../dock/dock-terminal"; // registers the global Ctrl+\` hotkey`. The bare import was documentation — the value import already loads the module and registers the hotkey — so the comment moved onto the merged statement rather than being deleted with the line.

## Verification

`pnpm lint` (0), `pnpm format:check`, `pnpm -r build`, `pnpm typecheck` (all 13 packages), and `pnpm test`: core 1063/1068 (5 skipped), server 1646, web 1621, cli 385, docs 53, landing 71.

One pre-existing failure, unrelated and not introduced here: `packages/desktop test/cli-link.test.ts > repairs a link left dangling by a moved or updated app` fails with `EEXIST` on `symlinkSync` after `rmSync(target, { force: true })`. Verified it fails identically on a pristine `main` checkout with these changes stashed — it looks environment-dependent (dangling symlink removal under `/tmp`), and is left for a separate PR.
