### PR TITLE
Switching the model keeps the conversation on its machine

### DIFF
--- a/changelog/unreleased/2026-09-09-model-switch-on-its-machine.md
+++ b/changelog/unreleased/2026-09-09-model-switch-on-its-machine.md
@@ -1,0 +1,11 @@
+# Switching the model keeps the conversation on its machine
+
+- **Date:** 2026-09-09
+- **Type:** fix
+- **Scope:** `web`
+
+[中文版](2026-09-09-model-switch-on-its-machine.zh.md)
+
+Switching the model on a conversation that runs on a machine answered `Workspace does not exist or is inaccessible`. The switch opens a NEW Session for the same Agent on the picked model, deliberately carrying the source Session's Workspace so the files it refers to stay reachable — but it asked THIS server to create it. The path it carried is a directory on the machine, and a server refuses a Workspace it does not have, so the switch failed with a message about a directory that exists and is perfectly reachable where the conversation actually lives.
+
+The creation now goes to the machine the source Session is on. The machine travels with the path, here as everywhere else: the new Session lands beside the old one, its first task (the `[model_switch_from]` block and the user's text) is posted to the same machine, and the trace the model reads for context is on the disk it is served from.

--- a/changelog/unreleased/2026-09-09-model-switch-on-its-machine.md
+++ b/changelog/unreleased/2026-09-09-model-switch-on-its-machine.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-09-09
 - **Type:** fix
 - **Scope:** `web`
+- **PR:** [#650](https://github.com/Prism-Shadow/penguin-harness/pull/650)
 
 [中文版](2026-09-09-model-switch-on-its-machine.zh.md)
 

--- a/changelog/unreleased/2026-09-09-model-switch-on-its-machine.zh.md
+++ b/changelog/unreleased/2026-09-09-model-switch-on-its-machine.zh.md
@@ -1,0 +1,11 @@
+# 切换模型时对话留在它自己的机器上
+
+- **Date:** 2026-09-09
+- **Type:** fix
+- **Scope:** `web`
+
+[English](2026-09-09-model-switch-on-its-machine.md)
+
+在运行于某台机器上的对话里切换模型，会报 `Workspace does not exist or is inaccessible`。切换模型的做法是：为同一个 Agent 以新模型开一个**新 Session**，并特意沿用原 Session 的 Workspace，好让对话引用的文件仍然可达——但这个创建请求发给了**本机**。它带过去的路径是那台机器上的目录，而服务器会拒绝自己没有的 Workspace，于是切换失败，报的却是一个在对话真正所在之处完好可达的目录。
+
+现在创建请求发往原 Session 所在的那台机器。机器与路径同行，这里与别处一致：新 Session 落在旧的旁边，它的第一个任务（`[model_switch_from]` 源信息块加用户的文字）发往同一台机器，模型为取上下文而读的轨迹文件也就在它被服务的那块磁盘上。

--- a/changelog/unreleased/2026-09-09-model-switch-on-its-machine.zh.md
+++ b/changelog/unreleased/2026-09-09-model-switch-on-its-machine.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-09-09
 - **Type:** fix
 - **Scope:** `web`
+- **PR:** [#650](https://github.com/Prism-Shadow/penguin-harness/pull/650)
 
 [English](2026-09-09-model-switch-on-its-machine.md)
 

--- a/packages/web/src/features/chat/chat-page.tsx
+++ b/packages/web/src/features/chat/chat-page.tsx
@@ -1124,12 +1124,21 @@ export function ChatPage() {
       };
       let createdId: string | null = null;
       try {
-        const created = await api.createSession(projectId, selected.agentId, {
-          provider: ref.provider,
-          modelId: ref.modelId,
-          workspace: selected.workspace,
-          approvalMode: selected.approvalMode,
-        });
+        const created = await api.createSession(
+          projectId,
+          selected.agentId,
+          {
+            provider: ref.provider,
+            modelId: ref.modelId,
+            workspace: selected.workspace,
+            approvalMode: selected.approvalMode,
+          },
+          // On the machine the source Session is on: the Workspace being carried over is a
+          // directory THERE, and this server would refuse a path it does not have
+          // ("Workspace does not exist or is inaccessible"). The machine travels with the
+          // path, here as everywhere.
+          machineForSession(selected.sessionId),
+        );
         createdId = created.session.sessionId;
         const res = await api.postTask(createdId, { input: [origin, ...input] });
         addSession(created.session);


### PR DESCRIPTION
Reported: switching the model reports `Workspace does not exist`.

`onSwitchModel` (chat-page.tsx) opens a NEW Session for the same Agent on the picked model and deliberately carries the source Session's Workspace, so the files the conversation refers to stay reachable. It called `api.createSession(...)` **without a machine** — so the request went to this server with a path that is a directory on the machine the conversation runs on. `assertWorkspaceAllowed` realpaths it, cannot find it here, and answers `400 workspace_not_found`: "Workspace does not exist or is inaccessible: …" — about a directory that exists and is reachable where the Session actually lives.

The creation now goes to `machineForSession(selected.sessionId)`. `createSession` records the new Session against that machine, so the follow-up `postTask` (the `[model_switch_from]` block plus the user's remainder) reaches the same server, and the trace the new model reads for context is on the disk that serves it.

## The same class, found while looking

- **`/agent` handoff** (same file, just below) also creates on this server. It passes no Workspace, so it cannot fail this way — but a handoff from a conversation on a machine silently starts the new chat *here*, with a temporary workspace, instead of beside the work. Left alone: the target Agent is picked from this server's Agent list, and creating it over there would 404 for an Agent that machine has never heard of. It becomes a one-line change once the Agent list is the union across machines (the follow-up to #648).
- **Schedules** carry a `workspace` and are read and written on this server only, so a schedule for an Agent that lives on a machine has the same shape of problem. That one is part of the larger gap — an Agent's state (AGENTS.md, skills, memory, vault, schedules) is a separate copy per machine — which needs a design decision, not a routing fix.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` clean; `pnpm --filter @prismshadow/penguin-web test` — 142 files / 1808 tests pass.

Stacked on #648.