### PR TITLE
ci(docker): publish latest from main and the exact version from a release, nothing else

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -162,9 +162,9 @@ pnpm test:e2e                                        # core live-model e2e, need
   GitHub's auto-generated notes.
 - **The official image is built from source**, by `.github/workflows/docker.yml`, and
   pushed to Docker Hub `hiyouga/penguinharness` for `linux/amd64` and `linux/arm64`. Every
-  push to `main` publishes that commit as `latest` and as `main-<sha7>`; the release
-  workflow's `docker` job builds the tag's own source and publishes `X.Y.Z`, `X.Y` and —
-  while the tag is the current latest Release — `stable`. A PR touching the `Dockerfile`,
+  push to `main` publishes that commit as `latest`, the only tag a push moves; the release
+  workflow's `docker` job builds the tag's own source and publishes the exact version
+  `X.Y.Z`, nothing else. A PR touching the `Dockerfile`,
   `docker/` or that workflow runs the same file as an amd64 smoke build. The push
   needs the `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets of the `docker` GitHub Environment (whose URL is the Docker Hub repository) — the latter a
   Docker Hub access token with read/write scope on that repository — and the Docker Hub

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,10 +5,10 @@
 #   container — readiness, sign-in, the healthcheck, the unprivileged user, a graceful stop and a
 #   restart onto the same data root. It builds the PR's own checkout, so it proves the Dockerfile
 #   against the code the PR carries.
-# - push to main: `publish` builds that commit and moves `latest`, alongside an immutable
-#   `main-<sha7>` twin. Every push, no path filter — `latest` follows main.
-# - workflow_call from release.yml's `docker` job: the same build at the tag, published as
-#   `X.Y.Z`, `X.Y` and `stable`.
+# - push to main: `publish` builds that commit and moves `latest`. Every push, no path filter —
+#   `latest` follows main, and it is the only tag a push moves.
+# - workflow_call from release.yml's `docker` job: the same build at the tag, published as the
+#   exact version `X.Y.Z` and nothing else.
 # - workflow_dispatch for a manual re-publish, mirroring release.yml's own dispatch input.
 name: Docker
 
@@ -198,16 +198,17 @@ jobs:
         with:
           ref: ${{ inputs.tag || '' }}
 
-      # Two tag policies.
+      # Two tag policies, one tag each.
       #
-      # A push to main publishes `latest` plus an immutable `main-<sha7>` twin, so `latest` always
-      # names the newest build and anyone who needs to pin one can.
+      # A push to main publishes `latest` and nothing else: `latest` always names the newest build
+      # of main. The image is still stamped with `main-<sha7>` as its version (the app's reported
+      # version and the OCI label), so a running container can say which commit it is.
       #
-      # A release publishes the exact version, `X.Y` for a plain X.Y.Z tag (a prerelease has no
-      # meaningful minor line to move), and `stable` — resolved in the next step — for readers who
-      # want releases only. The commit comes from the checkout rather than from github.sha, which
-      # on a dispatch names the branch the run was started on and not the tag.
-      - name: Resolve the version and its tags
+      # A release publishes the exact version, `X.Y.Z`, and nothing else — no moving `X.Y` or
+      # `stable` line: a deployment that wants a release pins its version, and `latest` is main.
+      # The commit comes from the checkout rather than from github.sha, which on a dispatch names
+      # the branch the run was started on and not the tag.
+      - name: Resolve the version and its tag
         id: version
         env:
           EVENT: ${{ github.event_name }}
@@ -217,35 +218,10 @@ jobs:
           echo "commit=$COMMIT" >> "$GITHUB_OUTPUT"
           if [ "$EVENT" = "push" ]; then
             echo "version=main-$(printf '%s' "$COMMIT" | cut -c1-7)" >> "$GITHUB_OUTPUT"
-            echo "minor=" >> "$GITHUB_OUTPUT"
-            echo "latest=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          V="${TAG#v}"
-          echo "version=$V" >> "$GITHUB_OUTPUT"
-          echo "latest=false" >> "$GITHUB_OUTPUT"
-          if printf '%s' "$V" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "minor=${V%.*}" >> "$GITHUB_OUTPUT"
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
           else
-            echo "minor=" >> "$GITHUB_OUTPUT"
-            echo "$TAG is not a plain X.Y.Z tag; publishing the exact version only."
-          fi
-
-      # `stable` moves only when the tag is GitHub's current latest Release, so re-publishing an
-      # older tag cannot demote the newest release image.
-      - name: Determine whether the tag is the latest Release
-        id: stable
-        if: github.event_name != 'push'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TAG: ${{ inputs.tag }}
-        run: |
-          LATEST_TAG="$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq .tagName)"
-          if [ "$TAG" = "$LATEST_TAG" ]; then
-            echo "update=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "update=false" >> "$GITHUB_OUTPUT"
-            echo "$TAG will be published without moving :stable (current latest: $LATEST_TAG)."
+            echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+            echo "tag=${TAG#v}" >> "$GITHUB_OUTPUT"
           fi
 
       # arm64 is emulated: the image is built on one x64 runner, and only the stage that compiles
@@ -269,10 +245,7 @@ jobs:
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=${{ steps.version.outputs.version }}
-            type=raw,value=${{ steps.version.outputs.minor }},enable=${{ steps.version.outputs.minor != '' }}
-            type=raw,value=latest,enable=${{ steps.version.outputs.latest == 'true' }}
-            type=raw,value=stable,enable=${{ steps.stable.outputs.update == 'true' }}
+            type=raw,value=${{ steps.version.outputs.tag }}
 
       # provenance is off: the attestation manifest it attaches shows up in the package listing as
       # an "unknown/unknown" platform, which is worse for a reader than the attestation is worth.

--- a/changelog/unreleased/2026-09-10-docker-tags-latest-and-version.md
+++ b/changelog/unreleased/2026-09-10-docker-tags-latest-and-version.md
@@ -1,0 +1,15 @@
+# The image publishes two tags only: `latest` from main, the exact version from a release
+
+- **Date:** 2026-09-10
+- **Type:** fix
+- **Scope:** `ci`, `docs`
+- **PR:** [#661](https://github.com/Prism-Shadow/penguin-harness/pull/660)
+
+[中文版](2026-09-10-docker-tags-latest-and-version.zh.md)
+
+The Docker workflow no longer publishes the `main-<sha7>` twin on a push to main, nor the `X.Y` line and `stable` on a release. A push to `main` moves `latest` and nothing else; a release publishes the exact version `X.Y.Z` and nothing else. The image is still stamped with `main-<sha7>` or the version as its reported version.
+
+## Details
+
+- `.github/workflows/docker.yml`: the version step resolves one tag — `latest` for a push, the tag's version for a release — and the latest-Release lookup that moved `stable` is gone.
+- Docs (`quickstart-docker`), the contributing guide and the design's delivery-channel note describe the two tags; the stray `main-*` and `0.2` tags already on Docker Hub have to be deleted by hand — a workflow only adds tags, and the publish token has no delete scope.

--- a/changelog/unreleased/2026-09-10-docker-tags-latest-and-version.zh.md
+++ b/changelog/unreleased/2026-09-10-docker-tags-latest-and-version.zh.md
@@ -1,0 +1,15 @@
+# 镜像只发布两种 tag：main 的 `latest` 与发布版的精确版本号
+
+- **Date:** 2026-09-10
+- **Type:** fix
+- **Scope:** `ci`, `docs`
+- **PR:** [#661](https://github.com/Prism-Shadow/penguin-harness/pull/660)
+
+[English](2026-09-10-docker-tags-latest-and-version.md)
+
+Docker 工作流不再在 push main 时发布 `main-<sha7>` 副本，也不再在发版时发布 `X.Y` 与 `stable`。push `main` 只移动 `latest`；发版只发布精确版本号 `X.Y.Z`。镜像内部仍以 `main-<sha7>` 或版本号作为其上报的版本。
+
+## 细节
+
+- `.github/workflows/docker.yml`：版本步骤只解析一个 tag——push 为 `latest`，发版为该 tag 的版本号——移动 `stable` 所依赖的「最新 Release」查询随之删除。
+- 文档（`quickstart-docker`）、贡献指南与设计文档的交付渠道说明改为描述这两种 tag；Docker Hub 上已出现的 `main-*` 与 `0.2` 需手工删除——工作流只会新增 tag，发布用的 token 也没有删除权限。

--- a/packages/docs/content/quickstart-docker.en.md
+++ b/packages/docs/content/quickstart-docker.en.md
@@ -9,7 +9,7 @@ The official image runs the same server `penguin server` starts, with the Web Ap
 hiyouga/penguinharness
 ```
 
