### PR TITLE
feat(web): a new chat opens the way that Workspace was last opened

### DIFF
--- a/changelog/unreleased/2026-09-07-draft-kind-per-workspace.md
+++ b/changelog/unreleased/2026-09-07-draft-kind-per-workspace.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-09-07
 - **Type:** feature
 - **Scope:** `web`
+- **PR:** [#644](https://github.com/Prism-Shadow/penguin-harness/pull/644)
 
 [中文版](2026-09-07-draft-kind-per-workspace.zh.md)
 

--- a/changelog/unreleased/2026-09-07-draft-kind-per-workspace.zh.md
+++ b/changelog/unreleased/2026-09-07-draft-kind-per-workspace.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-09-07
 - **Type:** feature
 - **Scope:** `web`
+- **PR:** [#644](https://github.com/Prism-Shadow/penguin-harness/pull/644)
 
 [English](2026-09-07-draft-kind-per-workspace.md)
 


### PR DESCRIPTION
The draft page's third pill chooses what a new chat opens: a conversation, or one of the surfaces a plugin contributes — Claude Code being the first of them. It started at "conversation" on every visit, so a repository that is only ever driven through Claude Code cost the same two picks every time.

The pick now belongs to the **Workspace** it was made in, and is re-applied whenever that Workspace is selected again — on arriving at the page, and on switching the Workspace pill. The directory beside it keeps its own answer. A machine is part of which Workspace this is, so the same path on two machines is two Workspaces with two memories.

It is kept **out of the draft cache** on purpose: that cache is cleared by the send it belongs to, and this is a standing preference that has to survive one. Same disciplines otherwise — isolated by user × Project (#68), validated field by field on read, best-effort on write — and a new `penguin.chatSurface.` family classified in `install-scope.ts` (install-scoped: Workspace paths and machine ids inside it). A remembered kind whose plugin the Project no longer loads falls back to the conversation instead of a composer that can only say "unavailable".

Stacked on #639.

## Verification

- `pnpm -r build`, `pnpm typecheck`, `pnpm lint`, `pnpm format:check` — clean.
- `packages/web` unit tests: 141 files, all passing, including the new `surface-memory.test.ts` (18 cases: per-Workspace isolation, the conversation dropping its entry, user/Project isolation, corrupt storage, a refusing storage).
- By hand on a phone viewport (Pixel 7, built app on a dev root with the claude-code plugin loaded): a fresh draft reads 对话; picking Claude Code survives a reload; switching to another Workspace reads 对话 again; switching back reads Claude Code, with only that Workspace's entry in `localStorage`.