### PR TITLE
fix(web,server): the dashboard's counts unfold into the Sessions they count, and leave subagents out

### DIFF
--- a/changelog/unreleased/2026-09-07-dashboard-session-list.md
+++ b/changelog/unreleased/2026-09-07-dashboard-session-list.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-09-07
 - **Type:** fix
 - **Scope:** `web`, `server`
+- **PR:** [#643](https://github.com/Prism-Shadow/penguin-harness/pull/643)
 
 [中文版](2026-09-07-dashboard-session-list.zh.md)
 

--- a/changelog/unreleased/2026-09-07-dashboard-session-list.zh.md
+++ b/changelog/unreleased/2026-09-07-dashboard-session-list.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-09-07
 - **Type:** fix
 - **Scope:** `web`, `server`
+- **PR:** [#643](https://github.com/Prism-Shadow/penguin-harness/pull/643)
 
 [English](2026-09-07-dashboard-session-list.md)
 


### PR DESCRIPTION
Stacked on #642 (`feat/single-socket`), the machines chain's tail.

## What was wrong

The dashboard's **to review** count did not come down when the Sessions it pointed at were opened. `GET …/sessions/overview` returned every non-archived Session of the Project, and the page counted each settled unread one — including **subagent Sessions**, which the sidebar keeps in a folder closed by default. Opening every visible Session left those untouched, so the number stayed up and did not match the sidebar's dots.

## What changes

- **Server:** `SessionActivityInfo` gains `agentId`, `title?` and `source?` (`schedule` / `subagent`). The origin comes from the same registry the sidebar's folders are decided by (`sourceOf`: the in-process entry, else the trace index's registration-time facts — no file is read). `sessionsOverview` is async for that.
- **Counting:** a subagent Session is left out of both counts — it belongs to the conversation that spawned it, which is the row a person opens. Scheduled runs still count. A count of zero is not shown, on a row or in the header.
- **Lists:** tapping a row's count unfolds the Sessions behind it, one fixed line each: the sidebar's glyph, the title truncated to the line, and the id's short tail (`shortSessionId`, the same tail the subagent chips show). Tapping a line opens the conversation — it records the Session's machine (`rememberSessionMachine`) so the chat page's calls reach the machine that has it, stamps the Session read, and makes its Agent current, the way the sidebar's `openSession` does.
- Changelog entry (en + zh) under `changelog/unreleased/`.

## Screenshots

Counts only, then unfolded, then after opening one line and coming back (the count drops from 4 to 3):

<img src="https://raw.githubusercontent.com/Prism-Shadow/penguin-harness/pr-assets/dashboard-list/1-counts.png" width="300"> <img src="https://raw.githubusercontent.com/Prism-Shadow/penguin-harness/pr-assets/dashboard-list/2-expanded.png" width="300"> <img src="https://raw.githubusercontent.com/Prism-Shadow/penguin-harness/pr-assets/dashboard-list/3-after-open.png" width="300">

## Verification

- `pnpm -r build`, `pnpm typecheck`, `pnpm lint`, `pnpm format` + `pnpm format:check`: pass.
- `pnpm test`: pass, except two server suites (`hot-replace`, `sse-stream`) that hit their 10 s timeouts under the full run on a loaded shared box and pass when rerun alone; and the known local-only `cli` / `desktop` cases.
- New tests: `dashboard-view.test.ts` (subagents excluded, lists latest first with what opening needs); `session-overview.test.ts` (Agent and origin on the wire, absent keys rather than nulls).
- Manual: an isolated instance of this build, four seeded Sessions over two Workspaces, Playwright on a 420 px viewport — the screenshots above; opening a line lands on `/chat/<id>` and the count comes down on return.
