### PR TITLE
fix(core): order a provider chunk's items by generation before segmenting

### DIFF
--- a/changelog/unreleased/2026-09-10-transition-chunk-order.md
+++ b/changelog/unreleased/2026-09-10-transition-chunk-order.md
@@ -3,6 +3,8 @@
 - **Date:** 2026-09-10
 - **Type:** fix
 - **Scope:** `core`
+- **PR:** [#667](https://github.com/Prism-Shadow/penguin-harness/pull/667)
+- **Issue:** [#668](https://github.com/Prism-Shadow/penguin-harness/issues/668)
 
 [中文版](2026-09-10-transition-chunk-order.zh.md)
 
@@ -11,4 +13,4 @@ The engine's event translator now orders the items of one provider chunk by gene
 ## Details
 
 - `packages/core/src/llm/generative-model.ts`: `inGenerationOrder` stable-partitions a chunk's items so every `thinking` item precedes the rest; applied in `EventTranslator.pushEvent`.
-- Regression test in `packages/core/test/llm.test.ts`: a three-chunk stream whose middle chunk carries both fields yields one thinking segment and one text segment, each complete.
+- Regression tests in `packages/core/test/llm.test.ts`: a three-chunk stream whose middle chunk carries both fields yields one thinking segment and one text segment, each complete — once with hand-built events and once with the events AgentHub's `openai-chat` client produces from raw `chat.completion.chunk` objects.

--- a/changelog/unreleased/2026-09-10-transition-chunk-order.md
+++ b/changelog/unreleased/2026-09-10-transition-chunk-order.md
@@ -1,0 +1,14 @@
+# A chunk carrying the reasoning tail and the answer head no longer splits the transcript
+
+- **Date:** 2026-09-10
+- **Type:** fix
+- **Scope:** `core`
+
+[中文版](2026-09-10-transition-chunk-order.zh.md)
+
+The engine's event translator now orders the items of one provider chunk by generation order before segmenting them: thinking first, then text and tool calls. An OpenAI-compatible gateway can batch the last `reasoning_content` token and the first `content` token into one SSE delta, and the chat client reads `content` first, so such a chunk used to arrive as [text, thinking]. Taken literally, that closed the thinking segment on the answer's first words, opened a second thinking segment for the reasoning's last word, and a second text segment for the rest — the transcript showed the answer's opening wedged between two thinking blocks, the second one a few milliseconds long with its own "Done" header. Chunks carrying a single kind are unaffected.
+
+## Details
+
+- `packages/core/src/llm/generative-model.ts`: `inGenerationOrder` stable-partitions a chunk's items so every `thinking` item precedes the rest; applied in `EventTranslator.pushEvent`.
+- Regression test in `packages/core/test/llm.test.ts`: a three-chunk stream whose middle chunk carries both fields yields one thinking segment and one text segment, each complete.

--- a/changelog/unreleased/2026-09-10-transition-chunk-order.zh.md
+++ b/changelog/unreleased/2026-09-10-transition-chunk-order.zh.md
@@ -3,6 +3,8 @@
 - **Date:** 2026-09-10
 - **Type:** fix
 - **Scope:** `core`
+- **PR:** [#667](https://github.com/Prism-Shadow/penguin-harness/pull/667)
+- **Issue:** [#668](https://github.com/Prism-Shadow/penguin-harness/issues/668)
 
 [English](2026-09-10-transition-chunk-order.md)
 
@@ -11,4 +13,4 @@
 ## Details
 
 - `packages/core/src/llm/generative-model.ts`：`inGenerationOrder` 对分片内条目做稳定分区，所有 `thinking` 条目排到最前；在 `EventTranslator.pushEvent` 中应用。
-- `packages/core/test/llm.test.ts` 新增回归测试：三个分片、中间分片同时携带两个字段的流，产出一个完整的 thinking 段和一个完整的 text 段。
+- `packages/core/test/llm.test.ts` 新增两个回归测试：三个分片、中间分片同时携带两个字段的流，产出一个完整的 thinking 段和一个完整的 text 段——一次用手工构造的事件，一次用 AgentHub `openai-chat` 客户端从原始 `chat.completion.chunk` 转换出的事件。

--- a/changelog/unreleased/2026-09-10-transition-chunk-order.zh.md
+++ b/changelog/unreleased/2026-09-10-transition-chunk-order.zh.md
@@ -1,0 +1,14 @@
+# 同一分片同时携带推理尾部与回答开头时，不再把对话切碎
+
+- **Date:** 2026-09-10
+- **Type:** fix
+- **Scope:** `core`
+
+[English](2026-09-10-transition-chunk-order.md)
+
+引擎的事件翻译器现在先把同一个 provider 分片内的条目按生成顺序排好再分段：thinking 在前，text 与 tool call 在后。OpenAI 兼容网关可能把最后一个 `reasoning_content` token 和第一个 `content` token 打进同一个 SSE delta，而 chat 客户端先读 `content`，于是这种分片以 [text, thinking] 的顺序到达。此前翻译器照单全收：回答的头几个词把 thinking 段关掉，推理的最后一个词又开出第二个 thinking 段，余下的回答再开第二个 text 段——对话里回答的开头被夹在两个思考块之间，第二个思考块只有几毫秒长，还带着自己的「Done」标题。只含一种条目的分片不受影响。
+
+## Details
+
+- `packages/core/src/llm/generative-model.ts`：`inGenerationOrder` 对分片内条目做稳定分区，所有 `thinking` 条目排到最前；在 `EventTranslator.pushEvent` 中应用。
+- `packages/core/test/llm.test.ts` 新增回归测试：三个分片、中间分片同时携带两个字段的流，产出一个完整的 thinking 段和一个完整的 text 段。

--- a/packages/core/src/llm/generative-model.ts
+++ b/packages/core/src/llm/generative-model.ts
@@ -111,6 +111,26 @@ function fidelityEquals(a?: Fidelity, b?: Fidelity): boolean {
   return JSON.stringify(a ?? {}) === JSON.stringify(b ?? {});
 }
 
+/**
+ * One provider chunk can carry both the reasoning tail and the answer head: OpenAI-compatible
+ * gateways batch tokens per SSE chunk, and `reasoning_content` and `content` are two fields of
+ * one delta with no order between them. The chat client reads `content` first, so such a chunk
+ * arrives as [text, thinking] — the reverse of generation order. Taken literally, that closes
+ * the thinking segment on the text, then opens a second thinking segment for the tail and a
+ * second text segment for the rest, and the transcript shows the answer's first words wedged
+ * between two thinking blocks. Within one chunk, thinking precedes everything else: a reasoning
+ * model emits its reasoning before its answer. Chunks that carry a single kind pass through.
+ */
+function inGenerationOrder(items: UniEvent["content_items"]): UniEvent["content_items"] {
+  if (!items.some((i) => i.type === "thinking") || items.every((i) => i.type === "thinking")) {
+    return items;
+  }
+  return [
+    ...items.filter((i) => i.type === "thinking"),
+    ...items.filter((i) => i.type !== "thinking"),
+  ];
+}
+
 /** Spread helper: attach `fidelity` only when it carries at least one key. */
 function fidelityProp(fidelity?: Fidelity): { fidelity?: Fidelity } {
   return hasFidelity(fidelity) ? { fidelity } : {};
@@ -344,7 +364,7 @@ export class EventTranslator {
       this.requestTokens = this.usageOnce(event.usage_metadata);
     }
 
-    for (const item of event.content_items) {
+    for (const item of inGenerationOrder(event.content_items)) {
       switch (item.type) {
         case "text": {
           // Mirrors AgentHub baseClient text aggregation. A `fidelity.phase` marker can arrive

--- a/packages/core/test/llm.test.ts
+++ b/packages/core/test/llm.test.ts
@@ -11,6 +11,7 @@
  */
 import { describe, expect, it } from "vitest";
 import {
+  AutoLLMClient,
   EmptyResponseError,
   ThinkingLevel,
   ToolCallArgumentParseError,
@@ -2449,5 +2450,48 @@ describe("translateEvents: a chunk carrying the reasoning tail and the answer he
       .filter((p) => p.event_type === "start")
       .map((p) => p.type);
     expect(starts).toEqual(["partial_thinking", "partial_text"]);
+  });
+});
+
+describe("the OpenAI-compatible client and the translator, end to end on a transition chunk", () => {
+  // The wire fact the ordering rests on, taken from the real client rather than assumed: a
+  // Chat Completions delta carrying both `content` and `reasoning_content` is emitted as
+  // [text, thinking]. Fed to the translator untouched, that order split one reasoning stream
+  // and one answer into thinking / text / thinking / text.
+  it("yields one thinking segment and one text segment from raw chunks", () => {
+    const client = new AutoLLMClient({
+      model: "deepseek-reasoner",
+      clientType: "openai-chat",
+      apiKey: "sk-test",
+      baseUrl: "http://127.0.0.1:9",
+    });
+    const chunk = (delta: Record<string, string>) => ({
+      id: "chatcmpl-test",
+      object: "chat.completion.chunk" as const,
+      created: 0,
+      model: "deepseek-reasoner",
+      choices: [{ index: 0, delta, finish_reason: null, logprobs: null }],
+    });
+    const events = [
+      chunk({ reasoning_content: "Let me just reorgan" }),
+      chunk({ content: "The wrapper layout", reasoning_content: "ize." }),
+      chunk({ content: " got flattened during copy." }),
+    ].map((c) => client.transformModelOutputToUniEvent(c));
+
+    expect(events[1]!.content_items.map((i) => i.type)).toEqual(["text", "thinking"]);
+
+    const { messages } = translateEvents([
+      ev({ event_type: "start", content_items: [] }),
+      ...events,
+      ev({ event_type: "stop", content_items: [], finish_reason: "stop" }),
+    ]);
+    const complete = messages
+      .map((m) => m.payload as { type: string; thinking?: string; text?: string })
+      .filter((p) => p.type === "thinking" || p.type === "text")
+      .map((p) => [p.type, p.thinking ?? p.text]);
+    expect(complete).toEqual([
+      ["thinking", "Let me just reorganize."],
+      ["text", "The wrapper layout got flattened during copy."],
+    ]);
   });
 });

--- a/packages/core/test/llm.test.ts
+++ b/packages/core/test/llm.test.ts
@@ -2410,3 +2410,44 @@ describe("tool_call_id uniquification (name-as-id providers, e.g. Gemini uses th
     expect(callIdsOf(out)).toEqual(["get_time#2"]);
   });
 });
+
+describe("translateEvents: a chunk carrying the reasoning tail and the answer head", () => {
+  // OpenAI-compatible gateways batch tokens per SSE chunk, and a chunk can carry both the
+  // last `reasoning_content` token and the first `content` token. The chat client emits the
+  // chunk's items as [text, thinking] (it reads `content` first), which is the reverse of the
+  // model's generation order. The translator must not take that order at face value.
+  it("keeps one thinking segment and one text segment, in generation order", () => {
+    const fidelity = { reasoning_field: "reasoning_content" };
+    const events: UniEvent[] = [
+      ev({ event_type: "start", content_items: [] }),
+      ev({
+        content_items: [{ type: "thinking", thinking: "Let me just reorgan", fidelity }],
+      }),
+      // The transition chunk: `content` and `reasoning_content` in the same delta.
+      ev({
+        content_items: [
+          { type: "text", text: "The wrapper layout" },
+          { type: "thinking", thinking: "ize.", fidelity },
+        ],
+      }),
+      ev({ content_items: [{ type: "text", text: " got flattened during copy." }] }),
+      ev({ event_type: "stop", content_items: [], finish_reason: "stop" }),
+    ];
+    const { messages } = translateEvents(events);
+    const complete = messages
+      .map((m) => m.payload as { type: string; thinking?: string; text?: string })
+      .filter((p) => p.type === "thinking" || p.type === "text")
+      .map((p) => [p.type, p.thinking ?? p.text]);
+    expect(complete).toEqual([
+      ["thinking", "Let me just reorganize."],
+      ["text", "The wrapper layout got flattened during copy."],
+    ]);
+
+    // The partial stream tells the same story: exactly one thinking start and one text start.
+    const starts = messages
+      .map((m) => m.payload as { type: string; event_type?: string })
+      .filter((p) => p.event_type === "start")
+      .map((p) => p.type);
+    expect(starts).toEqual(["partial_thinking", "partial_text"]);
+  });
+});


### PR DESCRIPTION
Closes #668.

## What

A user's transcript showed the answer's first words wedged between two thinking blocks: `Thinking …reorgan` / `The wrapper layout` / `Done 205ms` + `Thinking …ize.` / `got flattened …`. Read top to bottom, that is one reasoning stream ending in "reorganize." and one answer beginning "The wrapper layout got flattened…", split into thinking / text / thinking / text.

The cause is in the engine, not the Web App. OpenAI-compatible gateways batch tokens per SSE chunk, and a chunk can carry the last `reasoning_content` token and the first `content` token together. AgentHub's chat client reads `content` first, so that chunk reaches `EventTranslator.pushEvent` as `[text, thinking]`. The translator segments strictly in item order: the text closes the thinking segment, the trailing thinking opens a second one (a few milliseconds long, hence the `Done 205ms` header), and the next chunk's text opens a second text segment.

`inGenerationOrder` now stable-partitions a chunk's items so every `thinking` item precedes the rest before segmentation. Chunks carrying a single kind pass through untouched, and ordering across chunks is unchanged (the existing "text→thinking boundary is not reordered" test still holds). The same `[text, thinking]` emission exists in AgentHub's `kimi_k3` and `glm5_3` clients, so the fix sits in the translator rather than per client; an upstream reorder in AgentHub would be a complement, not a replacement.

## Tests

Both in `packages/core/test/llm.test.ts`, both failing against main's translator and passing here:

- Translator-only: a three-chunk stream whose middle chunk carries both fields in the client's order. On main it produced `thinking "Let me just reorgan" / text "The wrapper layout" / thinking "ize." / text " got flattened during copy."`.
- End to end: raw `chat.completion.chunk` objects run through the real `openai-chat` client (`AutoLLMClient` with `clientType: "openai-chat"`), asserting the client emits `[text, thinking]` for the transition chunk, then that the translator yields one complete thinking segment and one complete text segment.

## Verification

- `pnpm typecheck` (after building skills/core/server): clean.
- `pnpm lint`, `pnpm format:check`: clean.
- `packages/core`: `vitest run` — 49 files passed, 1066 tests passed, 5 skipped.

Supersedes #657 (a Web App sticky-row hypothesis that did not reproduce).