### PR TITLE
fix(core): exec_command reads `command` as `cmd`, and a rejected call explains how to fix itself

### DIFF
--- a/changelog/unreleased/2026-09-10-tool-argument-guidance.md
+++ b/changelog/unreleased/2026-09-10-tool-argument-guidance.md
@@ -1,0 +1,15 @@
+# exec_command accepts `command` for `cmd`, and a rejected call explains how to fix itself
+
+- **Date:** 2026-09-10
+- **Type:** fix
+- **Scope:** `core`, `web`, `cli`, `docs`
+
+[中文版](2026-09-10-tool-argument-guidance.zh.md)
+
+A model that named the shell text `command` instead of `cmd` — the parameter name of other harnesses' shell tools — had every `exec_command` call rejected with a one-line "missing argument", and typically re-issued the same call unchanged. `exec_command` now runs a call that carries the text as `command` (the schema still declares `cmd` alone, and `cmd` wins when both are present), and every built-in tool that rejects a call for its arguments now answers with a complete correction guide instead of one line.
+
+## Details
+
+- The alias is read through one list shared by the tool, the command policy and the call previews: the policy screens exactly the text the tool runs, and the Web App's and CLI's `$ …` previews — the line the user approves — show it.
+- The correction guide names the fault (missing, wrong type, empty, or invalid, and the alias the argument arrived under if any), lists the argument names received and calls out the ones the tool does not declare, restates the tool's parameters from the schema the model was handed (name, type, required or optional, aliases, description), and closes with the shape of a correct call carrying every required parameter. Its closing line repeats the tool and argument names, so the tail the server's error ledger keeps still says what went wrong.
+- Covered: `exec_command` (`cmd`), `input_command` (`process_id`), `run_subagent` (`prompt`), `input_subagent` (`subagent_id`), `read_file` (`file_path`, and an unusable `offset` or `limit`), `write_file` (`file_path`, `content`), `edit_file` (`file_path`, `old_string`, `new_string`).

--- a/changelog/unreleased/2026-09-10-tool-argument-guidance.md
+++ b/changelog/unreleased/2026-09-10-tool-argument-guidance.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-09-10
 - **Type:** fix
 - **Scope:** `core`, `web`, `cli`, `docs`