-`latest` follows `main` — every push rebuilds it, and `main-<sha7>` names that same image immutably. `stable` is the newest release; `X.Y.Z` and `X.Y` pin one. Every tag is built from this repository's source at that commit, and each is a multi-platform manifest covering `linux/amd64` and `linux/arm64`, so the same reference serves an x86 VPS and an arm64 one alike. The examples below use `latest`; a deployment that should move only when a version ships wants `stable` instead.
+The image has two kinds of tag: `latest` follows `main` — every push rebuilds it — and `X.Y.Z` is a release, built from that tag's own source. There is no `main-<sha>`, `X.Y` or `stable`: nothing that moves under a second name. Every tag is a multi-platform manifest covering `linux/amd64` and `linux/arm64`, so the same reference serves an x86 VPS and an arm64 one alike. The examples below use `latest`; a deployment that should move only when a version ships pins a version.
 
 ## Run it
 

--- a/packages/docs/content/quickstart-docker.zh.md
+++ b/packages/docs/content/quickstart-docker.zh.md
@@ -9,7 +9,7 @@ description: 运行官方 PenguinHarness 镜像——一个容器、一个卷，
 hiyouga/penguinharness
 ```
 
-`latest` 跟随 `main`——每次 push 都重新构建它，`main-<sha7>` 则是同一个镜像的不可变名字。`stable` 是最新的发布版；`X.Y.Z` 与 `X.Y` 用于钉住某个发布版。每个 tag 都由本仓库该 commit 的源码构建，也都是覆盖 `linux/amd64` 与 `linux/arm64` 的多平台 manifest，同一个引用在 x86 VPS 与 arm64 机器上通用。下面的示例用 `latest`；只希望随发布版移动的部署应改用 `stable`。
+镜像只有两种 tag：`latest` 跟随 `main`——每次 push 都重新构建它；`X.Y.Z` 是某个发布版，由该 tag 自身的源码构建。没有 `main-<sha>`、`X.Y` 或 `stable` 之类会移动或重复的名字。每个 tag 都是覆盖 `linux/amd64` 与 `linux/arm64` 的多平台 manifest，同一个引用在 x86 VPS 与 arm64 机器上通用。下面的示例用 `latest`；只希望随发布版移动的部署应钉住某个版本号。
 
 ## 跑起来
 


### PR DESCRIPTION
## Summary

The Docker workflow published `latest` plus an immutable `main-<sha7>` twin on every push to main, and `X.Y.Z` plus a moving `X.Y` and `stable` on a release. Those extra names showed up on Docker Hub (`main-8b94dcb`, `main-28d25ba`, `0.2`) and were not wanted. Now:

- a push to `main` publishes **`latest`** and nothing else;
- a release publishes the exact version **`X.Y.Z`** and nothing else (no `X.Y`, no `stable`).

The image is still stamped with `main-<sha7>` (push) or the version (release) as its reported version and OCI label, so a container can say which commit it runs.

- `.github/workflows/docker.yml`: the version step resolves one `tag` output; the latest-Release lookup for `stable` is removed; the metadata step lists that one tag.
- `packages/docs/content/quickstart-docker.{en,zh}.md`, `.github/CONTRIBUTING.md`: describe the two tags.
- Changelog pair `changelog/unreleased/2026-09-10-docker-tags-latest-and-version.{md,zh.md}`.
- The stray `main-*` and `0.2` tags already on Docker Hub have to be deleted by hand on the Hub: a workflow only adds tags, and the publish token turned out to lack the delete scope (`access denied: insufficient scope`).

## Design

Design PR: https://github.com/Prism-Shadow/penguin-harness-design/pull/118 (the delivery-channel note names the two tags).

## Verification

- Workflow YAML unchanged in structure (one step edited, one removed); the PR-time `smoke` job does not publish, so the policy is exercised by the next push to main — `latest` moves and no `main-*` tag appears.
- vps3: install / build / typecheck / lint / format:check and every test shard (reported in the review thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZVj41ZVxRkykzhyApifDY
