### PR TITLE
perf(web): first paint at once, one round trip to the sidebar, KaTeX and pages off the entry

### DIFF
--- a/changelog/unreleased/2026-09-07-web-first-paint.md
+++ b/changelog/unreleased/2026-09-07-web-first-paint.md
@@ -1,0 +1,18 @@
+# The Web App paints its frame at once and reaches the sidebar in one round trip
+
+- **Date:** 2026-09-07
+- **Type:** fix
+- **Scope:** `web`
+
+[中文版](2026-09-07-web-first-paint.zh.md)
+
+A cold load of the Web App on a phone used to show a blank page until the whole entry bundle had been fetched and parsed, then kept it blank while four dependent requests ran one after another — `/api/me`, the Project list, that Project's Agents, and only then the sidebar's Sessions — with KaTeX, the largest single dependency, parsed on every load whether or not a formula was ever shown. This change shortens each of those stages.
+
+## Details
+
+- `index.html` now carries the empty frame of the app — the sidebar on wide screens, the top bar on narrow ones, in the persisted theme and sidebar width — as static markup with inline CSS, so the first paint has the app's shape before the bundle arrives. The route guard renders the same frame (`BootSkeleton`) while `/api/me` is in flight instead of nothing.
+- The first round trip leaves before React mounts: `lib/boot-prefetch.ts` asks for the user, the Project list and the remembered Project's Agents in the same instant as the install-scope probe, and the auth and Project providers take those in-flight answers once instead of issuing their own. A later reload goes to the network as before.
+- KaTeX moved out of the entry into a chunk of its own (`lib/markdown-katex.ts`, stylesheet included), loaded by `import()` the first time a settled body contains a math delimiter. Until it lands, once per page, a formula shows its own TeX source — exactly what a streaming body shows already — and typesets on the re-render the load triggers. Every Markdown surface now renders through one `<Markdown>` component, which is where that decision is made.
+- Every page but the chat is a lazy route chunk: agents, agent settings, plugins, models, usage, benchmark and the terminal are fetched the first time they are opened.
+
+Measured on this change's own build, before and after: the entry script went from 1,662 kB (499 kB gzip) to 1,176 kB (363 kB gzip), the entry stylesheet from 123 kB (24 kB gzip) to 96 kB (17 kB gzip); KaTeX is a 270 kB (81 kB gzip) chunk that a page without math never requests.

--- a/changelog/unreleased/2026-09-07-web-first-paint.md
+++ b/changelog/unreleased/2026-09-07-web-first-paint.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-09-07
 - **Type:** fix
 - **Scope:** `web`
