### PR TITLE
fix(web): mint client ids where crypto.randomUUID does not exist

### DIFF
--- a/changelog/unreleased/2026-09-11-web-client-id-insecure-context.md
+++ b/changelog/unreleased/2026-09-11-web-client-id-insecure-context.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-09-11
 - **Type:** fix
 - **Scope:** `web`
+- **PR:** [#675](https://github.com/Prism-Shadow/penguin-harness/pull/675)
 
 [中文版](2026-09-11-web-client-id-insecure-context.zh.md)
 

--- a/changelog/unreleased/2026-09-11-web-client-id-insecure-context.md
+++ b/changelog/unreleased/2026-09-11-web-client-id-insecure-context.md
@@ -1,0 +1,15 @@
+# Client ids minted where `crypto.randomUUID` does not exist
+
+- **Date:** 2026-09-11
+- **Type:** fix
+- **Scope:** `web`
+
+[中文版](2026-09-11-web-client-id-insecure-context.zh.md)
+
+The web app stopped calling `crypto.randomUUID`, which browsers define only in a secure context. A harness reached over plain HTTP — the usual `http://<host>:7364` on a LAN — had the button that starts a new conversation and the one that saves a shortcut die with `TypeError: crypto.randomUUID is not a function`, before any request was sent.
+
+## Details
+
+- `randomUuid()` (`packages/web/src/lib/random-uuid.ts`) assembles a v4 UUID from `crypto.getRandomValues`, which carries no secure-context restriction, and falls back to `Math.random` only where Web Crypto is absent altogether. It is random, not secret: these ids are handles the server stores and hands back, and nothing authenticates against them.
+- The two callers — the parked-draft id (`features/chat/draft-sessions.ts`) and the saved-shortcut id (`features/chat/user-shortcuts.ts`) — now take their id from it, slicing it exactly as before, so the `draft-` and `sc-` prefixes and their lengths are unchanged.
+- `test/random-uuid.test.ts` pins the v4 shape and both contexts: an id is minted with `Crypto.prototype.randomUUID` removed, and again with no Web Crypto on the global at all.

--- a/changelog/unreleased/2026-09-11-web-client-id-insecure-context.zh.md
+++ b/changelog/unreleased/2026-09-11-web-client-id-insecure-context.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-09-11
 - **Type:** fix
 - **Scope:** `web`
+- **PR:** [#675](https://github.com/Prism-Shadow/penguin-harness/pull/675)
 
 [English](2026-09-11-web-client-id-insecure-context.md)
 

--- a/changelog/unreleased/2026-09-11-web-client-id-insecure-context.zh.md
+++ b/changelog/unreleased/2026-09-11-web-client-id-insecure-context.zh.md
@@ -1,0 +1,15 @@
+# 在 `crypto.randomUUID` 不存在处生成客户端 id
+
+- **Date:** 2026-09-11
+- **Type:** fix
+- **Scope:** `web`
+
+[English](2026-09-11-web-client-id-insecure-context.md)
+
+Web 应用不再调用 `crypto.randomUUID`——浏览器只在安全上下文中定义它。通过明文 HTTP 访问的 harness（局域网中常见的 `http://<host>:7364`）上，「新建对话」与「保存快捷指令」两个按钮会以 `TypeError: crypto.randomUUID is not a function` 直接失败，任何请求都还没发出。
+
+## 细节
+
+- `randomUuid()`（`packages/web/src/lib/random-uuid.ts`）用 `crypto.getRandomValues` 拼出 v4 UUID——后者没有安全上下文的限制——只有在 Web Crypto 完全缺失时才退回 `Math.random`。它是随机而非保密：这些 id 是服务端保存并回传的句柄，没有任何东西以它们做认证。
+- 两个调用方——暂存草稿 id（`features/chat/draft-sessions.ts`）与已保存快捷指令 id（`features/chat/user-shortcuts.ts`）——改为从这里取 id，切片方式与原先完全一致，因此 `draft-` 与 `sc-` 前缀及其长度均未改变。
+- `test/random-uuid.test.ts` 固定住 v4 形状与两种上下文：在移除 `Crypto.prototype.randomUUID` 后能生成 id，在全局完全没有 Web Crypto 时也能生成 id。

--- a/packages/web/src/features/chat/draft-sessions.ts
+++ b/packages/web/src/features/chat/draft-sessions.ts
@@ -20,6 +20,7 @@
  */
 import { useStore } from "zustand/react";
 import { createStore } from "zustand/vanilla";
+import { randomUuid } from "../../lib/random-uuid";
 import { clearDraft, draftFromUnknown, draftKey, loadDraft, saveDraft } from "./draft-cache";
 import type { DraftCache, DraftStorage } from "./draft-cache";
 
@@ -126,7 +127,7 @@ export function useDraftSessions(
   );
 }
 
-const randomDraftId = (): string => `draft-${crypto.randomUUID().replace(/-/g, "").slice(0, 8)}`;
+const randomDraftId = (): string => `draft-${randomUuid().replace(/-/g, "").slice(0, 8)}`;
 
 /**
  * Moves the ACTIVE new-chat draft into the parked list when it holds typed text;

--- a/packages/web/src/features/chat/user-shortcuts.ts
+++ b/packages/web/src/features/chat/user-shortcuts.ts
@@ -22,6 +22,7 @@
  * `test/user-shortcuts.test.ts` fails if the two copies drift apart.
  */
 import type { DraftShortcut } from "@prismshadow/penguin-server/api";
+import { randomUuid } from "../../lib/random-uuid";
 
 /** A saved shortcut, as stored and as rendered. Re-exported from the API type so the two cannot drift. */
 export type UserShortcut = DraftShortcut;
@@ -38,7 +39,7 @@ export const SHORTCUT_PROMPT_MAX = 4000;
  * opaque, and never derived from the title — a rename must not change what an edit addresses.
  */
 export function newShortcutId(): string {
-  return `sc-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+  return `sc-${randomUuid().replace(/-/g, "").slice(0, 12)}`;
 }
 
 /** One trimmed, length-capped string field read back out of free-form JSON; null when unusable. */

--- a/packages/web/src/lib/random-uuid.ts
+++ b/packages/web/src/lib/random-uuid.ts
@@ -1,0 +1,35 @@
+/**
+ * A v4 UUID for the client-side ids the draft screen mints — never for a secret.
+ *
+ * `crypto.randomUUID` is defined only in a **secure context**: HTTPS, `localhost`, or a
+ * `file://` document. A harness served over plain HTTP on a LAN address (the common
+ * `http://<host>:7364` deployment) is not one, and there `crypto` exists while
+ * `crypto.randomUUID` is `undefined` — so every caller that reached for it threw
+ * `TypeError: crypto.randomUUID is not a function` at the moment of the click, before any
+ * request left the browser. `crypto.getRandomValues` carries no such restriction, so the id
+ * is assembled from it instead; a secure context gets an equally random id, and the two
+ * callers (the parked-draft id and the saved-shortcut id) behave identically either way.
+ *
+ * These ids are opaque handles the server stores and hands back — nothing authenticates
+ * against them, nothing is derived from them — so the fallback below weakens nothing that
+ * was ever a guarantee. Keep it that way: an id that has to be unguessable belongs on the
+ * server, not here.
+ */
+export function randomUuid(): string {
+  const bytes = new Uint8Array(16);
+  if (typeof crypto !== "undefined" && typeof crypto.getRandomValues === "function") {
+    crypto.getRandomValues(bytes);
+  } else {
+    // No Web Crypto at all (a test shim, an embedded view): `Math.random` still separates
+    // two ids minted in the same session, which is all these handles need.
+    for (let i = 0; i < bytes.length; i++) bytes[i] = Math.floor(Math.random() * 256);
+  }
+  // RFC 4122 version 4 (random) and variant, written as the bytes are hex-encoded, so the
+  // shape matches what `randomUUID` returns without re-reading the array.
+  const hex = Array.from(bytes, (byte, i) => {
+    if (i === 6) return ((byte & 0x0f) | 0x40).toString(16).padStart(2, "0");
+    if (i === 8) return ((byte & 0x3f) | 0x80).toString(16).padStart(2, "0");
+    return byte.toString(16).padStart(2, "0");
+  }).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/packages/web/test/random-uuid.test.ts
+++ b/packages/web/test/random-uuid.test.ts
@@ -1,0 +1,39 @@
+/**
+ * The client-side id generator (random-uuid.ts): the draft screen's ids must be mintable in
+ * every context the harness is served from, including the plain-HTTP LAN address where
+ * `crypto.randomUUID` does not exist, and must keep the v4 shape the callers slice up.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { randomUuid } from "../src/lib/random-uuid";
+
+const V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("randomUuid", () => {
+  it("returns a v4 UUID, distinct per call", () => {
+    const ids = new Set(Array.from({ length: 100 }, () => randomUuid()));
+    expect(ids.size).toBe(100);
+    for (const id of ids) expect(id).toMatch(V4);
+  });
+
+  it("does not need crypto.randomUUID (absent in a non-secure context)", () => {
+    const descriptor = Object.getOwnPropertyDescriptor(Crypto.prototype, "randomUUID");
+    Object.defineProperty(Crypto.prototype, "randomUUID", {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+    try {
+      expect(randomUuid()).toMatch(V4);
+    } finally {
+      if (descriptor) Object.defineProperty(Crypto.prototype, "randomUUID", descriptor);
+      else delete (Crypto.prototype as { randomUUID?: unknown }).randomUUID;
+    }
+  });
+
+  it("still returns an id when there is no Web Crypto at all", () => {
+    vi.stubGlobal("crypto", {});
+    expect(randomUuid()).toMatch(V4);
+  });
+});


### PR DESCRIPTION
## What this changes

`crypto.randomUUID` is defined only in a **secure context** — HTTPS, `localhost`, `file://`. A harness reached over plain HTTP (the usual `http://<host>:7364` on a LAN) has `crypto` but no `randomUUID`, so every call site died with:

```
Uncaught TypeError: crypto.randomUUID is not a function
    at rne (index-Bm9n7ZV-.js:439:4358)
    at Gu  (index-Bm9n7ZV-.js:439:4642)
```

Two of them sit behind the first click a user makes — the id for a new conversation's parked draft (`features/chat/draft-sessions.ts`, `rne`) and the id for a saved shortcut (`features/chat/user-shortcuts.ts`). The click threw before any request left the browser, so **新建对话 did nothing** on that deployment; nothing in the server logs, because nothing was sent.

This adds `randomUuid()` (`packages/web/src/lib/random-uuid.ts`): a v4 UUID assembled from `crypto.getRandomValues`, which carries no secure-context restriction, falling back to `Math.random` only where Web Crypto is absent altogether. Both callers now take their id from it and slice it exactly as before, so the `draft-<8 hex>` and `sc-<12 hex>` shapes are unchanged. The ids are opaque handles the server stores and hands back, never secrets.

## Tests

`packages/web/test/random-uuid.test.ts` (3 cases):

1. 100 calls return 100 distinct v4 UUIDs.
2. `Crypto.prototype.randomUUID` removed → still returns a v4 UUID (the shape of the reported deployment).
3. No Web Crypto on the global at all → still returns a v4 UUID.

Case 2 is the regression guard: reverting the helper to `crypto.randomUUID()` fails it.

## Verification

- `pnpm --filter @prismshadow/penguin-web test` — 130 files, 1819 tests passed.
- `pnpm --filter @prismshadow/penguin-web typecheck` — clean.
- `pnpm format:check` — clean. `pnpm lint` (oxlint) — 0 warnings, 0 errors.
- Mutation check — with `randomUuid()` replaced by a bare `crypto.randomUUID()`, `test/random-uuid.test.ts` fails 2 of 3.
- Reproduced and re-checked in the real app: Chrome (Playwright) on `http://<lan-ip>:7364`, where `isSecureContext === false`, `typeof crypto.randomUUID === "undefined"`, and the two expressions from the bundle above threw. With a UUID polyfill injected into that deployment's `index.html`, the same two expressions return `draft-…` / `sc-…`, which is what this change moves into the source.

## Checklist

- [x] Changelog entry pair under `changelog/unreleased/` (`2026-09-11-web-client-id-insecure-context.md` + `.zh.md`).
- [x] Docs — no documented behaviour changes; the ids keep their prefixes and lengths.
- [x] No credential in the diff, the logs or the screenshots.