+- **PR:** [#661](https://github.com/Prism-Shadow/penguin-harness/pull/661)
 
 [中文版](2026-09-10-tool-argument-guidance.zh.md)
 

--- a/changelog/unreleased/2026-09-10-tool-argument-guidance.zh.md
+++ b/changelog/unreleased/2026-09-10-tool-argument-guidance.zh.md
@@ -1,0 +1,15 @@
+# exec_command 接受 `command` 作为 `cmd`,被拒的调用自带改法
+
+- **Date:** 2026-09-10
+- **Type:** fix
+- **Scope:** `core`, `web`, `cli`, `docs`
+
+[English](2026-09-10-tool-argument-guidance.md)
+
+把 shell 文本写成 `command` 而非 `cmd`(其他 harness 的 shell 工具用的参数名)的模型,此前每一次 `exec_command` 调用都被一行「缺少参数」拒绝,并且通常会原样重发同一调用。现在 `exec_command` 会执行以 `command` 携带文本的调用(schema 仍只声明 `cmd`,两者同时出现以 `cmd` 为准);每个因参数被拒的内置工具,也都以一份完整的纠错指引作答,而不再是一行话。
+
+## 细节
+
+- 别名经工具、命令策略与调用预览共用的同一份名单读取:策略筛查的正是工具将执行的文本,Web App 与 CLI 的 `$ …` 预览——用户审批时看的那一行——也会显示它。
+- 纠错指引点出出错之处(缺失、类型不符、为空或不可用,若经别名送达也一并点明)、列出实际收到的参数名并点出工具未声明的名字、按交给模型的 schema 重述全部参数(名称、类型、必填与否、别名、说明),并以携带全部必填参数的正确调用形态收尾。末句重述工具名与参数名,服务端异常台账保留的输出尾部因此仍能说明出了什么错。
+- 覆盖范围:`exec_command`(`cmd`)、`input_command`(`process_id`)、`run_subagent`(`prompt`)、`input_subagent`(`subagent_id`)、`read_file`(`file_path`,以及不可用的 `offset` 或 `limit`)、`write_file`(`file_path`、`content`)、`edit_file`(`file_path`、`old_string`、`new_string`)。

--- a/changelog/unreleased/2026-09-10-tool-argument-guidance.zh.md
+++ b/changelog/unreleased/2026-09-10-tool-argument-guidance.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-09-10
 - **Type:** fix
 - **Scope:** `core`, `web`, `cli`, `docs`
+- **PR:** [#661](https://github.com/Prism-Shadow/penguin-harness/pull/661)
 
 [English](2026-09-10-tool-argument-guidance.md)
 

--- a/packages/cli/src/tool-render.ts
+++ b/packages/cli/src/tool-render.ts
@@ -240,7 +240,8 @@ export function renderPartialToolCall(
   if (name === "exec_command") {
     const desc = describedState(argsJson, opts);
     if (desc === "pending") return null;
-    const cmd = extractField(argsJson, "cmd");
+    // `command` is the alias core accepts for `cmd` (see core's exec-command.ts).
+    const cmd = extractField(argsJson, "cmd") ?? extractField(argsJson, "command");
     if (desc !== "none") {
       if (!desc.complete || cmd === null) return `${name} <- ${desc.text}`;
       return describedForm(name, desc.text, `$ ${toSingleLine(cmd.value)}`, cmd.complete);

--- a/packages/cli/test/tool-render.test.ts
+++ b/packages/cli/test/tool-render.test.ts
@@ -6,6 +6,14 @@ import {
 } from "../src/tool-render.js";
 
 describe("renderPartialToolCall — exec_command", () => {
+  it("previews the shell text under the `command` alias core also runs", () => {
+    expect(renderPartialToolCall("exec_command", '{"command":"ls"}')).toBe("exec_command <- $ ls");
+    // `cmd` is what runs when both are present, so it is what previews.
+    expect(renderPartialToolCall("exec_command", '{"cmd":"pwd","command":"ls"}')).toBe(
+      "exec_command <- $ pwd",
+    );
+  });
+
   it("streams `exec_command <- $ {cmd}` when the schema has no description argument", () => {
     // The default path: the switch is off (or the tool is unknown), so nothing can supersede
     // the plain form and it streams character by character.

--- a/packages/core/src/environment/tools/edit-file.ts
+++ b/packages/core/src/environment/tools/edit-file.ts
@@ -30,6 +30,7 @@ import type { BuiltinTool, ToolExecutionContext, ToolResult } from "./types.js";
 import { atomicWriteFile } from "../../internal/atomic-write.js";
 import { buildReplacementHunks, renderHunk } from "./diff.js";
 import { missingPathHint } from "./path-hint.js";
+import { describeArgumentError } from "./tool-arguments.js";
 
 /** Tool name constant (used only within this tool module, never exposed to Environment). */
 export const EDIT_FILE_NAME = "edit_file";
@@ -74,23 +75,36 @@ export function createEditFileTool(definition: ToolDefinitionConfig): BuiltinToo
 
       const filePath = args["file_path"];
       if (typeof filePath !== "string" || filePath.length === 0) {
-        yield delta(`Missing required argument "file_path" for ${definition.name}.`);
+        yield delta(
+          describeArgumentError(definition, args, { argument: "file_path", kind: "missing" }),
+        );
         return { stopReason: "fatal" };
       }
       const oldString = args["old_string"];
       if (typeof oldString !== "string") {
-        yield delta(`Missing required argument "old_string" for ${definition.name}.`);
+        yield delta(
+          describeArgumentError(definition, args, { argument: "old_string", kind: "missing" }),
+        );
         return { stopReason: "fatal" };
       }
       if (oldString.length === 0) {
         yield delta(
-          "old_string must not be empty — edit_file replaces existing text. To create a file or rewrite it wholesale, use write_file.",
+          describeArgumentError(
+            definition,
+            args,
+            { argument: "old_string", kind: "missing" },
+            {
+              hint: `${definition.name} replaces existing text; to create a file or rewrite it wholesale, use write_file.`,
+            },
+          ),
         );
         return { stopReason: "fatal" };
       }
       const newString = args["new_string"];
       if (typeof newString !== "string") {
-        yield delta(`Missing required argument "new_string" for ${definition.name}.`);
+        yield delta(
+          describeArgumentError(definition, args, { argument: "new_string", kind: "missing" }),
+        );
         return { stopReason: "fatal" };
       }
       if (oldString === newString) {

--- a/packages/core/src/environment/tools/exec-command.ts
+++ b/packages/core/src/environment/tools/exec-command.ts
@@ -26,9 +26,27 @@ import type { BuiltinTool, ToolExecutionContext, ToolResult } from "./types.js";
 import { DEFAULT_EXEC_YIELD_MS, isStopSignal, resultForExit } from "./command/index.js";
 import type { ManagedSession } from "./command/index.js";
 import { clampYield, reportLabel, tailForReport } from "./background/index.js";
+import { describeArgumentError, stringArgument } from "./tool-arguments.js";
 
 /** Tool name constant (used only inside this tool module, not exposed to Environment). */
 export const EXEC_COMMAND_NAME = "exec_command";
+
+/**
+ * The argument names that carry the shell text, in the order the tool reads them: `cmd`, the
+ * schema's name, then `command`, accepted as an alias. Models trained on harnesses whose
+ * shell tool takes `command` emit that name even while reading a schema that says `cmd`, and
+ * a call rejected for it tends to be re-issued unchanged — the model believes it followed
+ * the schema — so one session can spend most of its calls on the same mistake. The schema
+ * itself keeps naming `cmd` alone. Every reader of the shell text goes through this list:
+ * the command policy screens exactly the text the tool runs (internal/command-policy.ts),
+ * and the Web App's and CLI's previews fall back to the alias the same way.
+ */
+export const EXEC_COMMAND_TEXT_ARGUMENTS: readonly string[] = ["cmd", "command"];
+
+/** The alias table for argument explanations: `command` is `cmd` under another name, not an unknown argument. */
+const EXEC_COMMAND_ALIASES: Readonly<Record<string, readonly string[]>> = {
+  cmd: EXEC_COMMAND_TEXT_ARGUMENTS.slice(1),
+};
 
 /**
  * exec_command built-in tool: parses arguments, resolves workdir, and delegates to
@@ -61,11 +79,19 @@ export function createExecCommandTool(
         return { stopReason: "fatal" };
       }
 
-      const cmd = args["cmd"];
-      if (typeof cmd !== "string" || cmd.length === 0) {
-        yield delta(`Missing required argument "cmd" for ${definition.name}.`);
+      const text = stringArgument(args, EXEC_COMMAND_TEXT_ARGUMENTS);
+      if (text === undefined || text.value.length === 0) {
+        yield delta(
+          describeArgumentError(
+            definition,
+            args,
+            { argument: "cmd", kind: "missing" },
+            { aliases: EXEC_COMMAND_ALIASES },
+          ),
+        );
         return { stopReason: "fatal" };
       }
+      const cmd = text.value;
       // workdir defaults to workspaceDir; relative paths are resolved against workspaceDir.
       const rawWorkdir = args["workdir"];
       const workdir =

--- a/packages/core/src/environment/tools/input-command.ts
+++ b/packages/core/src/environment/tools/input-command.ts
@@ -32,6 +32,7 @@ import {
   resultForExit,
 } from "./command/index.js";
 import { clampYield } from "./background/index.js";
+import { describeArgumentError } from "./tool-arguments.js";
 
 /** Tool name constant. */
 export const INPUT_COMMAND_NAME = "input_command";
@@ -62,7 +63,9 @@ export function createInputCommandTool(
 
       const processId = args["process_id"];
       if (typeof processId !== "string" || processId.length === 0) {
-        yield delta('Missing required argument "process_id" for input_command.');
+        yield delta(
+          describeArgumentError(definition, args, { argument: "process_id", kind: "missing" }),
+        );
         return { stopReason: "fatal" };
       }
       const session = manager.get(processId);

--- a/packages/core/src/environment/tools/input-subagent.ts
+++ b/packages/core/src/environment/tools/input-subagent.ts
@@ -35,6 +35,7 @@ import {
 import { approvalHint } from "./run-subagent.js";
 import { collectWindow } from "./subagent/collect.js";
 import { clampYield } from "./background/index.js";
+import { describeArgumentError } from "./tool-arguments.js";
 
 /** Tool name constant. */
 export const INPUT_SUBAGENT_NAME = "input_subagent";
@@ -62,7 +63,9 @@ export function createInputSubagentTool(
 
       const subagentId = args["subagent_id"];
       if (typeof subagentId !== "string" || subagentId.length === 0) {
-        yield delta('Missing required argument "subagent_id" for input_subagent.');
+        yield delta(
+          describeArgumentError(definition, args, { argument: "subagent_id", kind: "missing" }),
+        );
         return { stopReason: "fatal" };
       }
       let session = manager.get(subagentId);

--- a/packages/core/src/environment/tools/read-file.ts
+++ b/packages/core/src/environment/tools/read-file.ts
@@ -59,6 +59,7 @@ import type {
 } from "../../interfaces/index.js";
 import { formatSize, isHttpUrl, loadImage, looksLikeImageFile } from "./image-source.js";
 import { missingPathHint } from "./path-hint.js";
+import { describeArgumentError } from "./tool-arguments.js";
 import type { BuiltinTool, ToolExecutionContext, ToolResult } from "./types.js";
 
 /** Tool name constant (used only within this tool module, never exposed to Environment). */
@@ -395,19 +396,31 @@ export function createReadFileTool(
 
       const filePath = args["file_path"];
       if (typeof filePath !== "string" || filePath.length === 0) {
-        yield delta(`Missing required argument "file_path" for ${definition.name}.`);
+        yield delta(
+          describeArgumentError(definition, args, { argument: "file_path", kind: "missing" }),
+        );
         return { stopReason: "fatal" };
       }
       const offsetArg = coerceCount(args["offset"], 1);
       if (!offsetArg.ok) {
-        yield delta(`Invalid "offset": expected a number (got ${JSON.stringify(args["offset"])}).`);
+        yield delta(
+          describeArgumentError(definition, args, {
+            argument: "offset",
+            kind: "invalid",
+            detail: `expected a number (got ${JSON.stringify(args["offset"])})`,
+          }),
+        );
         return { stopReason: "fatal" };
       }
       const offset = Math.max(1, offsetArg.value);
       const limitArg = coerceCount(args["limit"], DEFAULT_READ_FILE_LIMIT);
       if (!limitArg.ok || limitArg.value <= 0) {
         yield delta(
-          `Invalid "limit": expected a positive number (got ${JSON.stringify(args["limit"])}).`,
+          describeArgumentError(definition, args, {
+            argument: "limit",
+            kind: "invalid",
+            detail: `expected a positive number (got ${JSON.stringify(args["limit"])})`,
+          }),
         );
         return { stopReason: "fatal" };
       }

--- a/packages/core/src/environment/tools/run-subagent.ts
+++ b/packages/core/src/environment/tools/run-subagent.ts
@@ -43,6 +43,7 @@ import {
 } from "./subagent/index.js";
 import { collectWindow } from "./subagent/collect.js";
 import { clampYield, reportLabel, tailForReport } from "./background/index.js";
+import { describeArgumentError } from "./tool-arguments.js";
 
 /** Tool name constant (used only within this tool module, never exposed to Environment). */
 export const SUBAGENT_NAME = "run_subagent";
@@ -84,7 +85,9 @@ export function createSubagentTool(
       }
       const prompt = typeof args.prompt === "string" ? args.prompt : "";
       if (prompt.trim().length === 0) {
-        yield* fail("[run_subagent error: missing required string argument `prompt`]");
+        yield* fail(
+          describeArgumentError(definition, args, { argument: "prompt", kind: "missing" }),
+        );
         return { stopReason: "fatal" };
       }
       const agentId = typeof args.agent_id === "string" ? args.agent_id : undefined;

--- a/packages/core/src/environment/tools/tool-arguments.ts
+++ b/packages/core/src/environment/tools/tool-arguments.ts
@@ -1,0 +1,265 @@
+/**
+ * Argument handling shared by the built-in tools: reading an argument that may arrive under
+ * more than one name, and explaining a call whose arguments do not fit the tool.
+ *
+ * Environment parses the argument JSON and hands each tool a plain object; whether that
+ * object fits is the tool's own check, and a failed check ends the call with
+ * `stop_reason: fatal` and the explanation built here as its whole output. The explanation
+ * is written for the model that made the call, which has to repair the call from the tool
+ * output alone: it names the fault, lists the argument names actually received and calls
+ * out the ones the tool does not know, restates the tool's parameters from the schema the
+ * model was handed, and closes with the shape of a correct call. Without the restatement a
+ * model that misnamed one argument tends to re-issue the same call unchanged — it believes
+ * it followed the schema, and a one-line "missing argument" gives it nothing to compare
+ * against.
+ *
+ * The closing line repeats the tool and argument names on purpose: the server's error
+ * ledger keeps the **tail** of a failed tool's output (see the server's
+ * stream-error-watcher), so the tail has to say what went wrong on its own.
+ * Docs: /docs/tools § "Execution contract".
+ */
+import type { ToolDefinitionConfig } from "../../interfaces/index.js";
+
+/** A string argument as read from a call: the name it arrived under and its value. */
+export interface StringArgument {
+  name: string;
+  value: string;
+}
+
+/**
+ * The first of `names` that carries a string in `args`, with its value; undefined when none
+ * does. `names` is in priority order — the schema name first, then any alias — so a call
+ * carrying several is read the same way by every consumer: the tool that runs the value and
+ * the command policy that screens it see one value, not two.
+ */
+export function stringArgument(
+  args: Record<string, unknown>,
+  names: readonly string[],
+): StringArgument | undefined {
+  for (const name of names) {
+    const value = args[name];
+    if (typeof value === "string") return { name, value };
+  }
+  return undefined;
+}
+
+/** What is wrong with one argument of a call. */
+export type ArgumentFault =
+  /**
+   * A required argument the tool cannot proceed without. The explanation reads `args` to say
+   * whether it is absent, of the wrong type, or empty.
+   */
+  | { argument: string; kind: "missing" }
+  /**
+   * An argument that is present but unusable; `detail` states the requirement and what
+   * arrived, without a trailing period, e.g. `expected a positive number (got 0)`.
+   */
+  | { argument: string; kind: "invalid"; detail: string };
+
+export interface ArgumentErrorOptions {
+  /**
+   * Names accepted for a parameter beyond its schema name (exec_command's `command` for
+   * `cmd`): not reported as unrecognized, and listed beside the parameter.
+   */
+  aliases?: Readonly<Record<string, readonly string[]>>;
+  /** Guidance appended to the fault sentence, e.g. which tool to use instead. */
+  hint?: string;
+}
+
+/** One parameter as the tool's schema declares it. */
+interface SchemaParameter {
+  name: string;
+  type: string;
+  required: boolean;
+  description: string | undefined;
+}
+
+/**
+ * The parameters declared by the definition's JSON schema, in declaration order (the order
+ * the model was shown). Empty when the definition carries no schema or no properties.
+ */
+function schemaParameters(definition: ToolDefinitionConfig): SchemaParameter[] {
+  const params = definition.parameters;
+  const properties = params?.["properties"];
+  if (properties === null || typeof properties !== "object") return [];
+  const required = params?.["required"];
+  const requiredNames = new Set(
+    Array.isArray(required) ? required.filter((n): n is string => typeof n === "string") : [],
+  );
+  return Object.entries(properties as Record<string, unknown>).map(([name, schema]) => {
+    const s =
+      schema !== null && typeof schema === "object" ? (schema as Record<string, unknown>) : {};
+    return {
+      name,
+      type: schemaType(s["type"]),
+      required: requiredNames.has(name),
+      description: typeof s["description"] === "string" ? s["description"] : undefined,
+    };
+  });
+}
+
+/** A schema `type` as prose: a name, a union of names, or `any` when the schema states none. */
+function schemaType(type: unknown): string {
+  if (typeof type === "string") return type;
+  if (Array.isArray(type)) {
+    const names = type.filter((t): t is string => typeof t === "string");
+    if (names.length > 0) return names.join(" | ");
+  }
+  return "any";
+}
+
+/** The type of a received value, as prose with its article: `a number`, `an array`, `null`. */
+function typeName(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "an array";
+  switch (typeof value) {
+    case "string":
+      return "a string";
+    case "number":
+      return "a number";
+    case "boolean":
+      return "a boolean";
+    case "object":
+      return "an object";
+    default:
+      return typeof value;
+  }
+}
+
+/** Prefixes a type name with its article: `a string`, `an integer`. */
+function withArticle(type: string): string {
+  return /^[aeiou]/i.test(type) ? `an ${type}` : `a ${type}`;
+}
+
+/** A placeholder value of the parameter's type for the example call. */
+function placeholder(parameter: SchemaParameter): string {
+  switch (parameter.type) {
+    case "number":
+    case "integer":
+      return "0";
+    case "boolean":
+      return "false";
+    case "array":
+      return "[]";
+    case "object":
+      return "{}";
+    default:
+      return `"<${parameter.name}>"`;
+  }
+}
+
+/**
+ * The sentence naming the fault: which argument, and — for a missing one — whether it is
+ * absent, arrived under the wrong type, or is empty. When the argument arrived under an
+ * alias, the sentence says so, so the model can map the schema name to what it sent.
+ */
+function faultSentence(
+  fault: ArgumentFault,
+  args: Record<string, unknown>,
+  parameters: SchemaParameter[],
+  aliases: Readonly<Record<string, readonly string[]>>,
+): string {
+  const quoted = `"${fault.argument}"`;
+  if (fault.kind === "invalid") {
+    return `argument ${quoted} is invalid: ${fault.detail}.`;
+  }
+  const present = [fault.argument, ...(aliases[fault.argument] ?? [])].find((n) => n in args);
+  if (present === undefined) return `required argument ${quoted} is missing.`;
+  const as = present === fault.argument ? "" : ` (received as "${present}")`;
+  const value = args[present];
+  const expected = parameters.find((p) => p.name === fault.argument)?.type ?? "string";
+  // A string where a string was wanted is only ever rejected for being blank; a string where
+  // a number or a boolean was wanted is the wrong type, blank or not.
+  if (typeof value === "string" && (expected === "string" || value.trim() === "")) {
+    return `required argument ${quoted}${as} is empty.`;
+  }
+  if (expected === "any") {
+    // A hand-edited schema property with no `type`: there is no type to hold the value against.
+    return `argument ${quoted}${as} cannot be used as received (${typeName(value)}).`;
+  }
+  return `argument ${quoted}${as} must be ${withArticle(expected)}, but ${typeName(value)} was received.`;
+}
+
+/**
+ * The argument names the call carried, with the ones the schema does not declare (and no
+ * alias covers) called out — the line a misnamed argument is caught by. Without a schema
+ * there is nothing to judge names against, so only the names are listed.
+ */
+function receivedLine(
+  tool: string,
+  args: Record<string, unknown>,
+  parameters: SchemaParameter[],
+  aliases: Readonly<Record<string, readonly string[]>>,
+): string {
+  const names = Object.keys(args);
+  if (names.length === 0) return "Arguments received: none.";
+  let line = `Arguments received: ${names.join(", ")}.`;
+  if (parameters.length > 0) {
+    const known = new Set(parameters.map((p) => p.name));
+    for (const list of Object.values(aliases)) for (const alias of list) known.add(alias);
+    const unknown = names.filter((n) => !known.has(n));
+    if (unknown.length > 0) {
+      const noun = unknown.length === 1 ? "a parameter" : "parameters";
+      line += ` Not ${noun} of ${tool}: ${unknown.join(", ")}.`;
+    }
+  }
+  return line;
+}
+
+/** One line of the parameter list: name, type, required or optional, aliases, description. */
+function parameterLine(parameter: SchemaParameter, aliases: readonly string[] | undefined): string {
+  const facts = [parameter.type, parameter.required ? "required" : "optional"].join(", ");
+  const alias =
+    aliases !== undefined && aliases.length > 0
+      ? `; also accepted as ${aliases.map((a) => `"${a}"`).join(", ")}`
+      : "";
+  const head = `- ${parameter.name} (${facts}${alias})`;
+  return parameter.description === undefined ? head : `${head}: ${parameter.description}`;
+}
+
+/**
+ * The closing instruction: call again with the faulted argument fixed, as one JSON object
+ * under the schema's names, with an example carrying every required parameter plus the
+ * faulted one. Names the tool and the argument so the tail of the output says what went wrong.
+ */
+function closingLine(tool: string, fault: ArgumentFault, parameters: SchemaParameter[]): string {
+  const fix =
+    fault.kind === "missing"
+      ? `with "${fault.argument}" provided`
+      : `with a valid "${fault.argument}"`;
+  const shown = parameters.filter((p) => p.required || p.name === fault.argument);
+  if (shown.length === 0) {
+    return `Call ${tool} again ${fix}, as one JSON object using the tool's parameter names.`;
+  }
+  const example = `{${shown.map((p) => `"${p.name}": ${placeholder(p)}`).join(", ")}}`;
+  return `Call ${tool} again ${fix}, as one JSON object using exactly these parameter names, e.g. ${example}.`;
+}
+
+/**
+ * The whole output of a call rejected for its arguments (see the module header for what it
+ * carries and why). `definition` is the entry the tool was assembled from — the same schema
+ * the model was handed, `call_description` filtering included — so the restated parameter
+ * list is exactly what the model can send.
+ */
+export function describeArgumentError(
+  definition: ToolDefinitionConfig,
+  args: Record<string, unknown>,
+  fault: ArgumentFault,
+  options: ArgumentErrorOptions = {},
+): string {
+  const tool = definition.name;
+  const parameters = schemaParameters(definition);
+  const aliases = options.aliases ?? {};
+  const hint = options.hint === undefined ? "" : ` ${options.hint}`;
+  const lines = [
+    `${tool} was not run: ${faultSentence(fault, args, parameters, aliases)}${hint}`,
+    receivedLine(tool, args, parameters, aliases),
+  ];
+  if (parameters.length > 0) {
+    lines.push(`Parameters of ${tool}:`);
+    for (const parameter of parameters)
+      lines.push(parameterLine(parameter, aliases[parameter.name]));
+  }
+  lines.push(closingLine(tool, fault, parameters));
+  return lines.join("\n");
+}

--- a/packages/core/src/environment/tools/write-file.ts
+++ b/packages/core/src/environment/tools/write-file.ts
@@ -31,6 +31,7 @@ import { partialToolCallOutput } from "../../omnimessage/index.js";
 import type { OmniMessage } from "../../omnimessage/index.js";
 import type { ToolDefinitionConfig } from "../../interfaces/index.js";
 import type { BuiltinTool, ToolExecutionContext, ToolResult } from "./types.js";
+import { describeArgumentError } from "./tool-arguments.js";
 
 /** Tool name constant (used only within this tool module, never exposed to Environment). */
 export const WRITE_FILE_NAME = "write_file";
@@ -74,14 +75,18 @@ export function createWriteFileTool(definition: ToolDefinitionConfig): BuiltinTo
 
       const filePath = args["file_path"];
       if (typeof filePath !== "string" || filePath.length === 0) {
-        yield delta(`Missing required argument "file_path" for ${definition.name}.`);
+        yield delta(
+          describeArgumentError(definition, args, { argument: "file_path", kind: "missing" }),
+        );
         return { stopReason: "fatal" };
       }
       // An empty string is valid content (creates an empty file); only a missing/non-string
       // value is an argument error.
       const content = args["content"];
       if (typeof content !== "string") {
-        yield delta(`Missing required argument "content" for ${definition.name}.`);
+        yield delta(
+          describeArgumentError(definition, args, { argument: "content", kind: "missing" }),
+        );
         return { stopReason: "fatal" };
       }
 

--- a/packages/core/src/internal/command-policy.ts
+++ b/packages/core/src/internal/command-policy.ts
@@ -8,7 +8,8 @@
  * always did — ask the approval boundary, record the decision, feed a denied call its
  * terminal output.
  *
- * Both tools that reach a shell are checked: `exec_command`'s `cmd` (the launch) and
+ * Both tools that reach a shell are checked: `exec_command`'s `cmd` (the launch, read through
+ * the tool's own argument list so its `command` alias is screened the same) and
  * `input_command`'s `chars` (what gets typed into an already-running one). Guarding only the
  * first would have made the guardrail exactly one interpreter launch deep — start `bash`,
  * which matches nothing, then type. The one exemption is a lone `\u0003`, which the tool
@@ -47,8 +48,12 @@
  */
 import type { ApproveFn, CommandPolicyConfig, CommandPolicyRule } from "../interfaces/index.js";
 import { effectiveCommandPolicyRules } from "../state/command-policy-defaults.js";
-import { EXEC_COMMAND_NAME } from "../environment/tools/exec-command.js";
+import {
+  EXEC_COMMAND_NAME,
+  EXEC_COMMAND_TEXT_ARGUMENTS,
+} from "../environment/tools/exec-command.js";
 import { INPUT_COMMAND_NAME, INTERRUPT } from "../environment/tools/input-command.js";
+import { stringArgument } from "../environment/tools/tool-arguments.js";
 
 /** A command-policy hit: the matched rule's name. */
 export interface CommandPolicyVeto {
@@ -114,13 +119,15 @@ export function evaluateCommandPolicy(
 }
 
 /**
- * The argument that carries shell text, per tool: `exec_command` launches one (`cmd`) and
- * `input_command` types into one already running (`chars`). Every other tool — MCP included —
- * is not the policy's business.
+ * The arguments that carry shell text, per tool, in the order the tool itself reads them:
+ * `exec_command` launches one (`cmd`, or its alias `command`) and `input_command` types into
+ * one already running (`chars`). Sharing the tool's own list is what keeps the screened text
+ * and the executed text one value. Every other tool — MCP included — is not the policy's
+ * business.
  */
-const SHELL_TEXT_ARGUMENT: Readonly<Record<string, string>> = {
-  [EXEC_COMMAND_NAME]: "cmd",
-  [INPUT_COMMAND_NAME]: "chars",
+const SHELL_TEXT_ARGUMENTS: Readonly<Record<string, readonly string[]>> = {
+  [EXEC_COMMAND_NAME]: EXEC_COMMAND_TEXT_ARGUMENTS,
+  [INPUT_COMMAND_NAME]: ["chars"],
 };
 
 /**
@@ -135,8 +142,8 @@ export function vetoForToolCall(
   argsJson: string,
   policy?: CommandPolicyConfig,
 ): CommandPolicyVeto | null {
-  const key = SHELL_TEXT_ARGUMENT[toolName];
-  if (key === undefined) return null;
+  const names = SHELL_TEXT_ARGUMENTS[toolName];
+  if (names === undefined) return null;
   let args: unknown;
   try {
     args = JSON.parse(argsJson) as unknown;
@@ -144,8 +151,8 @@ export function vetoForToolCall(
     return null;
   }
   if (args === null || typeof args !== "object" || Array.isArray(args)) return null;
-  const text = (args as Record<string, unknown>)[key];
-  if (typeof text !== "string") return null;
+  const text = stringArgument(args as Record<string, unknown>, names)?.value;
+  if (text === undefined) return null;
   if (text === INTERRUPT) return null;
   return evaluateCommandPolicy(text, policy);
 }

--- a/packages/core/test/command-policy.test.ts
+++ b/packages/core/test/command-policy.test.ts
@@ -267,6 +267,19 @@ describe("vetoForToolCall", () => {
     expect(vetoForToolCall("mcp__server__shell", json({ cmd: "rm -rf /" }))).toBeNull();
   });
 
+  it("screens the shell text under exec_command's `command` alias, reading it as the tool does", () => {
+    // The alias is what the tool runs, so it is what the policy sees — a launch is never
+    // waved through for arriving under the other accepted name.
+    expect(vetoForToolCall("exec_command", json({ command: "rm -rf /" }))?.rule).toBe(
+      "rm-recursive-force",
+    );
+    // Both present: `cmd` is the one the tool runs, and the one screened.
+    expect(vetoForToolCall("exec_command", json({ cmd: "ls", command: "rm -rf /" }))).toBeNull();
+    expect(vetoForToolCall("exec_command", json({ cmd: "rm -rf /", command: "ls" }))?.rule).toBe(
+      "rm-recursive-force",
+    );
+  });
+
   it("exempts the lone Ctrl-C, which the tool turns into SIGINT rather than typed text", () => {
     const interrupt = String.fromCharCode(3);
     expect(

--- a/packages/core/test/environment.test.ts
+++ b/packages/core/test/environment.test.ts
@@ -185,6 +185,66 @@ describe("Environment.executeTool — basic file write", () => {
   });
 });
 
+describe("Environment.executeTool — exec_command reads `command` as `cmd`", () => {
+  it("runs a call that carries the shell text as `command`", async () => {
+    const env = new Environment({ workspaceDir: tmp, toolConfig: makeToolConfig() });
+    const messages = await collect(
+      env.executeTool({
+        toolCall: toolCall({
+          name: "exec_command",
+          arguments: JSON.stringify({ command: "printf 'via-alias' > note.txt" }),
+          toolCallId: "call_alias",
+        }),
+      }),
+    );
+    const last = messages[messages.length - 1]!.payload as { type: string; stop_reason?: string };
+    expect(last.type).toBe("tool_call_output");
+    expect(last.stop_reason).toBe("completed");
+    expect(await readFileEventually(path.join(tmp, "note.txt"), "via-alias")).toBe("via-alias");
+    env.dispose();
+  });
+
+  it("runs `cmd` when both names are present", async () => {
+    const env = new Environment({ workspaceDir: tmp, toolConfig: makeToolConfig() });
+    const messages = await collect(
+      env.executeTool({
+        toolCall: toolCall({
+          name: "exec_command",
+          arguments: JSON.stringify({
+            cmd: "printf 'from-cmd' > note.txt",
+            command: "printf 'from-command' > note.txt",
+          }),
+          toolCallId: "call_both",
+        }),
+      }),
+    );
+    const last = messages[messages.length - 1]!.payload as { stop_reason?: string };
+    expect(last.stop_reason).toBe("completed");
+    expect(await readFileEventually(path.join(tmp, "note.txt"), "from-cmd")).toBe("from-cmd");
+    env.dispose();
+  });
+
+  it("explains a `command` of the wrong type as `cmd` received under its alias", async () => {
+    const env = new Environment({ workspaceDir: tmp, toolConfig: makeToolConfig() });
+    const messages = await collect(
+      env.executeTool({
+        toolCall: toolCall({
+          name: "exec_command",
+          arguments: JSON.stringify({ command: 42 }),
+          toolCallId: "call_alias_type",
+        }),
+      }),
+    );
+    const last = messages[messages.length - 1]!.payload as { output: string; stop_reason?: string };
+    expect(last.stop_reason).toBe("fatal");
+    expect(last.output).toContain(
+      'argument "cmd" (received as "command") must be a string, but a number was received.',
+    );
+    expect(last.output).not.toContain("Not a parameter");
+    env.dispose();
+  });
+});
+
 describe("Environment.executeTool — vault env injection", () => {
   it("injects vault entries into the command env; hardened entries are not overridable", async () => {
     const env = new Environment({
@@ -1274,7 +1334,14 @@ describe("Environment.executeTool — robustness", () => {
     const last = messages[messages.length - 1]!;
     const payload = last.payload as { type: string; output: string };
     expect(payload.type).toBe("tool_call_output");
-    expect(payload.output).toContain("Missing required argument");
+    // The whole output is a correction guide: the fault, the names received, the schema's
+    // parameters, and the shape of a correct call (see tool-arguments.test.ts for the format).
+    expect(payload.output).toContain(
+      'exec_command was not run: required argument "cmd" is missing.',
+    );
+    expect(payload.output).toContain("Arguments received: workdir.");
+    expect(payload.output).toContain("- cmd (string, required");
+    expect(payload.output).toContain('Call exec_command again with "cmd" provided');
   });
 
   it("reports a non-zero exit code in the final output", async () => {

--- a/packages/core/test/file-tools.test.ts
+++ b/packages/core/test/file-tools.test.ts
@@ -419,10 +419,14 @@ describe("read_file — argument coercion, CRLF, secret guard", () => {
     await writeFile(path.join(tmp, "a.txt"), "x\n");
     const badOffset = await run(tool(), { file_path: "a.txt", offset: "abc" }, tmp);
     expect(badOffset.result?.stopReason).toBe("fatal");
-    expect(badOffset.text).toContain('Invalid "offset"');
+    expect(badOffset.text).toContain(
+      'read_file was not run: argument "offset" is invalid: expected a number (got "abc").',
+    );
     const badLimit = await run(tool(), { file_path: "a.txt", limit: 0 }, tmp);
     expect(badLimit.result?.stopReason).toBe("fatal");
-    expect(badLimit.text).toContain('Invalid "limit"');
+    expect(badLimit.text).toContain(
+      'read_file was not run: argument "limit" is invalid: expected a positive number (got 0).',
+    );
   });
 
   it("strips trailing \\r from displayed lines and notes CRLF line endings", async () => {
@@ -562,7 +566,7 @@ describe("edit_file — review follow-ups", () => {
       tmp,
     );
     expect(result?.stopReason).toBe("fatal");
-    expect(text).toContain("old_string must not be empty");
+    expect(text).toContain('required argument "old_string" is empty.');
     expect(text).toContain("write_file");
   });
 

--- a/packages/core/test/tool-arguments.test.ts
+++ b/packages/core/test/tool-arguments.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+import { describeArgumentError, stringArgument } from "../src/environment/tools/tool-arguments.js";
+import type { ToolDefinitionConfig } from "../src/interfaces/index.js";
+import { defaultSystemConfig } from "../src/state/default-config.js";
+
+/** A schema shaped like the shipped exec_command entry (see state/default-config.ts). */
+const execCommand: ToolDefinitionConfig = {
+  name: "exec_command",
+  description: "Run a shell command.",
+  parameters: {
+    type: "object",
+    properties: {
+      description: { type: "string", description: "One sentence shown to the user." },
+      cmd: { type: "string", description: "Shell command to execute." },
+      workdir: { type: "string", description: "Working directory for the command." },
+      yield_time_ms: { type: "number", description: "How long to wait before yielding." },
+      run_in_background: { type: "boolean", description: "Return a process_id immediately." },
+    },
+    required: ["description", "cmd"],
+  },
+};
+
+const readFile: ToolDefinitionConfig = {
+  name: "read_file",
+  description: "Read a file.",
+  parameters: {
+    type: "object",
+    properties: {
+      file_path: { type: "string", description: "Path to read." },
+      offset: { type: "number", description: "First line to show." },
+      limit: { type: "number", description: "Maximum lines to show." },
+    },
+    required: ["file_path"],
+  },
+};
+
+const aliases = { cmd: ["command"] };
+
+describe("stringArgument", () => {
+  it("reads the first listed name that carries a string, in list order", () => {
+    expect(stringArgument({ cmd: "ls", command: "rm" }, ["cmd", "command"])).toEqual({
+      name: "cmd",
+      value: "ls",
+    });
+    expect(stringArgument({ command: "ls" }, ["cmd", "command"])).toEqual({
+      name: "command",
+      value: "ls",
+    });
+  });
+
+  it("skips a listed name whose value is not a string, and is undefined when none fits", () => {
+    expect(stringArgument({ cmd: 42, command: "ls" }, ["cmd", "command"])).toEqual({
+      name: "command",
+      value: "ls",
+    });
+    expect(stringArgument({ cmd: 42 }, ["cmd", "command"])).toBeUndefined();
+    expect(stringArgument({}, ["cmd"])).toBeUndefined();
+  });
+});
+
+describe("describeArgumentError", () => {
+  it("names the missing argument, the names received, the unknown ones, every parameter, and a correct call", () => {
+    const text = describeArgumentError(
+      execCommand,
+      { description: "list files", comand: "ls" },
+      { argument: "cmd", kind: "missing" },
+    );
+    const lines = text.split("\n");
+    expect(lines[0]).toBe('exec_command was not run: required argument "cmd" is missing.');
+    expect(lines[1]).toBe(
+      "Arguments received: description, comand. Not a parameter of exec_command: comand.",
+    );
+    expect(lines[2]).toBe("Parameters of exec_command:");
+    expect(lines).toContain("- description (string, required): One sentence shown to the user.");
+    expect(lines).toContain("- cmd (string, required): Shell command to execute.");
+    expect(lines).toContain("- workdir (string, optional): Working directory for the command.");
+    expect(lines).toContain(
+      "- yield_time_ms (number, optional): How long to wait before yielding.",
+    );
+    expect(lines).toContain(
+      "- run_in_background (boolean, optional): Return a process_id immediately.",
+    );
+    expect(lines[lines.length - 1]).toBe(
+      'Call exec_command again with "cmd" provided, as one JSON object using exactly these ' +
+        'parameter names, e.g. {"description": "<description>", "cmd": "<cmd>"}.',
+    );
+  });
+
+  it("pluralizes the unknown names and says so when nothing was received", () => {
+    expect(
+      describeArgumentError(execCommand, { a: 1, b: 2 }, { argument: "cmd", kind: "missing" }),
+    ).toContain("Arguments received: a, b. Not parameters of exec_command: a, b.");
+    expect(describeArgumentError(execCommand, {}, { argument: "cmd", kind: "missing" })).toContain(
+      "Arguments received: none.",
+    );
+  });
+
+  it("treats an alias as the parameter it stands for, and shows it beside the parameter", () => {
+    const text = describeArgumentError(
+      execCommand,
+      { description: "x", command: 42 },
+      { argument: "cmd", kind: "missing" },
+      { aliases },
+    );
+    expect(text).toContain(
+      'exec_command was not run: argument "cmd" (received as "command") must be a string, but a number was received.',
+    );
+    expect(text).toContain("Arguments received: description, command.\n");
+    expect(text).not.toContain("Not a parameter");
+    expect(text).toContain('- cmd (string, required; also accepted as "command"): Shell command');
+  });
+
+  it("distinguishes an empty value and a wrong type from an absent argument", () => {
+    expect(
+      describeArgumentError(execCommand, { cmd: "" }, { argument: "cmd", kind: "missing" }),
+    ).toContain('required argument "cmd" is empty.');
+    expect(
+      describeArgumentError(execCommand, { cmd: null }, { argument: "cmd", kind: "missing" }),
+    ).toContain('argument "cmd" must be a string, but null was received.');
+    expect(
+      describeArgumentError(execCommand, { cmd: ["ls"] }, { argument: "cmd", kind: "missing" }),
+    ).toContain('argument "cmd" must be a string, but an array was received.');
+    expect(
+      describeArgumentError(
+        execCommand,
+        { yield_time_ms: "soon" },
+        { argument: "yield_time_ms", kind: "missing" },
+      ),
+    ).toContain('argument "yield_time_ms" must be a number, but a string was received.');
+    // A schema property that declares no type (a hand-edited config) has nothing to hold the value against.
+    expect(
+      describeArgumentError(
+        {
+          ...execCommand,
+          parameters: { type: "object", properties: { cmd: {} }, required: ["cmd"] },
+        },
+        { cmd: 42 },
+        { argument: "cmd", kind: "missing" },
+      ),
+    ).toContain('argument "cmd" cannot be used as received (a number).');
+  });
+
+  it("carries an invalid argument's detail and puts that argument in the example call", () => {
+    const text = describeArgumentError(
+      readFile,
+      { file_path: "a.txt", offset: "abc" },
+      { argument: "offset", kind: "invalid", detail: 'expected a number (got "abc")' },
+    );
+    expect(text).toContain(
+      'read_file was not run: argument "offset" is invalid: expected a number (got "abc").',
+    );
+    expect(text).toContain("Arguments received: file_path, offset.\n");
+    expect(text.split("\n").pop()).toBe(
+      'Call read_file again with a valid "offset", as one JSON object using exactly these ' +
+        'parameter names, e.g. {"file_path": "<file_path>", "offset": 0}.',
+    );
+  });
+
+  it("appends the hint to the fault sentence", () => {
+    const text = describeArgumentError(
+      { ...readFile, name: "edit_file" },
+      { file_path: "f", old_string: "" },
+      { argument: "old_string", kind: "missing" },
+      { hint: "To create a file, use write_file." },
+    );
+    expect(text.split("\n")[0]).toBe(
+      'edit_file was not run: required argument "old_string" is empty. To create a file, use write_file.',
+    );
+  });
+
+  it("still explains a definition that declares no parameters", () => {
+    const text = describeArgumentError(
+      { name: "read_file", description: "Read a file." },
+      { path: "a.txt" },
+      { argument: "file_path", kind: "missing" },
+    );
+    expect(text).toBe(
+      [
+        'read_file was not run: required argument "file_path" is missing.',
+        "Arguments received: path.",
+        'Call read_file again with "file_path" provided, as one JSON object using the tool\'s parameter names.',
+      ].join("\n"),
+    );
+  });
+
+  it("keeps the tool and argument names inside the last 500 characters, the tail the error ledger records", () => {
+    // The shipped entry: its parameter descriptions alone run past the ledger's message cap.
+    const shipped = defaultSystemConfig().tools?.builtin?.find((t) => t.name === "exec_command");
+    expect(shipped).toBeDefined();
+    const text = describeArgumentError(shipped!, {}, { argument: "cmd", kind: "missing" });
+    expect(text.length).toBeGreaterThan(500);
+    const tail = text.slice(-500);
+    expect(tail).toContain("exec_command");
+    expect(tail).toContain('"cmd"');
+  });
+});

--- a/packages/docs/content/tools.en.md
+++ b/packages/docs/content/tools.en.md
@@ -43,7 +43,7 @@ A tool only yields incremental `partial_tool_call_output` deltas; the Environmen
 - never-empty output (`[no output]` is substituted when a tool produced nothing);
 - `note` (e.g. the exit code) and images are appended outside the output budget, so the terminal marker survives even when long output is cut.
 
-Tools and the Environment never throw into the engine: errors collapse into `tool_call_output` messages the model can read and react to. See the [OmniMessage Protocol](/omni-message) for message structure.
+Tools and the Environment never throw into the engine: errors collapse into `tool_call_output` messages the model can read and react to. A call whose arguments do not fit the tool ends as `fatal` with a correction guide as its whole output: the fault, the argument names received with unknown ones called out, the tool's parameters restated from its schema, and the shape of a correct call — enough to repair the call from the output alone. See the [OmniMessage Protocol](/omni-message) for message structure.
 
 ### Recovering oversized output
 
@@ -112,7 +112,7 @@ The tools' arguments (explicit keys):
 ```ts
 // exec_command
 {
-  cmd: string;             // required: the shell command to run
+  cmd: string;             // required: the shell command to run (also accepted as `command`; the schema names only `cmd`)
   workdir?: string;        // working directory; defaults to the Workspace root, relative paths resolve against it
   yield_time_ms?: number;  // foreground wait; default 60000, minimum 250, capped below the tool timeout
   run_in_background?: boolean; // true = return process_id immediately; completion arrives as a user message

--- a/packages/docs/content/tools.zh.md
+++ b/packages/docs/content/tools.zh.md
@@ -43,7 +43,7 @@ interface ToolResult {
 - 输出永不为空：没有任何输出时补 `[no output]`;
 - `note`(如退出码)与图像附加在输出预算之外，长输出被截断时终止标记不会丢失。
 
-工具与 Environment 从不向引擎抛异常：错误一律折叠为 `tool_call_output` 消息，交给模型阅读并调整下一步。消息结构见 [OmniMessage 协议](/omni-message)。
+工具与 Environment 从不向引擎抛异常：错误一律折叠为 `tool_call_output` 消息，交给模型阅读并调整下一步。参数不合工具定义的调用以 `fatal` 收尾，整段输出即一份纠错指引：出错之处、实际收到的参数名（点出 schema 未声明的名字）、按 schema 重述的全部参数，以及一次正确调用的形态——仅凭这段输出就能改对再发。消息结构见 [OmniMessage 协议](/omni-message)。
 
 ### 过长输出恢复
 
@@ -111,7 +111,7 @@ exec_command(cmd)
 ```ts
 // exec_command
 {
-  cmd: string;             // 必填:要执行的 shell 命令
+  cmd: string;             // 必填:要执行的 shell 命令(也接受别名 `command`;schema 只声明 `cmd`)
   workdir?: string;        // 工作目录;缺省为 Workspace 根,相对路径按其解析
   yield_time_ms?: number;  // 前台等待时长;默认 60000,最小 250,上限受工具超时约束
   run_in_background?: boolean; // true = 立即返回 process_id;完成回报以 user message 送达

--- a/packages/web/src/features/chat/tool-call-card.tsx
+++ b/packages/web/src/features/chat/tool-call-card.tsx
@@ -84,7 +84,10 @@ export function shortenPath(p: string): string {
  */
 export function previewArguments(name: string, argsJson: string): string {
   if (name === "exec_command") {
-    const cmd = extractStringField(argsJson, "cmd");
+    // The schema names `cmd`; core also runs a call carrying the text as `command` (its alias,
+    // see core's exec-command.ts), and a call that runs must preview — and be approved — as
+    // the command it is.
+    const cmd = extractStringField(argsJson, "cmd") ?? extractStringField(argsJson, "command");
     if (cmd !== null) return `$ ${cmd.value.replace(/\s+/g, " ").trim()}`;
   }
   const pathArg = pathArgument(name);

--- a/packages/web/test/tool-call-preview.test.ts
+++ b/packages/web/test/tool-call-preview.test.ts
@@ -22,6 +22,12 @@ describe("previewArguments", () => {
     expect(previewArguments("exec_command", '{"cmd":"echo h')).toBe("$ echo h");
   });
 
+  it("previews exec_command's shell text under the `command` alias core also runs", () => {
+    expect(previewArguments("exec_command", '{"command":"ls -la"}')).toBe("$ ls -la");
+    // `cmd` is what runs when both are present, so it is what the approval row shows.
+    expect(previewArguments("exec_command", '{"cmd":"pwd","command":"ls"}')).toBe("$ pwd");
+  });
+
   it("renders the file tools by their shortened file_path", () => {
     expect(previewArguments("read_file", '{"file_path":"src/app.py","offset":3}')).toBe(
       "src/app.py",


### PR DESCRIPTION
## Summary

Two changes to how the built-in tools take their arguments, both aimed at a model that gets a call slightly wrong and then re-issues it unchanged.

1. **`exec_command` runs a call that carries the shell text as `command`.** The schema still declares `cmd` alone; `cmd` wins when both are present. The alias is read through one list exported by the tool (`EXEC_COMMAND_TEXT_ARGUMENTS`) and shared with the command-policy gate and the Web / CLI call previews, so the policy screens exactly the text the tool runs and the `$ …` line the user approves shows it.
2. **A call rejected for its arguments now gets a complete correction guide** instead of one line. A new shared helper (`environment/tools/tool-arguments.ts`) builds it from the tool's own definition — the schema the model was handed, `call_description` filtering included:

   ```
   exec_command was not run: required argument "cmd" is missing.
   Arguments received: description, comand. Not a parameter of exec_command: comand.
   Parameters of exec_command:
   - description (string, required): Required, and emit it first, …
   - cmd (string, required; also accepted as "command"): Shell command to execute.
   - workdir (string, optional): Working directory for the command; …
   - yield_time_ms (number, optional): …
   - run_in_background (boolean, optional): …
   Call exec_command again with "cmd" provided, as one JSON object using exactly these parameter names, e.g. {"description": "<description>", "cmd": "<cmd>"}.
   ```

   The fault sentence distinguishes absent / wrong type / empty / invalid, and names the alias the argument arrived under (`argument "cmd" (received as "command") must be a string, but a number was received.`). The closing line repeats the tool and argument names because the server's error ledger keeps only the last 500 characters of a failed tool's output.

   Covered: `exec_command` (`cmd`), `input_command` (`process_id`), `run_subagent` (`prompt`), `input_subagent` (`subagent_id`), `read_file` (`file_path`, unusable `offset` / `limit`), `write_file` (`file_path`, `content`), `edit_file` (`file_path`, `old_string`, `new_string`).

## Why

Models trained on harnesses whose shell tool takes `command` emit that name even while reading a schema that says `cmd`. The rejected call was re-issued verbatim — the model believed it had followed the schema, and `Missing required argument "cmd" for exec_command.` gave it nothing to compare against. One observed session lost 124 of 155 `exec_command` calls this way (reported in #620).

Why not only the tool: the command policy read `args.cmd` directly, so a `command`-keyed launch would have been executed while never being screened. The alias therefore lives in one list the tool, the policy and the previews all read.

Overlaps with #620, which adds the alias inside the tool only (the policy gate does not see it there) and bundles unrelated OpenCode session-header changes; this PR is independent of it.

Design: Prism-Shadow/penguin-harness-design#134 (05-ARCHITECTURE: tool/Environment contract, command sessions).

## Verification

- Local: `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `git diff --check` — clean.
- On the test box (`vps3`, Node 24): `@prismshadow/penguin-core` full suite; `@prismshadow/penguin-cli` `test/tool-render.test.ts`; `@prismshadow/penguin-web` `test/tool-call-preview.test.ts`; `@prismshadow/penguin-docs` suite.
- New tests: `packages/core/test/tool-arguments.test.ts` (message format, aliases, type naming, example call, no-schema fallback, the 500-char tail invariant); alias execution and both-present precedence in `environment.test.ts`; alias screening in `command-policy.test.ts`; alias previews in the CLI and Web preview tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXyqK5bgTH99HuXmroCPYs