+- **PR:** [#640](https://github.com/Prism-Shadow/penguin-harness/pull/640)
 
 [中文版](2026-09-07-web-first-paint.zh.md)
 

--- a/changelog/unreleased/2026-09-07-web-first-paint.zh.md
+++ b/changelog/unreleased/2026-09-07-web-first-paint.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-09-07
 - **Type:** fix
 - **Scope:** `web`
+- **PR:** [#640](https://github.com/Prism-Shadow/penguin-harness/pull/640)
 
 [English](2026-09-07-web-first-paint.md)
 

--- a/changelog/unreleased/2026-09-07-web-first-paint.zh.md
+++ b/changelog/unreleased/2026-09-07-web-first-paint.zh.md
@@ -1,0 +1,18 @@
+# Web App 首屏立刻画出框架，一个往返就到侧栏
+
+- **Date:** 2026-09-07
+- **Type:** fix
+- **Scope:** `web`
+
+[English](2026-09-07-web-first-paint.md)
+
+此前在手机上冷启动 Web App，要等整个入口 bundle 下载并解析完才有内容，之后又要在白屏里串行跑完四个相互依赖的请求——`/api/me`、Project 列表、该 Project 的 Agent 列表、最后才是侧栏的 Session 列表；而最大的一个依赖 KaTeX 每次加载都要解析，无论页面上有没有公式。本次改动缩短了其中每一段。
+
+## 细节
+
+- `index.html` 现在以静态标记加内联 CSS 直接带上应用的空框架——宽屏的侧栏、窄屏的顶栏，并采用已持久化的主题与侧栏宽度——于是 bundle 到达之前首屏就已经有了应用的形状。路由守卫在 `/api/me` 未返回期间渲染同一个框架（`BootSkeleton`），而不再渲染空白。
+- 第一个往返在 React 挂载之前就发出：`lib/boot-prefetch.ts` 与 install-scope 探测同时请求用户、Project 列表以及记住的 Project 的 Agent 列表，auth 与 Project 两个 provider 各取用一次这些在途的答案，而不再自己发起。之后的重新加载仍照旧走网络。
+- KaTeX 从入口移入独立的 chunk（`lib/markdown-katex.ts`，连同样式表），在某个已收束的正文首次含有数学分隔符时通过 `import()` 加载。加载落地之前（每次页面加载一次），公式显示自己的 TeX 源码——与流式输出中的正文本来就一样——并在加载触发的重渲染中排版。所有 Markdown 界面现在都经由同一个 `<Markdown>` 组件渲染，这个决定就在那里做出。
+- 除聊天页外的每个页面都是懒加载的路由 chunk：agents、agent 设置、plugins、models、usage、benchmark 与终端在首次打开时才获取。
+
+以本次改动自身的构建做前后对比：入口脚本从 1,662 kB（gzip 499 kB）降到 1,176 kB（gzip 363 kB），入口样式表从 123 kB（gzip 24 kB）降到 96 kB（gzip 17 kB）；KaTeX 成为一个 270 kB（gzip 81 kB）的 chunk，没有公式的页面从不请求它。

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -7,9 +7,90 @@
     <meta name="theme-color" content="#030712" media="(prefers-color-scheme: dark)" />
     <link rel="icon" type="image/svg+xml" href="/penguin-logo.svg" />
     <title>PenguinHarness</title>
+    <!-- The theme, before anything paints: the same decision state/theme.tsx makes after the
+         mount (its stored mode, else the system's), made here so neither the boot frame below
+         nor the first React frame flashes the wrong scheme. -->
+    <script>
+      (function () {
+        var mode = null;
+        try {
+          mode = localStorage.getItem("penguin.theme");
+        } catch (e) {}
+        var dark =
+          mode === "dark" ||
+          (mode !== "light" && window.matchMedia("(prefers-color-scheme: dark)").matches);
+        if (dark) document.documentElement.classList.add("dark");
+      })();
+    </script>
+    <!-- The frame of the app, painted from this HTML alone while the bundle is still on its
+         way: a sidebar on wide screens, a top bar on narrow ones, nothing in either. React
+         replaces it with components/layout/boot-skeleton.tsx (the same frame) on mount and with
+         the real layout once the user is known; the three must agree on these dimensions. The
+         colours are Tailwind's gray-50/200/800/900/950 and white, as AppLayout uses them. -->
+    <style>
+      .boot {
+        display: flex;
+        height: 100vh;
+        height: 100dvh;
+        background: #fff;
+      }
+      .boot-aside {
+        display: none;
+        flex-shrink: 0;
+        width: 16rem;
+        border-right: 1px solid #e5e7eb;
+        background: #f9fafb;
+      }
+      .boot-aside.narrow {
+        width: 3rem;
+      }
+      .boot-main {
+        flex: 1;
+        min-width: 0;
+      }
+      .boot-bar {
+        height: 3rem;
+        border-bottom: 1px solid #e5e7eb;
+      }
+      @media (min-width: 768px) {
+        .boot-aside {
+          display: block;
+        }
+        .boot-bar {
+          display: none;
+        }
+      }
+      @media (min-width: 1024px) {
+        .boot-aside:not(.narrow) {
+          width: 18rem;
+        }
+      }
+      .dark .boot {
+        background: #030712;
+      }
+      .dark .boot-aside {
+        border-color: #1f2937;
+        background: #111827;
+      }
+      .dark .boot-bar {
+        border-color: #1f2937;
+      }
+    </style>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <div class="boot" aria-hidden="true">
+        <div class="boot-aside" id="boot-aside"></div>
+        <div class="boot-main"><div class="boot-bar"></div></div>
+      </div>
+    </div>
+    <script>
+      // The persisted sidebar collapse, so the frame is the width the layout will take.
+      try {
+        if (localStorage.getItem("penguin.sidebarCollapsed") === "1")
+          document.getElementById("boot-aside").className += " narrow";
+      } catch (e) {}
+    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/packages/web/src/components/layout/boot-skeleton.tsx
+++ b/packages/web/src/components/layout/boot-skeleton.tsx
@@ -1,0 +1,35 @@
+/**
+ * What the screen shows while the app is not yet able to: the frame of AppLayout — a sidebar
+ * on wide screens, a top bar on narrow ones — with nothing in it.
+ *
+ * It exists twice on purpose. index.html carries the same frame as static markup with its own
+ * inline CSS, so the very first paint (before the bundle has even been fetched) already has the
+ * shape of the app; React then replaces it with this component while `/api/me` is in flight
+ * (RequireAuth), and with the real layout once the user is known. The two copies must agree on
+ * the frame — widths, the bar's height, the colours — or the boot visibly jumps: keep the
+ * dimensions here in step with index.html and AppLayout when any of them changes.
+ *
+ * Sidebar width follows the persisted collapse preference the layout itself reads, so a user
+ * who keeps the rail narrow does not watch a wide panel snap shut on every boot.
+ */
+export function BootSkeleton() {
+  let collapsed = false;
+  try {
+    collapsed = localStorage.getItem("penguin.sidebarCollapsed") === "1";
+  } catch {
+    // Site data blocked: the default width is as good a guess as any.
+  }
+  return (
+    <div className="flex h-full" aria-hidden>
+      <aside
+        className={`hidden shrink-0 border-r border-gray-200 bg-gray-50 md:block dark:border-gray-800 dark:bg-gray-900 ${
+          collapsed ? "w-12" : "w-64 lg:w-72"
+        }`}
+      />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <header className="h-12 shrink-0 border-b border-gray-200 bg-white md:hidden dark:border-gray-800 dark:bg-gray-950" />
+        <main className="min-h-0 min-w-0 flex-1" />
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/ui/markdown.tsx
+++ b/packages/web/src/components/ui/markdown.tsx
@@ -1,0 +1,36 @@
+/**
+ * The one Markdown renderer: every surface that shows Markdown — a chat message, a Trace event, a
+ * benchmark case, a Workspace file preview — goes through here, so they cannot drift apart on the
+ * pipeline (lib/markdown-plugins.ts) and none of them has to know that the math stage is loaded on
+ * demand. `useRehypeStage` is called here and nowhere else: a hook cannot sit inside the `.map`
+ * a Trace row renders its parts from, but a component can.
+ *
+ * `streaming` is the chat renderer's flag — the body is still receiving deltas, so the expensive
+ * stage stays off until it settles (see NO_REHYPE_PLUGINS). `components` is react-markdown's own
+ * element map, passed through as-is; a caller that builds one must build it once at module scope
+ * (a fresh map per render is a new element type per commit, which remounts every code block).
+ */
+import ReactMarkdown from "react-markdown";
+import type { Components } from "react-markdown";
+import { REMARK_PLUGINS, useRehypeStage } from "../../lib/markdown-plugins";
+
+export function Markdown({
+  text,
+  streaming = false,
+  components,
+}: {
+  text: string;
+  streaming?: boolean;
+  components?: Components;
+}) {
+  const rehypePlugins = useRehypeStage(text, streaming);
+  return (
+    <ReactMarkdown
+      remarkPlugins={REMARK_PLUGINS}
+      rehypePlugins={rehypePlugins}
+      components={components}
+    >
+      {text}
+    </ReactMarkdown>
+  );
+}

--- a/packages/web/src/features/benchmark/benchmark-case-browser.tsx
+++ b/packages/web/src/features/benchmark/benchmark-case-browser.tsx
@@ -5,9 +5,8 @@ import type {
   WorkspaceFileEntry,
   WorkspaceFilesResponse,
 } from "@prismshadow/penguin-server/api";
-import ReactMarkdown from "react-markdown";
 import type { Components } from "react-markdown";
-import { REHYPE_PLUGINS, REMARK_PLUGINS } from "../../lib/markdown-plugins";
+import { Markdown } from "../../components/ui/markdown";
 import * as api from "../../api/endpoints";
 import { apiErrorText } from "../../lib/api-error";
 import { joinWorkspacePath } from "../../lib/file-path";
@@ -455,13 +454,7 @@ export function BenchmarkCaseBrowser({ projectId, agentId, benchmarkId, caseSumm
           ) : preview.kind === "md" ? (
             <>
               <div className="md-body text-sm text-gray-800 dark:text-gray-100">
-                <ReactMarkdown
-                  remarkPlugins={REMARK_PLUGINS}
-                  rehypePlugins={REHYPE_PLUGINS}
-                  components={markdownComponents}
-                >
-                  {preview.content ?? ""}
-                </ReactMarkdown>
+                <Markdown text={preview.content ?? ""} components={markdownComponents} />
               </div>
               {preview.truncated && (
                 <p className="mt-2 text-xs text-gray-400">{S.files.previewTruncated}</p>

--- a/packages/web/src/features/chat/md.tsx
+++ b/packages/web/src/features/chat/md.tsx
@@ -12,15 +12,16 @@
  * re-render (new string instance, streaming=false) highlights each block exactly once.
  * Inline code keeps the default rendering (`.md-body code` styling).
  *
- * KaTeX is held back the same way, for the same reason: `streaming` swaps the rehype stage
- * out, so a formula shows its own TeX source until the message settles and is typeset once
- * (see NO_REHYPE_PLUGINS in lib/markdown-plugins.ts for the measurements).
+ * KaTeX is held back the same way, for the same reason: `streaming` keeps the rehype stage
+ * off, so a formula shows its own TeX source until the message settles and is typeset once
+ * (see NO_REHYPE_PLUGINS in lib/markdown-plugins.ts for the measurements). The stage itself
+ * is the shared Markdown component's business (components/ui/markdown.tsx) — it is loaded
+ * on demand, and this file only says whether the body has settled.
  */
 import { isValidElement, memo } from "react";
 import type { ComponentPropsWithoutRef, ReactNode } from "react";
-import ReactMarkdown from "react-markdown";
 import type { Components, ExtraProps } from "react-markdown";
-import { NO_REHYPE_PLUGINS, REHYPE_PLUGINS, REMARK_PLUGINS } from "../../lib/markdown-plugins";
+import { Markdown } from "../../components/ui/markdown";
 import { CodeBlock } from "./code-block";
 
 /** Flatten a react-markdown code element's children to plain text (string or string array in practice). */
@@ -85,7 +86,7 @@ function MdLink({
  * streams, including for blocks that closed long ago. `streaming` is the only thing the adapter
  * closes over, so one frozen map per value is enough; the single flip between them happens on
  * the settle render, which re-parses the message anyway — the same render the rehype stage
- * flips on. The `a` adapter closes over nothing, so both maps share the one `MdLink` reference.
+ * comes on for. The `a` adapter closes over nothing, so both maps share the one `MdLink` reference.
  */
 const STREAMING_COMPONENTS: Components = {
   pre: (props) => <MdPre streaming>{props.children}</MdPre>,
@@ -104,12 +105,10 @@ export const Md = memo(function Md({
   streaming?: boolean;
 }) {
   return (
-    <ReactMarkdown
-      remarkPlugins={REMARK_PLUGINS}
-      rehypePlugins={streaming ? NO_REHYPE_PLUGINS : REHYPE_PLUGINS}
+    <Markdown
+      text={text}
+      streaming={streaming}
       components={streaming ? STREAMING_COMPONENTS : SETTLED_COMPONENTS}
-    >
-      {text}
-    </ReactMarkdown>
+    />
   );
 });

--- a/packages/web/src/features/chat/workspace-browser.tsx
+++ b/packages/web/src/features/chat/workspace-browser.tsx
@@ -14,8 +14,7 @@
  */
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { ChangeEvent } from "react";
-import ReactMarkdown from "react-markdown";
-import { REHYPE_PLUGINS, REMARK_PLUGINS } from "../../lib/markdown-plugins";
+import { Markdown } from "../../components/ui/markdown";
 import type { SessionInfo, WorkspaceFilesResponse } from "@prismshadow/penguin-server/api";
 import * as api from "../../api/endpoints";
 import { ApiError } from "../../api/client";
@@ -613,9 +612,8 @@ export function WorkspaceBrowser({
             // (ReactMarkdown outputs pure static HTML with no script execution surface, so no iframe sandbox is needed).
             <>
               <div className="md-body text-base leading-relaxed text-gray-800 dark:text-gray-100">
-                <ReactMarkdown
-                  remarkPlugins={REMARK_PLUGINS}
-                  rehypePlugins={REHYPE_PLUGINS}
+                <Markdown
+                  text={preview.content ?? ""}
                   components={{
                     // Relative images are resolved against the md file's directory into the file API (otherwise resolving against the app's origin would always 404).
                     // `v` is the read nonce, not a cache-buster for its own sake: a
@@ -664,9 +662,7 @@ export function WorkspaceBrowser({
                       );
                     },
                   }}
-                >
-                  {preview.content ?? ""}
-                </ReactMarkdown>
+                />
               </div>
               {preview.truncated && (
                 <p className="mt-1 text-xs text-gray-400">… {S.files.previewTruncated}</p>

--- a/packages/web/src/features/traces/trace-event-row.tsx
+++ b/packages/web/src/features/traces/trace-event-row.tsx
@@ -13,8 +13,7 @@
  */
 import { Fragment, useState } from "react";
 import { HOOK_ICON } from "../../components/ui/icons";
-import ReactMarkdown from "react-markdown";
-import { REHYPE_PLUGINS, REMARK_PLUGINS } from "../../lib/markdown-plugins";
+import { Markdown } from "../../components/ui/markdown";
 import { S } from "../../lib/strings";
 import type { OmniMessage } from "@prismshadow/penguin-core/omnimessage";
 import { formatTime, humanizeTokens } from "../../lib/format";
@@ -237,9 +236,7 @@ function SessionMetaBody({ p }: { p: Record<string, unknown> }) {
         <details>
           <summary className={summaryClass}>{S.traces.systemPrompt}</summary>
           <div className="md-body mt-1.5 max-h-96 overflow-auto rounded bg-gray-100 px-2.5 py-2 text-sm leading-relaxed text-gray-700 dark:bg-gray-800/70 dark:text-gray-300">
-            <ReactMarkdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={REHYPE_PLUGINS}>
-              {prompt}
-            </ReactMarkdown>
+            <Markdown text={prompt} />
           </div>
         </details>
       )}
@@ -342,9 +339,7 @@ function EventBody({ msg }: { msg: OmniMessage }) {
       if (!md.trim()) return <p className="text-xs text-gray-400">—</p>;
       return (
         <div className="md-body text-sm leading-relaxed text-gray-700 dark:text-gray-300">
-          <ReactMarkdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={REHYPE_PLUGINS}>
-            {md}
-          </ReactMarkdown>
+          <Markdown text={md} />
         </div>
       );
     }

--- a/packages/web/src/lib/boot-prefetch.ts
+++ b/packages/web/src/lib/boot-prefetch.ts
@@ -1,0 +1,88 @@
+/**
+ * The boot's first round trip, started before React mounts.
+ *
+ * Left to the component tree, the first screen is a waterfall of four dependent requests —
+ * `/api/me` (the auth provider), then the Project list (the Project provider, which only mounts
+ * once the user is known), then that Project's Agents, and only then the sidebar's Sessions —
+ * each waiting on the one before, each a full round trip, and none of them able to start until
+ * the whole bundle has been parsed and the tree has rendered once. On a phone across a tunnel
+ * that is the difference between "opens" and "hangs".
+ *
+ * None of the first three depend on each other's ANSWER, only on the browser's memory of what
+ * was open last: the user, the Project list, and the Agents of the remembered Project can all be
+ * asked for in the same instant as the install-scope probe (main.tsx). So they are, and the
+ * providers then TAKE the in-flight promise instead of issuing their own — once each: a later
+ * reload (a Project switch, a manual refresh) goes to the network as before, and a taken promise
+ * is never handed out twice.
+ *
+ * The prefetch is a hint, not a contract. A remembered Project that no longer exists makes its
+ * Agents request 404 — the provider then sees the rejection exactly as it would see its own
+ * request fail, and the Project list's answer picks the real Project. A page opened signed out
+ * gets 401s — the same 401 `/api/me` yields, and the same handler (the auth provider's) clears
+ * the user. Every promise carries a no-op rejection handler so one nobody takes cannot surface
+ * as an unhandled rejection.
+ */
+import type { AgentsResponse, MeResponse, ProjectsResponse } from "@prismshadow/penguin-server/api";
+import * as api from "../api/endpoints";
+import { rememberedProjectId } from "./last-selection";
+
+interface Prefetched {
+  me: Promise<MeResponse> | null;
+  projects: Promise<ProjectsResponse> | null;
+  agents: { projectId: string; answer: Promise<AgentsResponse> } | null;
+}
+
+const held: Prefetched = { me: null, projects: null, agents: null };
+
+const noop = (): void => {};
+
+/**
+ * Starts the round trip. `signedOut` skips everything but `/api/me`: the login page has no use
+ * for a Project list, and asking would only be three 401s where one will do.
+ */
+export function prefetchBoot(opts: { signedOut?: boolean } = {}): void {
+  if (held.me !== null) return; // Already started: main.tsx calls this once.
+  held.me = api.getMe();
+  held.me.catch(noop);
+  if (opts.signedOut) return;
+  held.projects = api.listProjects();
+  held.projects.catch(noop);
+  const projectId = rememberedProjectId();
+  if (projectId !== null) {
+    const answer = api.listAgents(projectId);
+    answer.catch(noop);
+    held.agents = { projectId, answer };
+  }
+}
+
+/** The in-flight `/api/me`, once; null when there is none (not prefetched, or already taken). */
+export function takePrefetchedMe(): Promise<MeResponse> | null {
+  const answer = held.me;
+  held.me = null;
+  return answer;
+}
+
+/** The in-flight Project list, once. */
+export function takePrefetchedProjects(): Promise<ProjectsResponse> | null {
+  const answer = held.projects;
+  held.projects = null;
+  return answer;
+}
+
+/**
+ * The in-flight Agent list, once, and only for the Project it was asked for: a store that landed
+ * on a different Project (the remembered one is gone) must ask for its own.
+ */
+export function takePrefetchedAgents(projectId: string): Promise<AgentsResponse> | null {
+  const entry = held.agents;
+  if (entry === null || entry.projectId !== projectId) return null;
+  held.agents = null;
+  return entry.answer;
+}
+
+/** Test seam: forgets everything held, so each case starts from a cold boot. */
+export function resetBootPrefetch(): void {
+  held.me = null;
+  held.projects = null;
+  held.agents = null;
+}

--- a/packages/web/src/lib/last-selection.ts
+++ b/packages/web/src/lib/last-selection.ts
@@ -1,0 +1,35 @@
+/**
+ * The Project and Agent the user last had open, as this browser remembers them. Read by the
+ * Project store to restore the selection, and by the boot prefetch (boot-prefetch.ts) to ask for
+ * that Agent's list before the store even exists — which is why the keys live here and not in the
+ * store module: the store consumes the prefetch, so the prefetch cannot import the store.
+ *
+ * Every read is guarded: touching `localStorage` throws when site data is blocked, and a boot
+ * that cannot remember is still a boot.
+ */
+const PROJECT_KEY = "penguin.lastProjectId";
+const agentKey = (projectId: string) => `penguin.lastAgentId.${projectId}`;
+
+function read(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+export function rememberedProjectId(): string | null {
+  return read(PROJECT_KEY);
+}
+
+export function rememberProjectId(projectId: string): void {
+  localStorage.setItem(PROJECT_KEY, projectId);
+}
+
+export function rememberedAgentId(projectId: string): string | null {
+  return read(agentKey(projectId));
+}
+
+export function rememberAgentId(projectId: string, agentId: string): void {
+  localStorage.setItem(agentKey(projectId), agentId);
+}

--- a/packages/web/src/lib/markdown-katex.ts
+++ b/packages/web/src/lib/markdown-katex.ts
@@ -1,0 +1,57 @@
+/**
+ * The KaTeX half of the Markdown pipeline, in a chunk of its own.
+ *
+ * KaTeX is the single largest thing the entry bundle used to carry, and most page loads never
+ * typeset a formula: a sidebar, a settings page, a chat with no math. So this module is reached
+ * only by `import()` — from `loadKatexStage` in markdown-plugins.ts, the first time a settled
+ * body actually contains a math delimiter — and the entry stays free of it. The stylesheet rides
+ * along: Vite emits it as this chunk's own CSS and loads it before the chunk resolves, so no
+ * formula renders unstyled. It lands AFTER styles.css in the cascade, which is fine because every
+ * rule styles.css has on KaTeX markup outranks KaTeX's own on specificity, not on order (see the
+ * KaTeX section there); the woff2 faces are the same local assets as before (vite.config.ts).
+ *
+ * Nothing but markdown-plugins.ts and its test may import this module statically: a static
+ * import anywhere on the entry's graph puts KaTeX back into the entry.
+ */
+import rehypeKatex from "rehype-katex";
+import type { Options } from "react-markdown";
+import "katex/dist/katex.min.css";
+
+/**
+ * KaTeX settings for untrusted input, because that is what this renders: model output, and files
+ * out of a Workspace.
+ *
+ * - `strict: "ignore"` — KaTeX's default warns to the console for every LaTeX-incompatible but
+ *   renderable construct, and sloppy `\text` around CJK trips it per character. The warnings are
+ *   not actionable by anyone reading a chat transcript, and the render is identical either way.
+ * - `errorColor: "currentColor"` — the default `#cc0000` is an inline style, so it cannot adapt to
+ *   the dark theme, where it lands under 4:1 against a black background. Failed expressions instead
+ *   render as their own source in the body colour; `.katex-error` in styles.css marks them with a
+ *   dotted underline and keeps KaTeX's parse error in the `title` tooltip.
+ * - `trust: false` (KaTeX's default, restated because it is a boundary) — leaves `\href`, `\url`
+ *   and `\includegraphics` inert, so a formula cannot smuggle in a link or an image request.
+ * - `maxSize` — caps the em value any sizing command may claim. KaTeX defaults to Infinity, so
+ *   `\rule{9999em}{9999em}` is a black square the size of the viewport many times over; 5em is
+ *   80px at a 16px root, which a message body absorbs the way it absorbs an emoji. Every sizing
+ *   command a real formula uses — a `\rule` for a fraction bar, a `\raisebox`, an array row gap,
+ *   `\hspace{1cm}` — is well under it.
+ *
+ * `throwOnError` is *not* here, and cannot be: `rehype-katex` omits it from its options type
+ * because it owns that behaviour. It renders once strictly, and on any error re-renders with
+ * `throwOnError: false`, falling back to a `.katex-error` span holding the original source. That is
+ * exactly the required degradation — a malformed expression shows its own text instead of taking
+ * the message down with it — so there is nothing to override.
+ */
+const KATEX_OPTIONS = {
+  strict: "ignore",
+  errorColor: "currentColor",
+  trust: false,
+  maxSize: 5,
+} as const;
+
+/**
+ * The rehype (mdast -> hast) stage. `rehype-katex` turns every element the remark stage classed
+ * `math-inline` / `math-display` into KaTeX's own markup, replacing it outright — which is also why
+ * a `$$…$$` block never reaches the chat renderer's `<pre>` override and never becomes a CodeBlock.
+ */
+export const REHYPE_PLUGINS: NonNullable<Options["rehypePlugins"]> = [[rehypeKatex, KATEX_OPTIONS]];

--- a/packages/web/src/lib/markdown-plugins.ts
+++ b/packages/web/src/lib/markdown-plugins.ts
@@ -32,10 +32,21 @@
  * direction is that someone writing `$x^2$` sees `$x^2$` — the source, legible, and re-typable as
  * `\(x^2\)`. Corrupting prose that was already correct is the worse trade, so the dollar pair is
  * reserved for `$$…$$`, which no shell variable or price produces by accident.
+ *
+ * ## The rehype stage is loaded on demand
+ *
+ * The remark stage is small and always here. The rehype stage is KaTeX (markdown-katex.ts), which
+ * is loaded by `import()` the first time a settled body contains a math delimiter, and never for
+ * a page that shows no formula — it is a quarter of the entry bundle otherwise, paid on every
+ * cold load by the phone that will only ever read the sidebar. Until it arrives (once per page
+ * load), a body with math renders through the empty stage, which is exactly what a STREAMING body
+ * renders through already: the formula shows its own TeX source, and typesets on the re-render
+ * the load triggers. `useRehypeStage` is that decision as a hook; `<Markdown>`
+ * (components/ui/markdown.tsx) is the one place it is called.
  */
+import { useEffect, useSyncExternalStore } from "react";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
-import rehypeKatex from "rehype-katex";
 import type { Options } from "react-markdown";
 import { remarkAutolinkBoundary } from "./remark-autolink-boundary";
 import { remarkMathBrackets } from "./remark-math-brackets";
@@ -43,38 +54,7 @@ import { remarkMathDollars } from "./remark-math-dollars";
 
 /** react-markdown's own plugin-list type, taken from its props so `unified` need not be a dep. */
 type PluginList = NonNullable<Options["remarkPlugins"]>;
-
-/**
- * KaTeX settings for untrusted input, because that is what this renders: model output, and files
- * out of a Workspace.
- *
- * - `strict: "ignore"` — KaTeX's default warns to the console for every LaTeX-incompatible but
- *   renderable construct, and sloppy `\text` around CJK trips it per character. The warnings are
- *   not actionable by anyone reading a chat transcript, and the render is identical either way.
- * - `errorColor: "currentColor"` — the default `#cc0000` is an inline style, so it cannot adapt to
- *   the dark theme, where it lands under 4:1 against a black background. Failed expressions instead
- *   render as their own source in the body colour; `.katex-error` in styles.css marks them with a
- *   dotted underline and keeps KaTeX's parse error in the `title` tooltip.
- * - `trust: false` (KaTeX's default, restated because it is a boundary) — leaves `\href`, `\url`
- *   and `\includegraphics` inert, so a formula cannot smuggle in a link or an image request.
- * - `maxSize` — caps the em value any sizing command may claim. KaTeX defaults to Infinity, so
- *   `\rule{9999em}{9999em}` is a black square the size of the viewport many times over; 5em is
- *   80px at a 16px root, which a message body absorbs the way it absorbs an emoji. Every sizing
- *   command a real formula uses — a `\rule` for a fraction bar, a `\raisebox`, an array row gap,
- *   `\hspace{1cm}` — is well under it.
- *
- * `throwOnError` is *not* here, and cannot be: `rehype-katex` omits it from its options type
- * because it owns that behaviour. It renders once strictly, and on any error re-renders with
- * `throwOnError: false`, falling back to a `.katex-error` span holding the original source. That is
- * exactly the required degradation — a malformed expression shows its own text instead of taking
- * the message down with it — so there is nothing to override.
- */
-const KATEX_OPTIONS = {
-  strict: "ignore",
-  errorColor: "currentColor",
-  trust: false,
-  maxSize: 5,
-} as const;
+type RehypeList = NonNullable<Options["rehypePlugins"]>;
 
 /** The remark (Markdown -> mdast) stage. */
 export const REMARK_PLUGINS: PluginList = [
@@ -86,16 +66,9 @@ export const REMARK_PLUGINS: PluginList = [
 ];
 
 /**
- * The rehype (mdast -> hast) stage. `rehype-katex` turns every element the remark stage classed
- * `math-inline` / `math-display` into KaTeX's own markup, replacing it outright — which is also why
- * a `$$…$$` block never reaches the chat renderer's `<pre>` override and never becomes a CodeBlock.
- */
-export const REHYPE_PLUGINS: NonNullable<Options["rehypePlugins"]> = [[rehypeKatex, KATEX_OPTIONS]];
-
-/**
- * The rehype stage for a message that is still streaming: nothing, so the remark stage's own
- * `math-*` elements reach the DOM carrying the TeX source, and the formula is typeset once on the
- * settle render.
+ * The rehype stage for a message that is still streaming, and for any body until KaTeX has been
+ * loaded: nothing, so the remark stage's own `math-*` elements reach the DOM carrying the TeX
+ * source, and the formula is typeset once on the settle render.
  *
  * KaTeX itself is cheap — ~0.3ms for a typical formula. What is not cheap is the rest of the stage
  * around it: `rehype-katex` re-parses KaTeX's ~2.5KB of markup per formula back into hast, and
@@ -112,4 +85,58 @@ export const REHYPE_PLUGINS: NonNullable<Options["rehypePlugins"]> = [[rehypeKat
  * 2352ms in place. This is the same trade as `highlight={!streaming}` for code blocks — the settle
  * render re-parses the message anyway, so it is where the expensive stage belongs.
  */
-export const NO_REHYPE_PLUGINS: NonNullable<Options["rehypePlugins"]> = [];
+export const NO_REHYPE_PLUGINS: RehypeList = [];
+
+/**
+ * Whether a body can contain math at all — the three delimiter openers the remark stage
+ * recognises (`$$`, `\(`, `\[`), and nothing subtler: this decides whether to fetch KaTeX, not
+ * whether to typeset, so a false positive costs one chunk load and a false negative would leave a
+ * formula as source. A lone `$` is deliberately not one (single-dollar math is off, above).
+ */
+export function hasMath(text: string): boolean {
+  return /\$\$|\\\(|\\\[/.test(text);
+}
+
+let katexStage: RehypeList | null = null;
+let katexLoad: Promise<void> | null = null;
+const listeners = new Set<() => void>();
+
+/**
+ * Starts the KaTeX load if it has not started; resolves once the stage is usable. Idempotent: one
+ * import for the page, however many bodies asked. A failed load (offline mid-session, a stale
+ * chunk after a push) leaves the stage unloaded so a later ask retries, and the bodies keep
+ * showing their TeX source rather than nothing.
+ */
+export function loadKatexStage(): Promise<void> {
+  katexLoad ??= import("./markdown-katex").then(
+    (m) => {
+      katexStage = m.REHYPE_PLUGINS;
+      for (const notify of listeners) notify();
+    },
+    () => {
+      katexLoad = null;
+    },
+  );
+  return katexLoad;
+}
+
+function subscribe(notify: () => void): () => void {
+  listeners.add(notify);
+  return () => listeners.delete(notify);
+}
+
+const readStage = (): RehypeList | null => katexStage;
+
+/**
+ * The rehype stage for one body: KaTeX once the body has settled AND contains a delimiter AND the
+ * chunk is here, the empty stage otherwise. Asking for the chunk is the effect; the store
+ * subscription is what re-renders every waiting body the moment it lands.
+ */
+export function useRehypeStage(text: string, streaming: boolean): RehypeList {
+  const loaded = useSyncExternalStore(subscribe, readStage, readStage);
+  const wanted = !streaming && hasMath(text);
+  useEffect(() => {
+    if (wanted && loaded === null) void loadKatexStage();
+  }, [wanted, loaded]);
+  return wanted && loaded !== null ? loaded : NO_REHYPE_PLUGINS;
+}

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -23,11 +23,9 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";
 import { bootInstallScope, watchInstallScope } from "./lib/install-scope";
-// KaTeX's stylesheet and its woff2 faces, resolved out of node_modules so Vite emits them as local
-// assets: the desktop app has to render math with no network, and a CDN <link> would leave every
-// formula as unstyled markup offline. Imported before styles.css so the app's own `.katex` rules
-// (CJK fallback, error state, wide-formula scrolling) come later in the cascade and win.
-import "katex/dist/katex.min.css";
+import { prefetchBoot } from "./lib/boot-prefetch";
+// KaTeX (and its stylesheet) is not imported here: lib/markdown-katex.ts is loaded on demand by
+// the first body that shows a formula, and stays out of the entry until then.
 import "./styles.css";
 
 const container = document.getElementById("root");
@@ -44,6 +42,11 @@ function mount(): void {
 // A second tab can recognise a replaced root while this one is open, leaving everything on
 // screen here pointing at a data root that is gone.
 watchInstallScope();
+
+// The first round trip — the user, the Project list, the remembered Project's Agents — leaves
+// with the install probe rather than one dependent hop at a time after the mount (see
+// lib/boot-prefetch.ts). A swept boot reloads and throws these away; that is the rare case.
+prefetchBoot({ signedOut: location.pathname === "/login" });
 
 // The rejection handler mounts too: bootInstallScope already swallows everything it can, and
 // the app must mount even if it somehow does not.

--- a/packages/web/src/router.tsx
+++ b/packages/web/src/router.tsx
@@ -2,26 +2,61 @@
  * Router (react-router v7 declarative style): /login is public; all other routes go through
  * the RequireAuth guard (redirects to /login when not authenticated) and are wrapped in
  * ProjectProvider + AppLayout.
+ *
+ * Every page but the chat is a lazy chunk. The chat is what a boot lands on, so it stays in
+ * the entry; the rest — agents, plugins, models, usage, benchmark, the terminal — is fetched
+ * the first time it is opened, and until then costs a phone nothing to parse. The fallback
+ * while a page chunk loads is nothing at all, inside the layout: the sidebar stays, the
+ * content area is blank for the one round trip, which is the same thing the page itself
+ * shows while its first request is in flight.
  */
+import { Suspense, lazy } from "react";
 import { BrowserRouter, Navigate, Route, Routes } from "react-router";
 import { useAuth } from "./state/auth";
 import { ProjectProvider } from "./state/project";
 import { SessionsProvider } from "./state/sessions";
 import { AppLayout } from "./components/layout/app-layout";
+import { BootSkeleton } from "./components/layout/boot-skeleton";
 import { LoginPage } from "./pages/login";
 import { ChatPage } from "./features/chat/chat-page";
-import { AgentsPage } from "./features/agents/agents-page";
-import { AgentSettingsPage } from "./features/agents/agent-settings-page";
-import { PluginsPage } from "./features/plugins/plugins-page";
-import { ModelsPage } from "./features/models/models-page";
-import { UsagePage } from "./features/usage/usage-page";
-import { BenchmarkPage } from "./features/benchmark/benchmark-page";
-import { TerminalPage } from "./features/terminal/terminal-page";
 
-/** Route guard: shows blank while initializing, redirects to /login when not authenticated. */
+const AgentsPage = lazy(() =>
+  import("./features/agents/agents-page").then((m) => ({ default: m.AgentsPage })),
+);
+const AgentSettingsPage = lazy(() =>
+  import("./features/agents/agent-settings-page").then((m) => ({
+    default: m.AgentSettingsPage,
+  })),
+);
+const PluginsPage = lazy(() =>
+  import("./features/plugins/plugins-page").then((m) => ({ default: m.PluginsPage })),
+);
+const ModelsPage = lazy(() =>
+  import("./features/models/models-page").then((m) => ({ default: m.ModelsPage })),
+);
+const UsagePage = lazy(() =>
+  import("./features/usage/usage-page").then((m) => ({ default: m.UsagePage })),
+);
+const BenchmarkPage = lazy(() =>
+  import("./features/benchmark/benchmark-page").then((m) => ({ default: m.BenchmarkPage })),
+);
+const TerminalPage = lazy(() =>
+  import("./features/terminal/terminal-page").then((m) => ({ default: m.TerminalPage })),
+);
+
+/** A lazy page inside the layout: blank content area until its chunk is here. */
+function page(element: React.ReactNode) {
+  return <Suspense fallback={null}>{element}</Suspense>;
+}
+
+/**
+ * Route guard: shows the app's empty frame while initializing (the same frame index.html
+ * painted before the bundle arrived, so nothing flashes), redirects to /login when not
+ * authenticated.
+ */
 function RequireAuth() {
   const { user } = useAuth();
-  if (user === undefined) return null; // GET /api/me is still initializing
+  if (user === undefined) return <BootSkeleton />; // GET /api/me is still initializing
   if (user === null) return <Navigate to="/login" replace />;
   return (
     <ProjectProvider>
@@ -58,23 +93,19 @@ export function AppRouter() {
         <Route path="/login" element={<LoginRoute />} />
         <Route
           path="/terminal"
-          element={
-            <RequireAuthBare>
-              <TerminalPage />
-            </RequireAuthBare>
-          }
+          element={<RequireAuthBare>{page(<TerminalPage />)}</RequireAuthBare>}
         />
         <Route element={<RequireAuth />}>
           <Route index element={<Navigate to="/chat" replace />} />
           <Route path="/chat/:sessionId?" element={<ChatPage />} />
-          <Route path="/agents" element={<AgentsPage />} />
-          <Route path="/agents/:agentId" element={<AgentSettingsPage />} />
-          <Route path="/plugins" element={<PluginsPage />} />
-          <Route path="/models" element={<ModelsPage />} />
+          <Route path="/agents" element={page(<AgentsPage />)} />
+          <Route path="/agents/:agentId" element={page(<AgentSettingsPage />)} />
+          <Route path="/plugins" element={page(<PluginsPage />)} />
+          <Route path="/models" element={page(<ModelsPage />)} />
           {/* Admin-only server-side (403 otherwise); the sidebar hides the row for
               everyone else, so a member only ever reaches this by typing the URL. */}
-          <Route path="/usage" element={<UsagePage />} />
-          <Route path="/benchmark" element={<BenchmarkPage />} />
+          <Route path="/usage" element={page(<UsagePage />)} />
+          <Route path="/benchmark" element={page(<BenchmarkPage />)} />
           {/* System settings and user management live in the settings dialog now (see
               SettingsDialog); their old routes fall through to the catch-all. */}
           <Route path="*" element={<Navigate to="/chat" replace />} />

--- a/packages/web/src/state/auth.tsx
+++ b/packages/web/src/state/auth.tsx
@@ -9,6 +9,7 @@ import type { ReactNode } from "react";
 import type { MeResponse, UploadLimits, UserInfo } from "@prismshadow/penguin-server/api";
 import * as api from "../api/endpoints";
 import { ApiError, setUnauthorizedHandler } from "../api/client";
+import { takePrefetchedMe } from "../lib/boot-prefetch";
 
 /**
  * Stand-in until GET /api/me answers, matching the server's shipped defaults. The window is the
@@ -83,8 +84,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     let cancelled = false;
-    api
-      .getMe()
+    // The boot started this request before the tree mounted (lib/boot-prefetch.ts); the
+    // first mount takes that answer, any later one asks afresh.
+    (takePrefetchedMe() ?? api.getMe())
       .then((res) => {
         if (cancelled) return;
         setUser(res.user);

--- a/packages/web/src/state/project.tsx
+++ b/packages/web/src/state/project.tsx
@@ -15,9 +15,13 @@ import type { AgentSummary, ProjectSummary } from "@prismshadow/penguin-server/a
 import { useStore } from "zustand/react";
 import { createStore } from "zustand/vanilla";
 import * as api from "../api/endpoints";
-
-const PROJECT_KEY = "penguin.lastProjectId";
-const agentKey = (projectId: string) => `penguin.lastAgentId.${projectId}`;
+import { takePrefetchedAgents, takePrefetchedProjects } from "../lib/boot-prefetch";
+import {
+  rememberAgentId,
+  rememberProjectId,
+  rememberedAgentId,
+  rememberedProjectId,
+} from "../lib/last-selection";
 
 interface ProjectContextValue {
   projects: ProjectSummary[];
@@ -74,8 +78,10 @@ function createProjectStore() {
     reloadProjects: async () => {
       set({ projectsLoading: true });
       try {
-        const res = await api.listProjects();
-        const wanted = get().currentProjectId ?? localStorage.getItem(PROJECT_KEY);
+        // The boot may have asked already (lib/boot-prefetch.ts): the first load takes that
+        // answer, every later reload goes to the network.
+        const res = await (takePrefetchedProjects() ?? api.listProjects());
+        const wanted = get().currentProjectId ?? rememberedProjectId();
         const found = res.projects.find((p) => p.projectId === wanted);
         set({
           projects: res.projects,
@@ -93,7 +99,7 @@ function createProjectStore() {
       // so the Agent list (and the Session list mounted under it) would disappear for good
       // (reproducible by clicking the already-current Project in the dropdown).
       if (projectId === get().currentProjectId) return;
-      localStorage.setItem(PROJECT_KEY, projectId);
+      rememberProjectId(projectId);
       // Clear the Agent list in sync: avoids a transient render with "new projectId + old
       // Project's agents" that would make downstream consumers (Sessions) fetch with the
       // wrong Agent set (which could create spurious Sessions under the new Project).
@@ -112,8 +118,9 @@ function createProjectStore() {
       if (!currentProjectId) return;
       set({ agentsLoading: true });
       try {
-        const res = await api.listAgents(currentProjectId);
-        const wanted = get().currentAgentId ?? localStorage.getItem(agentKey(currentProjectId));
+        const res = await (takePrefetchedAgents(currentProjectId) ??
+          api.listAgents(currentProjectId));
+        const wanted = get().currentAgentId ?? rememberedAgentId(currentProjectId);
         const found = res.agents.find((a) => a.agentId === wanted);
         // Default to conversing with default_agent.
         const fallback =
@@ -126,7 +133,7 @@ function createProjectStore() {
 
     setCurrentAgentId: (agentId) => {
       const currentProjectId = get().currentProjectId;
-      if (currentProjectId) localStorage.setItem(agentKey(currentProjectId), agentId);
+      if (currentProjectId) rememberAgentId(currentProjectId, agentId);
       set({ currentAgentId: agentId });
     },
   }));

--- a/packages/web/test/boot-prefetch.test.ts
+++ b/packages/web/test/boot-prefetch.test.ts
@@ -1,0 +1,91 @@
+/**
+ * The boot prefetch (lib/boot-prefetch.ts): the first round trip leaves at once, and each
+ * answer is handed out exactly once, to the consumer it was asked for.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const calls: string[] = [];
+vi.mock("../src/api/endpoints", () => ({
+  getMe: () => {
+    calls.push("me");
+    return Promise.resolve({ user: { userId: "admin" } });
+  },
+  listProjects: () => {
+    calls.push("projects");
+    return Promise.resolve({ projects: [] });
+  },
+  listAgents: (projectId: string) => {
+    calls.push(`agents:${projectId}`);
+    return projectId === "gone"
+      ? Promise.reject(new Error("404"))
+      : Promise.resolve({ agents: [] });
+  },
+}));
+
+const storage = new Map<string, string>();
+vi.stubGlobal("localStorage", {
+  getItem: (k: string) => storage.get(k) ?? null,
+  setItem: (k: string, v: string) => storage.set(k, v),
+});
+
+const prefetch = await import("../src/lib/boot-prefetch");
+
+describe("boot prefetch", () => {
+  beforeEach(() => {
+    calls.length = 0;
+    storage.clear();
+    prefetch.resetBootPrefetch();
+  });
+  afterEach(() => prefetch.resetBootPrefetch());
+
+  it("asks for the user, the Projects and the remembered Project's Agents in one go", () => {
+    storage.set("penguin.lastProjectId", "p1");
+    prefetch.prefetchBoot();
+    expect(calls).toEqual(["me", "projects", "agents:p1"]);
+  });
+
+  it("asks only for the user on the login page, and nothing for an unremembered Project", () => {
+    prefetch.prefetchBoot({ signedOut: true });
+    expect(calls).toEqual(["me"]);
+    prefetch.resetBootPrefetch();
+    calls.length = 0;
+    prefetch.prefetchBoot();
+    expect(calls).toEqual(["me", "projects"]);
+  });
+
+  it("starts once however often it is called", () => {
+    prefetch.prefetchBoot();
+    prefetch.prefetchBoot();
+    expect(calls).toEqual(["me", "projects"]);
+  });
+
+  it("hands each answer out once, then nothing", async () => {
+    storage.set("penguin.lastProjectId", "p1");
+    prefetch.prefetchBoot();
+    await expect(prefetch.takePrefetchedMe()).resolves.toEqual({ user: { userId: "admin" } });
+    expect(prefetch.takePrefetchedMe()).toBeNull();
+    await expect(prefetch.takePrefetchedProjects()).resolves.toEqual({ projects: [] });
+    expect(prefetch.takePrefetchedProjects()).toBeNull();
+    await expect(prefetch.takePrefetchedAgents("p1")).resolves.toEqual({ agents: [] });
+    expect(prefetch.takePrefetchedAgents("p1")).toBeNull();
+  });
+
+  it("keeps an Agent list for the Project it was asked for, not whichever store asks", () => {
+    storage.set("penguin.lastProjectId", "p1");
+    prefetch.prefetchBoot();
+    expect(prefetch.takePrefetchedAgents("p2")).toBeNull();
+    expect(prefetch.takePrefetchedAgents("p1")).not.toBeNull();
+  });
+
+  it("lets a failed Agent request reject to its taker, and to nobody else", async () => {
+    storage.set("penguin.lastProjectId", "gone");
+    prefetch.prefetchBoot();
+    await expect(prefetch.takePrefetchedAgents("gone")).rejects.toThrow("404");
+  });
+
+  it("holds nothing before the boot asked", () => {
+    expect(prefetch.takePrefetchedMe()).toBeNull();
+    expect(prefetch.takePrefetchedProjects()).toBeNull();
+    expect(prefetch.takePrefetchedAgents("p1")).toBeNull();
+  });
+});

--- a/packages/web/test/markdown-math.test.ts
+++ b/packages/web/test/markdown-math.test.ts
@@ -8,13 +8,14 @@
  * malformed formula does to the message around it, and that all five renderers still share one
  * plugin list.
  */
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import ReactMarkdown from "react-markdown";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { REHYPE_PLUGINS, REMARK_PLUGINS } from "../src/lib/markdown-plugins";
+import { REMARK_PLUGINS, loadKatexStage } from "../src/lib/markdown-plugins";
+import { REHYPE_PLUGINS } from "../src/lib/markdown-katex";
 import { Md } from "../src/features/chat/md";
 import { dropNonWoff2FontSources } from "../vite.config.js";
 
@@ -268,6 +269,10 @@ describe("input that arrives broken or half-written", () => {
 });
 
 describe("the chat renderer", () => {
+  // The math stage is loaded on demand in the app; a static render has no effects to ask for
+  // it, so the tests load it up front — what is under test is the settle/stream decision.
+  beforeAll(() => loadKatexStage());
+
   const renderMd = (text: string, streaming = false) =>
     renderToStaticMarkup(createElement(Md, { text, streaming }));
 
@@ -323,9 +328,11 @@ describe("the pipeline every renderer shares", () => {
     readFileSync(fileURLToPath(new URL(relative, import.meta.url)), "utf8");
 
   /**
-   * A renderer that quietly dropped the shared list would still render Markdown, so no behavioural
-   * test would fail — only its math and its URL boundaries would be wrong, on one surface. Hence a
-   * source scan: every `<ReactMarkdown` in the app has to carry both stages.
+   * A renderer that quietly dropped the shared pipeline would still render Markdown, so no
+   * behavioural test would fail — only its math and its URL boundaries would be wrong, on one
+   * surface. Hence a source scan: every surface renders through `<Markdown>`
+   * (components/ui/markdown.tsx), which is the one place `<ReactMarkdown` may appear, and the one
+   * place the on-demand math stage is asked for.
    */
   const RENDERERS = [
     "../src/features/chat/md.tsx",
@@ -333,33 +340,42 @@ describe("the pipeline every renderer shares", () => {
     "../src/features/benchmark/benchmark-case-browser.tsx",
     "../src/features/traces/trace-event-row.tsx",
   ];
+  const SHARED_RENDERER = "../src/components/ui/markdown.tsx";
 
-  /**
-   * Matched by the constant each prop names rather than by an exact string, because md.tsx picks
-   * its rehype stage by `streaming`. What is being guarded is that the name comes from the shared
-   * module, not the shape of the expression around it.
-   */
-  const SHARED = { remarkPlugins: "REMARK_PLUGINS", rehypePlugins: "REHYPE_PLUGINS" };
-
-  it("every ReactMarkdown in the app is given both shared plugin lists", () => {
+  it("every Markdown surface in the app renders through the shared component", () => {
     let total = 0;
     for (const relative of RENDERERS) {
       const source = read(relative);
-      const uses = source.split("<ReactMarkdown").length - 1;
+      expect(source, relative).not.toContain("<ReactMarkdown");
+      const uses = source.match(/<Markdown[\s/>]/g)?.length ?? 0; // the element, not a comment naming it
       expect(uses, relative).toBeGreaterThan(0);
       total += uses;
-      for (const [prop, constant] of Object.entries(SHARED)) {
-        const values = [...source.matchAll(new RegExp(`${prop}=\\{([^}]*)\\}`, "g"))];
-        expect(values.length, `${relative} ${prop}`).toBe(uses);
-        for (const [, value] of values) expect(value, `${relative} ${prop}`).toContain(constant);
-      }
-      expect(source, relative).toContain('from "../../lib/markdown-plugins"');
+      expect(source, relative).toContain('from "../../components/ui/markdown"');
     }
     expect(total).toBe(5); // md.tsx, workspace, benchmark, and two in trace-event-row
+    const shared = read(SHARED_RENDERER);
+    expect(shared.split("<ReactMarkdown").length - 1).toBe(1);
+    expect(shared).toContain("remarkPlugins={REMARK_PLUGINS}");
+    expect(shared).toContain("useRehypeStage(");
+  });
+
+  it("KaTeX reaches the entry through no static import", () => {
+    // The lazy module is the only importer of rehype-katex and the stylesheet; the shared
+    // pipeline reaches it by `import()` alone. A static import anywhere else puts the whole of
+    // KaTeX back into the entry bundle, which is what the split exists to prevent.
+    const pipeline = read("../src/lib/markdown-plugins.ts");
+    expect(pipeline).toContain('import("./markdown-katex")');
+    expect(pipeline).not.toMatch(/^import .*markdown-katex/m);
+    for (const relative of [...RENDERERS, SHARED_RENDERER, "../src/main.tsx"]) {
+      const source = read(relative);
+      expect(source, relative).not.toContain('"rehype-katex"');
+      expect(source, relative).not.toContain("katex/dist/katex.min.css");
+      expect(source, relative).not.toMatch(/^import .*markdown-katex/m);
+    }
   });
 
   it("no renderer assembles its own pipeline out of the underlying plugins", () => {
-    for (const relative of RENDERERS) {
+    for (const relative of [...RENDERERS, SHARED_RENDERER]) {
       const source = read(relative);
       // The quotes are the point: a renderer may name a plugin in a comment, not import one.
       for (const plugin of ["remark-gfm", "remark-math", "rehype-katex"]) {

--- a/packages/web/test/markdown-stage.test.ts
+++ b/packages/web/test/markdown-stage.test.ts
@@ -1,0 +1,34 @@
+/**
+ * The on-demand math stage (lib/markdown-plugins.ts): which bodies ask for KaTeX at all, and
+ * that the load is one import for the page however many ask.
+ */
+import { describe, expect, it } from "vitest";
+import { NO_REHYPE_PLUGINS, hasMath, loadKatexStage } from "../src/lib/markdown-plugins";
+
+describe("hasMath", () => {
+  it("sees the three delimiters the remark stage accepts", () => {
+    expect(hasMath("$$x^2$$")).toBe(true);
+    expect(hasMath("so \\(x\\) here")).toBe(true);
+    expect(hasMath("\\[\\int f\\]")).toBe(true);
+  });
+
+  it("does not see prose, prices or shell variables as math", () => {
+    expect(hasMath("Set $PATH and $HOME before running.")).toBe(false);
+    expect(hasMath("It costs $5 and $10 in total.")).toBe(false);
+    expect(hasMath("a (b) [c]")).toBe(false);
+    expect(hasMath("")).toBe(false);
+  });
+});
+
+describe("loadKatexStage", () => {
+  it("is one import for the page", async () => {
+    const first = loadKatexStage();
+    expect(loadKatexStage()).toBe(first);
+    await first;
+  });
+
+  it("keeps the empty stage a stable identity", () => {
+    expect(NO_REHYPE_PLUGINS).toBe(NO_REHYPE_PLUGINS);
+    expect(NO_REHYPE_PLUGINS).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

A cold load of the Web App on a phone showed a blank page until the entire entry bundle had been fetched and parsed, then kept it blank while four dependent requests ran one after another — `/api/me` → project list → that project's agents → the sidebar's sessions — and it parsed KaTeX (the largest single dependency) on every load whether or not a formula was ever shown. This PR shortens each stage:

- **Frame before the bundle.** `index.html` carries the app's empty frame (sidebar on ≥md, top bar below) as static markup with inline CSS, in the persisted theme and sidebar width, so the first paint has the app's shape before any script runs. `RequireAuth` renders the same frame (`BootSkeleton`) while `/api/me` is in flight instead of `null`.
- **One round trip, not four.** `lib/boot-prefetch.ts` starts `/api/me`, the project list and the remembered project's agents in the same instant as the install-scope probe (before the mount); the auth and project providers take those in-flight answers once, and later reloads go to the network as before. A stale remembered project simply 404s to the provider, which then follows the project list's real answer.
- **KaTeX off the entry.** `lib/markdown-katex.ts` (plugin + stylesheet) is loaded by `import()` the first time a settled body contains `$$`, `\(` or `\[`. Until it lands (once per page) a formula shows its TeX source — what a streaming body shows already — and typesets on the re-render the load triggers. All five Markdown surfaces now render through one `<Markdown>` component, the one place the stage is chosen; the source-scan test guards that KaTeX has no static importer on the entry graph.
- **Lazy pages.** Agents, agent settings, plugins, models, usage, benchmark and the terminal are route-level `lazy()` chunks; the chat stays in the entry.

Cascade note: the lazy KaTeX stylesheet now lands after `styles.css`; every rule `styles.css` has on KaTeX markup outranks KaTeX's own on specificity, not order, so nothing changes visually.

## Measurements

Same machine, `pnpm build` before and after:

| asset | before | after |
| --- | --- | --- |
| entry script | 1,662 kB (499 kB gzip) | 1,176 kB (363 kB gzip) |
| entry stylesheet | 123 kB (24 kB gzip) | 96 kB (17 kB gzip) |
| KaTeX | in the entry | 270 kB (81 kB gzip) chunk, only when math is shown |
| pages (7) | in the entry | 2–87 kB chunks, on first open |

## Verification

- `pnpm --filter @prismshadow/penguin-web typecheck` — clean
- `pnpm --filter @prismshadow/penguin-web build` — the chunk list above
- web test suite: 120 files, 1634 tests passed (includes the rewritten `markdown-math` source scan, new `boot-prefetch` and `markdown-stage` tests)
- `pnpm lint`, `pnpm format` + `pnpm format:check` — clean
