### PR TITLE
fix(server): memory files keep one order whatever locale the server runs under

### DIFF
--- a/changelog/unreleased/2026-09-04-memory-file-order-locale.md
+++ b/changelog/unreleased/2026-09-04-memory-file-order-locale.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-09-04
 - **Type:** fix
 - **Scope:** `server`
+- **PR:** [#608](https://github.com/Prism-Shadow/penguin-harness/pull/608)
 
 [中文版](2026-09-04-memory-file-order-locale.zh.md)
 

--- a/changelog/unreleased/2026-09-04-memory-file-order-locale.md
+++ b/changelog/unreleased/2026-09-04-memory-file-order-locale.md
@@ -1,0 +1,9 @@
+# Memory files keep one order whatever locale the server runs under
+
+- **Date:** 2026-09-04
+- **Type:** fix
+- **Scope:** `server`
+
+[中文版](2026-09-04-memory-file-order-locale.zh.md)
+
+The Memory service sorted a scope's topic files with `String.localeCompare` called without a locale argument, so the order followed the locale of the server process: a scope holding `testing-conventions.md` and `项目背景.md` listed them in that order on an `en_US.UTF-8` host and reversed on a `zh_CN.UTF-8` one. That order is what the Memory file list shows and what the `files` array of an exported scope document carries, so the same scope exported to two different hosts produced two different documents. The comparator now folds case and breaks ties on code units — total, identical on every host, and reproducing the order `en_US.UTF-8` already produced, so existing exports do not reorder.

--- a/changelog/unreleased/2026-09-04-memory-file-order-locale.zh.md
+++ b/changelog/unreleased/2026-09-04-memory-file-order-locale.zh.md
@@ -1,0 +1,9 @@
+# 记忆文件的顺序不再取决于服务端所在的 locale
+
+- **Date:** 2026-09-04
+- **Type:** fix
+- **Scope:** `server`
+
+[English](2026-09-04-memory-file-order-locale.md)
+
+Memory 服务此前用不带 locale 参数的 `String.localeCompare` 排序一个作用域的主题文件，顺序因而随服务端进程的 locale 而变：同时存有 `testing-conventions.md` 与 `项目背景.md` 的作用域，在 `en_US.UTF-8` 主机上按此顺序列出，在 `zh_CN.UTF-8` 主机上则相反。这个顺序既是 Memory 文件列表所呈现的，也是导出文档 `files` 数组所携带的，同一个作用域在两台主机上导出会得到两份不同的文档。现在的比较器先折叠大小写、再以码元顺序断同，全序、在任何主机上一致，且复现了 `en_US.UTF-8` 原本的顺序，已有的导出不会重排。

--- a/changelog/unreleased/2026-09-04-memory-file-order-locale.zh.md
+++ b/changelog/unreleased/2026-09-04-memory-file-order-locale.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-09-04
 - **Type:** fix
 - **Scope:** `server`
+- **PR:** [#608](https://github.com/Prism-Shadow/penguin-harness/pull/608)
 
 [English](2026-09-04-memory-file-order-locale.md)
 

--- a/packages/server/src/services/memory-service.ts
+++ b/packages/server/src/services/memory-service.ts
@@ -116,6 +116,22 @@ export function isTopicFileName(name: string): boolean {
 }
 
 /**
+ * Orders topic file names identically on every host. `localeCompare` is deliberately not used
+ * here: with no locale argument it follows the server's own locale, so the same scope listed its
+ * files one way under `en_US.UTF-8` and another under `zh_CN.UTF-8` — and that order is what an
+ * export document carries. Case-folded first, so `Alpha.md` still sorts between `a.md` and
+ * `beta.md` rather than jumping ahead of both as raw code units would; ties then fall back to
+ * code units so the order is total. `toLowerCase`, never `toLocaleLowerCase` — the locale-aware
+ * one would put the dependency straight back.
+ */
+function compareTopicFileNames(a: string, b: string): number {
+  const foldedA = a.toLowerCase();
+  const foldedB = b.toLowerCase();
+  if (foldedA !== foldedB) return foldedA < foldedB ? -1 : 1;
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/**
  * Validates a transfer document on its way to the server's disk.
  *
  * Everything here is untrusted: the document may have been hand-written, produced by another
@@ -301,7 +317,7 @@ export class MemoryService {
       return (await fs.readdir(dir, { withFileTypes: true }))
         .filter((e) => e.isFile() && isTopicFileName(e.name))
         .map((e) => e.name)
-        .sort((a, b) => a.localeCompare(b));
+        .sort(compareTopicFileNames);
     } catch {
       return [];
     }


### PR DESCRIPTION
## What

`MemoryService.topicFileNames` sorted a Memory scope's topic files with `String.localeCompare` called without a locale argument, so the order followed the locale of the server process. A scope holding `testing-conventions.md` and `项目背景.md` listed them in that order under `en_US.UTF-8` and reversed under `zh_CN.UTF-8`.

That order is not internal. `topicFileNames` feeds the Memory file list and the `files` array of an exported scope document, so the same scope exported from two hosts produced two different documents — and anything downstream comparing those documents saw a spurious difference.

The comparator now folds case and breaks ties on code units.

```ts
function compareTopicFileNames(a: string, b: string): number {
  const foldedA = a.toLowerCase();
  const foldedB = b.toLowerCase();
  if (foldedA !== foldedB) return foldedA < foldedB ? -1 : 1;
  return a < b ? -1 : a > b ? 1 : 0;
}
```

## Why this comparator

Determinism alone was not the whole requirement — the order also had to stay where it is, so no existing export visibly reorders.

A plain code-unit sort is deterministic but rearranges ASCII: uppercase sorts below `_` in ASCII, so `Alpha.md` and `README.md` jump ahead of `_x.md`, `a.md` and `beta.md`. Folding case first keeps the existing arrangement; the code-unit fallback keeps the order total, so names differing only in case still have one fixed position rather than being left to sort stability.

On the sample `_x.md a.md Alpha.md beta.md README.md testing-conventions.md 项目背景.md`, the new comparator reproduces the `en_US.UTF-8` output exactly, and produces that same output under `zh_CN.UTF-8`, where `localeCompare` had moved `项目背景.md` to second place.

`toLowerCase`, not `toLocaleLowerCase`: the locale-aware form would reintroduce the dependency being removed. The comment on the helper says so, so the call does not get "tidied" back to `localeCompare` later.

## Scope

One call site. About a dozen other `localeCompare` sorts in `packages/server/src` carry the same latent dependence — `http/routes/dirs.ts:43`, `services/directory-skills.ts:204`, `services/benchmark-service.ts:206` and `:236`, `services/agent-service.ts:136`, `memory-service.ts:250`/`:253`, `trace-service.ts:1378`/`:1433`, `context-breakdown.ts:149`, `usage-service.ts:441`, `session-service.ts:212`, `workspace-files-service.ts:253`. Most order ASCII-only ids or ISO timestamps, where the practical risk is much lower, so a sweep deserves its own decision rather than riding along here.

The specs describe the export document's format (`design/specs/05-ARCHITECTURE.md`, `08-CHANGELOG.md`) but never its file ordering, so no spec change accompanies this.

## Verification

Run on the `zh_CN.UTF-8` host, with no `LANG`/`LC_ALL` pinned — pinning would hide the defect.

`packages/server`, same tree, comparator swapped:

| | Test Files | Tests |
| --- | --- | --- |
| before (`localeCompare`) | 1 failed \| 113 passed (114) | 1 failed \| 1644 passed (1645) |
| after | 114 passed (114) | 1645 passed (1645) |

The one failure before was `test/memory.test.ts > memory scope export/import > exports every topic file plus the scope's index, as one attachment` — `expected [ '项目背景.md', 'testing-conventions.md' ] to deeply equal [ 'testing-conventions.md', '项目背景.md' ]`. That expectation is unchanged by this PR; it simply stopped depending on where the server runs. No new test was added: the existing one becoming locale-independent is the proof.

Full chain on the same host: `pnpm -r build` clean, `pnpm typecheck` clean, `pnpm format:check` clean, and `pnpm -r test` — core 1063 passed / 5 skipped, server 1645, web 1621, cli 385, docs 53, landing 71.

`packages/desktop` fails one test, `test/cli-link.test.ts > syncSymlink (the macOS form) > repairs a link left dangling by a moved or updated app` (179 passed / 180). It is pre-existing and unrelated: it reproduces on this tree with this PR's source change reverted, and this PR touches no desktop code. Root cause, for whoever picks it up: on Node v24.12.0 `fs.rmSync(path, { force: true })` leaves a **dangling** symlink in place rather than unlinking it, so `writeSymlink` in `packages/desktop/src/cli-link.ts:119` then throws `EEXIST` from `fs.symlinkSync`. Reproduced standalone on that Node version. Not fixed here — separate defect, separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018YR7K8nFEYgUBGVLPK4hd2
