### PR TITLE
fix(web): mint draft and shortcut ids without crypto.randomUUID

### DIFF
--- a/changelog/unreleased/2026-09-11-random-id-insecure-context.md
+++ b/changelog/unreleased/2026-09-11-random-id-insecure-context.md
@@ -1,0 +1,14 @@
+# The "+" button parks a typed draft over plain HTTP
+
+- **Date:** 2026-09-11
+- **Type:** fix
+- **Scope:** `web`
+
+[中文版](2026-09-11-random-id-insecure-context.zh.md)
+
+Parked-draft and user-shortcut ids come from `crypto.getRandomValues` now, not
+`crypto.randomUUID`. The latter exists only in a secure context (HTTPS, or localhost), so a Web
+App opened over plain HTTP from any address but localhost threw
+`crypto.randomUUID is not a function` the moment it had to park a typed draft — a click on "+"
+while the draft held text — and every later click failed the same way while that text remained.
+The ids keep their shape: `draft-` plus 8 hex characters, `sc-` plus 12.

--- a/changelog/unreleased/2026-09-11-random-id-insecure-context.md
+++ b/changelog/unreleased/2026-09-11-random-id-insecure-context.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-09-11
 - **Type:** fix
 - **Scope:** `web`
+- **PR:** [#687](https://github.com/Prism-Shadow/penguin-harness/pull/687)
 
 [中文版](2026-09-11-random-id-insecure-context.zh.md)
 

--- a/changelog/unreleased/2026-09-11-random-id-insecure-context.zh.md
+++ b/changelog/unreleased/2026-09-11-random-id-insecure-context.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-09-11
 - **Type:** fix
 - **Scope:** `web`
+- **PR:** [#687](https://github.com/Prism-Shadow/penguin-harness/pull/687)
 
 [English](2026-09-11-random-id-insecure-context.md)
 

--- a/changelog/unreleased/2026-09-11-random-id-insecure-context.zh.md
+++ b/changelog/unreleased/2026-09-11-random-id-insecure-context.zh.md
@@ -1,0 +1,12 @@
+# 通过明文 HTTP 访问时，「+」按钮也能把已输入的草稿存入列表
+
+- **Date:** 2026-09-11
+- **Type:** fix
+- **Scope:** `web`
+
+[English](2026-09-11-random-id-insecure-context.md)
+
+草稿会话与用户快捷方式的 id 改由 `crypto.getRandomValues` 生成，不再使用 `crypto.randomUUID`。后者只在安全
+上下文（HTTPS 或 localhost）中存在，因此以明文 HTTP 从 localhost 以外的任何地址打开 Web App 时，一旦需要把
+已输入的草稿存入列表——即草稿里有文字时点击「+」——就会抛出 `crypto.randomUUID is not a function`，且只要
+文字还在，之后每次点击都同样失败。id 的形态保持不变：`draft-` 后接 8 位十六进制，`sc-` 后接 12 位。

--- a/packages/web/src/features/chat/draft-sessions.ts
+++ b/packages/web/src/features/chat/draft-sessions.ts
@@ -20,6 +20,7 @@
  */
 import { useStore } from "zustand/react";
 import { createStore } from "zustand/vanilla";
+import { randomHex } from "../../lib/random-id";
 import { clearDraft, draftFromUnknown, draftKey, loadDraft, saveDraft } from "./draft-cache";
 import type { DraftCache, DraftStorage } from "./draft-cache";
 
@@ -126,7 +127,7 @@ export function useDraftSessions(
   );
 }
 
-const randomDraftId = (): string => `draft-${crypto.randomUUID().replace(/-/g, "").slice(0, 8)}`;
+const randomDraftId = (): string => `draft-${randomHex(8)}`;
 
 /**
  * Moves the ACTIVE new-chat draft into the parked list when it holds typed text;

--- a/packages/web/src/features/chat/user-shortcuts.ts
+++ b/packages/web/src/features/chat/user-shortcuts.ts
@@ -22,6 +22,7 @@
  * `test/user-shortcuts.test.ts` fails if the two copies drift apart.
  */
 import type { DraftShortcut } from "@prismshadow/penguin-server/api";
+import { randomHex } from "../../lib/random-id";
 
 /** A saved shortcut, as stored and as rendered. Re-exported from the API type so the two cannot drift. */
 export type UserShortcut = DraftShortcut;
@@ -38,7 +39,7 @@ export const SHORTCUT_PROMPT_MAX = 4000;
  * opaque, and never derived from the title — a rename must not change what an edit addresses.
  */
 export function newShortcutId(): string {
-  return `sc-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+  return `sc-${randomHex(12)}`;
 }
 
 /** One trimmed, length-capped string field read back out of free-form JSON; null when unusable. */

--- a/packages/web/src/lib/random-id.ts
+++ b/packages/web/src/lib/random-id.ts
@@ -1,0 +1,17 @@
+/**
+ * Random ids for the things the browser mints on its own: parked drafts, user shortcuts.
+ *
+ * Drawn from `crypto.getRandomValues`, not `crypto.randomUUID`. The latter exists only in a
+ * secure context (HTTPS, or localhost), so a Web App opened over plain HTTP from any address but
+ * localhost has no such function, and the first id it tried to mint threw — which is how the "+"
+ * button died as soon as there was a typed draft to park. `getRandomValues` is present wherever
+ * `crypto` is at all.
+ */
+
+/** `length` random lowercase hex characters. */
+export function randomHex(length: number): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(Math.ceil(length / 2)));
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+    .slice(0, length);
+}

--- a/packages/web/test/random-id.test.ts
+++ b/packages/web/test/random-id.test.ts
@@ -1,15 +1,17 @@
 /**
- * randomHex (lib/random-id.ts), the generator behind parked-draft and shortcut ids. It has to
- * work in an insecure context — a Web App served over plain HTTP from any address but
- * localhost — where `crypto.randomUUID` does not exist and the previous generator threw on the
- * "+" button.
+ * randomHex (lib/random-id.ts) and the two ids it mints: parked drafts (draft-sessions.ts) and
+ * user shortcuts (user-shortcuts.ts). Both have to work in an insecure context — a Web App served
+ * over plain HTTP from any address but localhost — where `crypto.randomUUID` does not exist and
+ * the previous generator threw on the "+" button.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { draftKey, saveDraft } from "../src/features/chat/draft-cache";
+import type { DraftStorage } from "../src/features/chat/draft-cache";
+import { parkActiveDraft } from "../src/features/chat/draft-sessions";
+import { newShortcutId } from "../src/features/chat/user-shortcuts";
 import { randomHex } from "../src/lib/random-id";
 
 describe("randomHex", () => {
-  afterEach(() => vi.unstubAllGlobals());
-
   it("returns exactly the requested number of lowercase hex characters", () => {
     for (const length of [1, 8, 12, 13, 32]) {
       expect(randomHex(length)).toMatch(new RegExp(`^[0-9a-f]{${length}}$`));
@@ -20,11 +22,40 @@ describe("randomHex", () => {
     const ids = new Set(Array.from({ length: 200 }, () => randomHex(8)));
     expect(ids.size).toBe(200);
   });
+});
 
-  it("works where crypto.randomUUID is missing, as in an insecure context", () => {
+/**
+ * The regression, driven through the two functions that actually threw. Stubbing the global and
+ * then asserting on randomHex alone would prove nothing: randomHex never names randomUUID, so
+ * such a test passes just as happily with randomUUID put back into either call site.
+ */
+describe("an insecure context, where crypto carries getRandomValues and no randomUUID", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  function stubInsecureCrypto(): void {
     const real = globalThis.crypto;
     vi.stubGlobal("crypto", { getRandomValues: real.getRandomValues.bind(real) });
-    expect((globalThis.crypto as { randomUUID?: unknown }).randomUUID).toBeUndefined();
-    expect(randomHex(8)).toMatch(/^[0-9a-f]{8}$/);
+  }
+
+  /** In-memory storage: vitest runs in a Node environment, so there is no localStorage. */
+  function memStorage(): DraftStorage {
+    const map = new Map<string, string>();
+    return {
+      getItem: (k) => map.get(k) ?? null,
+      setItem: (k, v) => void map.set(k, v),
+      removeItem: (k) => void map.delete(k),
+    };
+  }
+
+  it("parks a typed draft rather than throwing on the '+' click", () => {
+    const s = memStorage();
+    stubInsecureCrypto();
+    saveDraft(draftKey("u-insecure", "proj"), { text: "half-written prompt" }, s);
+    expect(parkActiveDraft("u-insecure", "proj", s)).toMatch(/^draft-[0-9a-f]{8}$/);
+  });
+
+  it("mints a shortcut id rather than throwing on save", () => {
+    stubInsecureCrypto();
+    expect(newShortcutId()).toMatch(/^sc-[0-9a-f]{12}$/);
   });
 });

--- a/packages/web/test/random-id.test.ts
+++ b/packages/web/test/random-id.test.ts
@@ -1,0 +1,30 @@
+/**
+ * randomHex (lib/random-id.ts), the generator behind parked-draft and shortcut ids. It has to
+ * work in an insecure context — a Web App served over plain HTTP from any address but
+ * localhost — where `crypto.randomUUID` does not exist and the previous generator threw on the
+ * "+" button.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { randomHex } from "../src/lib/random-id";
+
+describe("randomHex", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("returns exactly the requested number of lowercase hex characters", () => {
+    for (const length of [1, 8, 12, 13, 32]) {
+      expect(randomHex(length)).toMatch(new RegExp(`^[0-9a-f]{${length}}$`));
+    }
+  });
+
+  it("does not repeat", () => {
+    const ids = new Set(Array.from({ length: 200 }, () => randomHex(8)));
+    expect(ids.size).toBe(200);
+  });
+
+  it("works where crypto.randomUUID is missing, as in an insecure context", () => {
+    const real = globalThis.crypto;
+    vi.stubGlobal("crypto", { getRandomValues: real.getRandomValues.bind(real) });
+    expect((globalThis.crypto as { randomUUID?: unknown }).randomUUID).toBeUndefined();
+    expect(randomHex(8)).toMatch(/^[0-9a-f]{8}$/);
+  });
+});


### PR DESCRIPTION
## Summary

Parked-draft and user-shortcut ids are minted from `crypto.getRandomValues` instead of `crypto.randomUUID`, through a small shared helper (`packages/web/src/lib/random-id.ts`). The id shapes are unchanged: `draft-` plus 8 hex characters, `sc-` plus 12.

## Why

`crypto.randomUUID` exists only in a secure context (HTTPS, or `localhost`). A Web App served over plain HTTP from any other address (a LAN IP, a hostname behind a non-TLS reverse proxy, the Docker image reached by IP) has no such function, so the first id it tried to mint threw:

```
Uncaught TypeError: crypto.randomUUID is not a function
    at rne (index-Bm9n7ZV-.js:439:4358)   // randomDraftId
    at Gu  (index-Bm9n7ZV-.js:439:4642)   // parkActiveDraft
    at Ga  (index-Bm9n7ZV-.js:448:115888) // "+" click handler
```

Every "New chat" entry point (sidebar "+", group headers, the Agents and Plugins pages, "Create with AI") calls `parkActiveDraft` first, which mints a draft id whenever the active draft holds typed text. The throw happened before the draft was moved, so the text stayed in the active slot and every later click failed the same way: once a user had typed a draft and navigated elsewhere, "+" was dead until the text was cleared by hand. Saving a user shortcut hit the same function.

`crypto.getRandomValues` is available in every context that has `crypto` at all, so no fallback branch is needed. The desktop shell loads `http://localhost:<port>` and was never affected.

## Verification

Run on the remote test host via `.agents/scripts/remote-test.sh` (core + server built there first):

- `vitest run test/random-id.test.ts test/draft-sessions.test.ts test/user-shortcuts.test.ts` — 3 files, 39 tests passed
- `pnpm --filter @prismshadow/penguin-web typecheck` — clean
- `prettier --check` on the six changed files and `git diff --check` — clean (local)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NN67fpAQm33xAnKVLpcA4n
