### PR TITLE
refactor(web): one record for every form control's font size

### DIFF
--- a/.agents/skills/penguin-harness-frontend/SKILL.md
+++ b/.agents/skills/penguin-harness-frontend/SKILL.md
@@ -156,8 +156,11 @@ one step under a `text-xs` title, and there is no rung below `text-xs` to step d
 A form field takes `sm`: dense forms, dialogs and filter bars, which is near enough the whole app.
 `base` is for a standalone page holding two controls and nothing else, and is **passed by name** —
 the login card is its only caller, and an unopted `base` is what six dialog fields had drifted into.
-The two full-height typing surfaces are outside the family entirely: the chat composer is
-`text-base` because it holds prose, the file editor `font-mono text-xs` because it holds code.
+Every control defaults to `sm` so a forgotten prop lands where its neighbours already are (the old
+`base` default put it at the roomiest rung in the densest place), but **name the rung anyway** — all
+112 call sites do, and the default is the safety net, not the habit. The two full-height typing
+surfaces are outside the family entirely: the chat composer is `text-base` because it holds prose,
+the file editor `font-mono text-xs` because it holds code.
 
 **A dialog's fields and its buttons share the small rung.** `Button` defaults to `md`
 (`text-sm px-3 py-1.5`), which is the page rung — a header's "New model", an empty state's action —

--- a/.agents/skills/penguin-harness-frontend/SKILL.md
+++ b/.agents/skills/penguin-harness-frontend/SKILL.md
@@ -155,7 +155,7 @@ one step under a `text-xs` title, and there is no rung below `text-xs` to step d
 
 A form field takes `sm`: dense forms, dialogs and filter bars, which is near enough the whole app.
 `base` is for a standalone page holding two controls and nothing else, and is **passed by name** —
-the login card is its only caller, and an unopted `base` is what six dialog fields had drifted into.
+the login card is its only caller, and an unopted `base` is what four dialog fields had drifted into.
 Every control defaults to `sm` so a forgotten prop lands where its neighbours already are (the old
 `base` default put it at the roomiest rung in the densest place), but **name the rung anyway** — all
 112 call sites do, and the default is the safety net, not the habit. The two full-height typing
@@ -170,8 +170,10 @@ a dialog *body* takes `sm` too, next to the fields it belongs with.
 
 `test/control-size.test.ts` parses the JSX and fails, naming file and line, on a font-size class in
 a `className` passed to `Input` / `Textarea` / `Select` / `OptionMenu` / `PasswordInput` /
-`FormPicker`, on a `Modal` footer Button that does not ask for `sm`, and on a second bracket font
-size inside the control modules.
+`FormPicker`, on a `Modal` footer Button that does not ask for `sm`, and on a font size spelled in
+a control module outside the two records. Its reach is what a parser sees without types: a footer
+handed over as a component or built in a variable, and a Button in a dialog body, follow the same
+rule but are on you.
 
 ## Every user-facing string is bilingual
 

--- a/.agents/skills/penguin-harness-frontend/SKILL.md
+++ b/.agents/skills/penguin-harness-frontend/SKILL.md
@@ -131,6 +131,45 @@ banners, `card` (`gap-3`) for a card row led by an avatar.
 `test/icon-scale.test.ts` fails on a stroke weight outside the chosen set and on a second copy of
 the caret, the close cross or the collapse chevron.
 
+## Control sizes
+
+One record: `sizeTextClass` in `components/ui/input.tsx`. Two rungs — `sm` is `text-xs`, `base` is
+`text-base` — and `sizeClass` pairs each with its padding. `Select`'s menu rows, `OptionMenu`'s row
+titles, `Textarea` and `FormPicker` all read it, so a rung moves the whole family at once.
+
+The rungs are **relative, not the pixel values their names suggest**. `theme.tsx`'s `FONT_PX` sets
+the root font size per tier (16/18/20px, default 18) and `styles.css` overrides no `--text-*`, so
+`text-xs` is 13.5px at the default tier rather than 12px, and every rung tracks the user's setting.
+
+**A call site passes `size`; it never spells a `text-*` class.** The caller's class and the
+component's own rung are both single-class font-size utilities of equal specificity, so which one
+wins depends on the order the CSS was generated in, not the order of classes in the string: the
+built sheet emits `.text-base` before `.text-sm` before `.text-xs`, so a caller's `text-sm` silently
+loses to an `sm` control's `text-xs`, and a bracket value beats all three. (`input.tsx`'s
+`errorClass` meets the same hazard on border and background and forces past it with `!`. A font
+size has a `size` prop instead, so it does not need to.)
+
+**No `text-[Npx]` on a control**: fixed px opts it out of the user's font-size setting altogether.
+`rowDescClass.sm` (`option-menu.tsx`) is the single grandfathered exception — a row description sits
+one step under a `text-xs` title, and there is no rung below `text-xs` to step down to.
+
+A form field takes `sm`: dense forms, dialogs and filter bars, which is near enough the whole app.
+`base` is for a standalone page holding two controls and nothing else, and is **passed by name** —
+the login card is its only caller, and an unopted `base` is what six dialog fields had drifted into.
+The two full-height typing surfaces are outside the family entirely: the chat composer is
+`text-base` because it holds prose, the file editor `font-mono text-xs` because it holds code.
+
+**A dialog's fields and its buttons share the small rung.** `Button` defaults to `md`
+(`text-sm px-3 py-1.5`), which is the page rung — a header's "New model", an empty state's action —
+so a `Modal` footer passes `size="sm"` on every button, as `ConfirmModal` always did. `Modal` owns
+the footer's wrapper but not the buttons inside it, so this cannot be set in one place; a Button in
+a dialog *body* takes `sm` too, next to the fields it belongs with.
+
+`test/control-size.test.ts` parses the JSX and fails, naming file and line, on a font-size class in
+a `className` passed to `Input` / `Textarea` / `Select` / `OptionMenu` / `PasswordInput` /
+`FormPicker`, on a `Modal` footer Button that does not ask for `sm`, and on a second bracket font
+size inside the control modules.
+
 ## Every user-facing string is bilingual
 
 Two dictionaries: `src/lib/strings.ts` is zh (and defines the `Strings` type), `src/lib/strings-en.ts`

--- a/changelog/unreleased/2026-09-11-control-size-scale.md
+++ b/changelog/unreleased/2026-09-11-control-size-scale.md
@@ -7,10 +7,10 @@
 
 [中文版](2026-09-11-control-size-scale.zh.md)
 
-The Web App's form controls spelled their font size in four places that had drifted apart, and six
-fields sat a tier above their neighbours because no call site had said which tier it wanted. The
-rung now comes from a single record, `sizeTextClass` in `components/ui/input.tsx`, and every control
-names the one it takes.
+The Web App's form controls spelled their font size in four places that had drifted apart, and four
+dialog fields sat a tier above their neighbours because no call site had said which tier it wanted.
+The rung now comes from a single record, `sizeTextClass` in `components/ui/input.tsx`, and every
+control names the one it takes.
 
 ## Details
 
@@ -25,7 +25,7 @@ names the one it takes.
   caller of that rung; its submit Button dropped a redundant `text-sm`.
 - `Input`, `Textarea`, `Select`, `OptionMenu` and `PasswordInput` default to `sm` instead of `base`,
   joining `FormPicker`, so a forgotten `size` lands on the rung its neighbours are already on rather
-  than the roomiest one — which is how the six fields above had drifted. Every call site names its
+  than the roomiest one — which is how the four fields above had drifted. Every call site names its
   rung regardless; the default only decides where the next omission lands.
 - `FormPicker` gained a `size` prop defaulting to `sm`, in place of a hard-coded tier, and
   `protocol-suffix.tsx`'s hand-rolled option menu imports `OptionMenu`'s row records rather than
@@ -44,7 +44,7 @@ names the one it takes.
 - `packages/web/test/control-size.test.ts` parses the JSX and fails, naming file and line, on a
   font-size class in a `className` passed to `Input`, `Textarea`, `Select`, `OptionMenu`,
   `PasswordInput` or `FormPicker` — such a class either does nothing or freezes the control against
-  the user's font-size setting, and neither shows up in review — and on a `Modal` footer button that
-  does not ask for `sm`.
+  the user's font-size setting, and neither shows up in review — on a `Modal` footer button that does
+  not ask for `sm`, and on a font size spelled in a control module outside the two records.
 - `.agents/skills/penguin-harness-frontend/SKILL.md` gained a "Control sizes" section recording the
   rungs, the stylesheet-order hazard behind the rule, and the one grandfathered bracket value.

--- a/changelog/unreleased/2026-09-11-control-size-scale.md
+++ b/changelog/unreleased/2026-09-11-control-size-scale.md
@@ -1,0 +1,46 @@
+# Form controls take their font size from one record
+
+- **Date:** 2026-09-11
+- **Type:** refactor
+- **Scope:** `web`, `skills`
+- **PR:** [#689](https://github.com/Prism-Shadow/penguin-harness/pull/689)
+
+[中文版](2026-09-11-control-size-scale.zh.md)
+
+The Web App's form controls spelled their font size in four places that had drifted apart, and six
+fields sat a tier above their neighbours because no call site had said which tier it wanted. The
+rung now comes from a single record, `sizeTextClass` in `components/ui/input.tsx`, and every control
+names the one it takes.
+
+## Details
+
+- `sizeClass` split into `sizeTextClass` (the font rung) and its padding. `Select`'s menu rows,
+  `OptionMenu`'s row titles and `Textarea` read the rung instead of re-spelling it — `Textarea` had
+  its own literals and matched only by coincidence, and now keeps just the padding as an explicit
+  override, a multi-line box wanting more room than a one-line input.
+- The rename-chat, rename-workspace, context-threshold and shortcuts dialogs pass `sm`, matching the
+  controls beside them; the shortcuts dialog had an `Input` at `text-base` directly above a
+  `Textarea` at `text-xs` inside one stack.
+- The login card keeps `text-base` and now asks for it by name (`size="base"`), the sole deliberate
+  caller of that rung; its submit Button dropped a redundant `text-sm`.
+- `FormPicker` gained a `size` prop defaulting to `sm`, in place of a hard-coded tier, and
+  `protocol-suffix.tsx`'s hand-rolled option menu imports `OptionMenu`'s row records rather than
+  duplicating them.
+- Four raw elements moved onto the family's rung: the machines page's search box (which also gained
+  the autofill opt-out the app's other four search boxes carry), the goal-budget input in the chat
+  composer's popover, the memory-import radio rows, and the trace-import file picker.
+- Every `Modal` footer button dropped from `Button`'s `md` default to `sm`, so a dialog's buttons
+  read at the same size as the fields above them — which is what `ConfirmModal` already did, and the
+  two dialog families had disagreed. 21 footers, 56 buttons, plus three in dialog bodies (the
+  speed-test dialog's hand-built action row and the OAuth dialog's authorize link). Page-level
+  buttons — a list header's create action, an empty state's action, the login card's submit — keep
+  `md`.
+- The chat composer and the Workspace file editor stay off the scale — one a prose surface, one a
+  code surface — and now say so where they are written.
+- `packages/web/test/control-size.test.ts` parses the JSX and fails, naming file and line, on a
+  font-size class in a `className` passed to `Input`, `Textarea`, `Select`, `OptionMenu`,
+  `PasswordInput` or `FormPicker` — such a class either does nothing or freezes the control against
+  the user's font-size setting, and neither shows up in review — and on a `Modal` footer button that
+  does not ask for `sm`.
+- `.agents/skills/penguin-harness-frontend/SKILL.md` gained a "Control sizes" section recording the
+  rungs, the stylesheet-order hazard behind the rule, and the one grandfathered bracket value.

--- a/changelog/unreleased/2026-09-11-control-size-scale.md
+++ b/changelog/unreleased/2026-09-11-control-size-scale.md
@@ -23,6 +23,10 @@ names the one it takes.
   `Textarea` at `text-xs` inside one stack.
 - The login card keeps `text-base` and now asks for it by name (`size="base"`), the sole deliberate
   caller of that rung; its submit Button dropped a redundant `text-sm`.
+- `Input`, `Textarea`, `Select`, `OptionMenu` and `PasswordInput` default to `sm` instead of `base`,
+  joining `FormPicker`, so a forgotten `size` lands on the rung its neighbours are already on rather
+  than the roomiest one — which is how the six fields above had drifted. Every call site names its
+  rung regardless; the default only decides where the next omission lands.
 - `FormPicker` gained a `size` prop defaulting to `sm`, in place of a hard-coded tier, and
   `protocol-suffix.tsx`'s hand-rolled option menu imports `OptionMenu`'s row records rather than
   duplicating them.

--- a/changelog/unreleased/2026-09-11-control-size-scale.zh.md
+++ b/changelog/unreleased/2026-09-11-control-size-scale.zh.md
@@ -7,7 +7,7 @@
 
 [English](2026-09-11-control-size-scale.md)
 
-Web App 的表单控件此前在四处各自书写字号，彼此已经走样；另有六个字段因为调用点没有声明档位，比相邻控件高出一档。
+Web App 的表单控件此前在四处各自书写字号，彼此已经走样；另有四个弹窗字段因为调用点没有声明档位，比相邻控件高出一档。
 字号现在统一来自 `components/ui/input.tsx` 中的 `sizeTextClass`，每个控件都显式声明自己所取的档位。
 
 ## 细节
@@ -20,7 +20,7 @@ Web App 的表单控件此前在四处各自书写字号，彼此已经走样；
 - 登录卡片保持 `text-base`，但改为显式声明（`size="base"`），是该档位唯一的有意调用方；其提交 Button 去掉了
   冗余的 `text-sm`。
 - `Input`、`Textarea`、`Select`、`OptionMenu` 与 `PasswordInput` 的默认档位由 `base` 改为 `sm`，与 `FormPicker`
-  看齐：漏写 `size` 时落在相邻控件已有的档位上，而不是最宽裕的那一档——上述六个字段正是这样走样的。所有调用点
+  看齐：漏写 `size` 时落在相邻控件已有的档位上，而不是最宽裕的那一档——上述四个字段正是这样走样的。所有调用点
   仍逐一声明档位，默认值只决定下一次遗漏落在哪里。
 - `FormPicker` 新增 `size` 属性（默认 `sm`），取代原先写死的档位；`protocol-suffix.tsx` 里手写的选项菜单改为
   引入 `OptionMenu` 的行记录，不再重复书写。
@@ -32,6 +32,7 @@ Web App 的表单控件此前在四处各自书写字号，彼此已经走样；
 - 对话输入区与 Workspace 文件编辑器仍在该字号族之外——一个承载散文，一个承载代码——现已在各自代码处写明缘由。
 - `packages/web/test/control-size.test.ts` 解析 JSX，一旦 `Input`、`Textarea`、`Select`、`OptionMenu`、
   `PasswordInput` 或 `FormPicker` 的 `className` 里出现字号类，即报出文件与行号并失败（这类类名要么毫无效果，
-  要么让控件不再跟随用户的字号设置，而两者在评审中都看不出来）；`Modal` 页脚按钮未声明 `sm` 时同样失败。
+  要么让控件不再跟随用户的字号设置，而两者在评审中都看不出来）；`Modal` 页脚按钮未声明 `sm`、或控件模块在
+  两份记录之外自行书写字号时，同样失败。
 - `.agents/skills/penguin-harness-frontend/SKILL.md` 新增「Control sizes」一节，记录各档位、规则背后的样式表
   顺序陷阱，以及唯一一处遗留的方括号字号。

--- a/changelog/unreleased/2026-09-11-control-size-scale.zh.md
+++ b/changelog/unreleased/2026-09-11-control-size-scale.zh.md
@@ -1,0 +1,34 @@
+# 表单控件的字号统一取自同一份记录
+
+- **Date:** 2026-09-11
+- **Type:** refactor
+- **Scope:** `web`, `skills`
+- **PR:** [#689](https://github.com/Prism-Shadow/penguin-harness/pull/689)
+
+[English](2026-09-11-control-size-scale.md)
+
+Web App 的表单控件此前在四处各自书写字号，彼此已经走样；另有六个字段因为调用点没有声明档位，比相邻控件高出一档。
+字号现在统一来自 `components/ui/input.tsx` 中的 `sizeTextClass`，每个控件都显式声明自己所取的档位。
+
+## 细节
+
+- `sizeClass` 拆为 `sizeTextClass`（字号档位）与内边距两部分。`Select` 的菜单行、`OptionMenu` 的行标题与
+  `Textarea` 改为读取该档位，不再各自书写——`Textarea` 原本用的是自己的字面量，与记录一致只是巧合；如今它只
+  保留内边距作为显式覆盖，因为多行文本框需要比单行输入框更宽裕的空间。
+- 重命名对话、重命名 Workspace、上下文阈值与快捷指令四个对话框改为传入 `sm`，与相邻控件一致；快捷指令对话框
+  原本在同一个纵向栈里，`text-base` 的 `Input` 正压在 `text-xs` 的 `Textarea` 之上。
+- 登录卡片保持 `text-base`，但改为显式声明（`size="base"`），是该档位唯一的有意调用方；其提交 Button 去掉了
+  冗余的 `text-sm`。
+- `FormPicker` 新增 `size` 属性（默认 `sm`），取代原先写死的档位；`protocol-suffix.tsx` 里手写的选项菜单改为
+  引入 `OptionMenu` 的行记录，不再重复书写。
+- 四处原生元素归入该字号族：机器页的搜索框（并补上应用内其余四个搜索框都带的自动填充退出项）、对话输入区弹层
+  里的目标预算输入框、记忆导入的单选行，以及 Trace 导入的选文件控件。
+- 所有 `Modal` 页脚按钮由 `Button` 的默认 `md` 降为 `sm`，使弹窗按钮与其上方字段读起来同样大小——`ConfirmModal`
+  本就如此，两类弹窗此前并不一致。共 21 个页脚、56 个按钮，另加三个位于弹窗正文的按钮（速度测试弹窗自建的操作行、
+  OAuth 弹窗的授权入口）。页面级按钮——列表页头的新建操作、空状态的操作、登录卡片的提交——保持 `md`。
+- 对话输入区与 Workspace 文件编辑器仍在该字号族之外——一个承载散文，一个承载代码——现已在各自代码处写明缘由。
+- `packages/web/test/control-size.test.ts` 解析 JSX，一旦 `Input`、`Textarea`、`Select`、`OptionMenu`、
+  `PasswordInput` 或 `FormPicker` 的 `className` 里出现字号类，即报出文件与行号并失败（这类类名要么毫无效果，
+  要么让控件不再跟随用户的字号设置，而两者在评审中都看不出来）；`Modal` 页脚按钮未声明 `sm` 时同样失败。
+- `.agents/skills/penguin-harness-frontend/SKILL.md` 新增「Control sizes」一节，记录各档位、规则背后的样式表
+  顺序陷阱，以及唯一一处遗留的方括号字号。

--- a/changelog/unreleased/2026-09-11-control-size-scale.zh.md
+++ b/changelog/unreleased/2026-09-11-control-size-scale.zh.md
@@ -19,6 +19,9 @@ Web App 的表单控件此前在四处各自书写字号，彼此已经走样；
   原本在同一个纵向栈里，`text-base` 的 `Input` 正压在 `text-xs` 的 `Textarea` 之上。
 - 登录卡片保持 `text-base`，但改为显式声明（`size="base"`），是该档位唯一的有意调用方；其提交 Button 去掉了
   冗余的 `text-sm`。
+- `Input`、`Textarea`、`Select`、`OptionMenu` 与 `PasswordInput` 的默认档位由 `base` 改为 `sm`，与 `FormPicker`
+  看齐：漏写 `size` 时落在相邻控件已有的档位上，而不是最宽裕的那一档——上述六个字段正是这样走样的。所有调用点
+  仍逐一声明档位，默认值只决定下一次遗漏落在哪里。
 - `FormPicker` 新增 `size` 属性（默认 `sm`），取代原先写死的档位；`protocol-suffix.tsx` 里手写的选项菜单改为
   引入 `OptionMenu` 的行记录，不再重复书写。
 - 四处原生元素归入该字号族：机器页的搜索框（并补上应用内其余四个搜索框都带的自动填充退出项）、对话输入区弹层

--- a/packages/web/src/components/account/change-password-dialog.tsx
+++ b/packages/web/src/components/account/change-password-dialog.tsx
@@ -72,10 +72,10 @@ export function ChangePasswordDialog({ open, onClose }: { open: boolean; onClose
       onClose={onClose}
       footer={
         <>
-          <Button onClick={onClose} disabled={busy}>
+          <Button size="sm" onClick={onClose} disabled={busy}>
             {S.common.cancel}
           </Button>
-          <Button variant="primary" disabled={busy} onClick={() => void submit()}>
+          <Button size="sm" variant="primary" disabled={busy} onClick={() => void submit()}>
             {S.common.save}
           </Button>
         </>

--- a/packages/web/src/components/account/update-modal.tsx
+++ b/packages/web/src/components/account/update-modal.tsx
@@ -154,7 +154,11 @@ function Body({ mode, flow }: { mode: UpdateMode; flow: UpdateFlow }): ReactNode
 }
 
 function Footer({ mode, flow }: { mode: UpdateMode; flow: UpdateFlow }): ReactNode {
-  const close = <Button onClick={closeUpdateModal}>{S.common.close}</Button>;
+  const close = (
+    <Button size="sm" onClick={closeUpdateModal}>
+      {S.common.close}
+    </Button>
+  );
   switch (flow.kind) {
     case "unknown":
     case "checking":
@@ -163,7 +167,7 @@ function Footer({ mode, flow }: { mode: UpdateMode; flow: UpdateFlow }): ReactNo
       return (
         <>
           {close}
-          <Button variant="primary" onClick={() => void checkForUpdates()}>
+          <Button size="sm" variant="primary" onClick={() => void checkForUpdates()}>
             {S.update.checkNow}
           </Button>
         </>
@@ -172,20 +176,28 @@ function Footer({ mode, flow }: { mode: UpdateMode; flow: UpdateFlow }): ReactNo
       if (!flow.canInstall) return close;
       return (
         <>
-          <Button onClick={closeUpdateModal}>{S.update.later}</Button>
-          <Button variant="primary" onClick={() => void downloadUpdate()}>
+          <Button size="sm" onClick={closeUpdateModal}>
+            {S.update.later}
+          </Button>
+          <Button size="sm" variant="primary" onClick={() => void downloadUpdate()}>
             {S.update.downloadAndInstall}
           </Button>
         </>
       );
     case "downloading":
-      return <Button onClick={closeUpdateModal}>{S.update.background}</Button>;
+      return (
+        <Button size="sm" onClick={closeUpdateModal}>
+          {S.update.background}
+        </Button>
+      );
     case "ready":
       if (flow.restart === "manual") return close;
       return (
         <>
-          <Button onClick={closeUpdateModal}>{S.update.later}</Button>
-          <Button variant="primary" onClick={() => void installUpdate()}>
+          <Button size="sm" onClick={closeUpdateModal}>
+            {S.update.later}
+          </Button>
+          <Button size="sm" variant="primary" onClick={() => void installUpdate()}>
             {S.update.restartNow}
           </Button>
         </>
@@ -197,6 +209,7 @@ function Footer({ mode, flow }: { mode: UpdateMode; flow: UpdateFlow }): ReactNo
         <>
           {close}
           <Button
+            size="sm"
             variant="primary"
             onClick={() => void (flow.retry === "check" ? checkForUpdates() : downloadUpdate())}
           >
@@ -211,7 +224,7 @@ function Footer({ mode, flow }: { mode: UpdateMode; flow: UpdateFlow }): ReactNo
         // A server refusal is a fact about the install; the check can still run again.
         <>
           {close}
-          <Button variant="primary" onClick={() => void checkForUpdates()}>
+          <Button size="sm" variant="primary" onClick={() => void checkForUpdates()}>
             {S.update.checkNow}
           </Button>
         </>

--- a/packages/web/src/components/layout/project-dialogs.tsx
+++ b/packages/web/src/components/layout/project-dialogs.tsx
@@ -114,8 +114,10 @@ export function CreateProjectDialog({
       onClose={onClose}
       footer={
         <>
-          <Button onClick={onClose}>{S.common.cancel}</Button>
-          <Button variant="primary" disabled={busy} onClick={() => void submit()}>
+          <Button size="sm" onClick={onClose}>
+            {S.common.cancel}
+          </Button>
+          <Button size="sm" variant="primary" disabled={busy} onClick={() => void submit()}>
             {S.common.create}
           </Button>
         </>

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -2275,10 +2275,11 @@ export function Sidebar({
         onClose={() => (renameBusy ? undefined : setRenamingSession(null))}
         footer={
           <>
-            <Button onClick={() => setRenamingSession(null)} disabled={renameBusy}>
+            <Button size="sm" onClick={() => setRenamingSession(null)} disabled={renameBusy}>
               {S.common.cancel}
             </Button>
             <Button
+              size="sm"
               variant="primary"
               disabled={renameBusy || !renameText.trim()}
               onClick={() => void confirmRename()}
@@ -2289,6 +2290,7 @@ export function Sidebar({
         }
       >
         <Input
+          size="sm"
           label={S.chat.renameSessionLabel}
           value={renameText}
           error={renameError ?? undefined}
@@ -2330,14 +2332,17 @@ export function Sidebar({
         onClose={() => setRenamingWorkspace(null)}
         footer={
           <>
-            <Button onClick={() => setRenamingWorkspace(null)}>{S.common.cancel}</Button>
-            <Button variant="primary" onClick={confirmRenameWorkspace}>
+            <Button size="sm" onClick={() => setRenamingWorkspace(null)}>
+              {S.common.cancel}
+            </Button>
+            <Button size="sm" variant="primary" onClick={confirmRenameWorkspace}>
               {S.common.save}
             </Button>
           </>
         }
       >
         <Input
+          size="sm"
           label={S.chat.renameWorkspaceLabel}
           hint={S.chat.renameWorkspaceHint}
           value={workspaceAliasText}

--- a/packages/web/src/components/ui/form-picker.tsx
+++ b/packages/web/src/components/ui/form-picker.tsx
@@ -1,7 +1,7 @@
 /**
  * Form-style picker shell: a full-width trigger that looks exactly like an Input/Select
- * (controlBase + the sm size tier — leading icon, truncating label, trailing chevron) with
- * a portaled dropdown hanging under its left edge. It is the single source of the
+ * (controlBase + the shared size tier, sm by default — leading icon, truncating label, trailing
+ * chevron) with a portaled dropdown hanging under its left edge. It is the single source of the
  * "form-variant" look shared by the model picker, the workspace picker and the schedule's
  * session picker, so the three read identically and none re-hand-rolls the trigger.
  *
@@ -14,6 +14,7 @@ import { Dropdown } from "./dropdown";
 import { ChevronDown } from "./icons";
 import { controlBase } from "./field";
 import { sizeClass } from "./input";
+import type { ControlSize } from "./input";
 
 export function FormPicker({
   open,
@@ -26,6 +27,7 @@ export function FormPicker({
   ariaLabel,
   ariaHaspopup = "listbox",
   disabled = false,
+  size = "sm",
   menuClass,
   children,
 }: {
@@ -43,6 +45,8 @@ export function FormPicker({
   ariaLabel: string;
   ariaHaspopup?: "listbox" | "dialog";
   disabled?: boolean;
+  /** Same size tier as Input/Select; sm is the form rung every picker sits at today. */
+  size?: ControlSize;
   /** Width / origin classes for the dropdown panel (placement itself is measured from the trigger). */
   menuClass: string;
   /** The dropdown menu body. */
@@ -63,7 +67,7 @@ export function FormPicker({
           aria-expanded={open}
           disabled={disabled}
           onClick={() => setOpen(!open)}
-          className={`flex w-full items-center gap-2 text-left ${controlBase} ${sizeClass.sm} disabled:cursor-not-allowed disabled:opacity-60`}
+          className={`flex w-full items-center gap-2 text-left ${controlBase} ${sizeClass[size]} disabled:cursor-not-allowed disabled:opacity-60`}
         >
           {leading}
           <span

--- a/packages/web/src/components/ui/input.tsx
+++ b/packages/web/src/components/ui/input.tsx
@@ -13,12 +13,26 @@ const baseClass =
   "placeholder:text-gray-400 disabled:cursor-not-allowed disabled:opacity-60 " +
   "dark:placeholder:text-gray-500";
 
-/** Size tier: base (form default) / sm (compact contexts like filter bars, keeps the toolbar from growing taller). */
+/**
+ * Size tier: sm is the form rung — dense forms, dialogs, filter bars, and what almost every
+ * control in the app takes. base is a full standalone page (the login card), which is roomier
+ * on purpose and asks for the tier by name.
+ */
 export type ControlSize = "base" | "sm";
 
+/**
+ * Font size per tier, and the only place a control's font size is spelled: Select's menu rows,
+ * OptionMenu's row titles and Textarea all read it, so moving a rung moves the whole family.
+ * The rungs are relative (`--text-*` is in rem and theme.tsx sets the root size per font tier),
+ * so a control must never be given a `text-[Npx]` — that freezes it against the user's setting.
+ */
+export const sizeTextClass: Record<ControlSize, string> = { base: "text-base", sm: "text-xs" };
+
+const sizePadClass: Record<ControlSize, string> = { base: "px-3 py-2", sm: "px-2 py-1" };
+
 export const sizeClass: Record<ControlSize, string> = {
-  base: "px-3 py-2 text-base",
-  sm: "px-2 py-1 text-xs",
+  base: `${sizePadClass.base} ${sizeTextClass.base}`,
+  sm: `${sizePadClass.sm} ${sizeTextClass.sm}`,
 };
 
 export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, "size"> {
@@ -150,8 +164,8 @@ export interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElemen
   invalid?: boolean;
   /** Monospace font (for editing Prompts/parameters). */
   mono?: boolean;
-  /** Font size: base (default, matches body text) or sm (smaller, for editing long Prompts). */
-  size?: "base" | "sm";
+  /** Same size tier as Input (sizeTextClass); sm is the form rung, base a standalone page. */
+  size?: ControlSize;
 }
 
 export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
@@ -190,7 +204,11 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function 
       <textarea
         ref={ref}
         id={info !== undefined ? controlId : id}
-        className={`${baseClass} px-3 py-2 ${size === "sm" ? "text-xs leading-relaxed" : "text-base"} ${mono ? "font-mono" : ""} ${bad ? errorClass : ""} ${className ?? ""}`}
+        // Font size comes from the shared record; the padding deliberately does NOT follow
+        // sizeClass — a multi-line box keeps the roomier px-3 py-2 at both tiers, because the
+        // sm tier's py-1 is sized for one line of text and crowds a block of them. The extra
+        // leading goes with that, and only at sm, where the lines are closest together.
+        className={`${baseClass} px-3 py-2 ${sizeTextClass[size]} ${size === "sm" ? "leading-relaxed" : ""} ${mono ? "font-mono" : ""} ${bad ? errorClass : ""} ${className ?? ""}`}
         aria-invalid={bad ? true : undefined}
         aria-required={required || undefined}
         aria-describedby={error ? errorId : undefined}

--- a/packages/web/src/components/ui/input.tsx
+++ b/packages/web/src/components/ui/input.tsx
@@ -20,7 +20,7 @@ const baseClass =
  *
  * Every control in the family defaults to sm, so a forgotten `size` lands on the rung its
  * neighbours are already on. The old default was base, which put a forgotten prop at the roomiest
- * rung in the densest place it could appear — that is how six dialog fields ended up a tier above
+ * rung in the densest place it could appear — that is how four dialog fields ended up a tier above
  * the controls beside them. The default is a safety net, not a licence: call sites still name
  * their rung.
  */

--- a/packages/web/src/components/ui/input.tsx
+++ b/packages/web/src/components/ui/input.tsx
@@ -17,6 +17,12 @@ const baseClass =
  * Size tier: sm is the form rung — dense forms, dialogs, filter bars, and what almost every
  * control in the app takes. base is a full standalone page (the login card), which is roomier
  * on purpose and asks for the tier by name.
+ *
+ * Every control in the family defaults to sm, so a forgotten `size` lands on the rung its
+ * neighbours are already on. The old default was base, which put a forgotten prop at the roomiest
+ * rung in the densest place it could appear — that is how six dialog fields ended up a tier above
+ * the controls beside them. The default is a safety net, not a licence: call sites still name
+ * their rung.
  */
 export type ControlSize = "base" | "sm";
 
@@ -111,7 +117,7 @@ export function Input({
   error,
   invalid,
   required,
-  size = "base",
+  size = "sm",
   className,
   autoComplete,
   id,
@@ -178,7 +184,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function 
     invalid,
     required,
     mono,
-    size = "base",
+    size = "sm",
     className,
     autoComplete,
     id,

--- a/packages/web/src/components/ui/option-menu.tsx
+++ b/packages/web/src/components/ui/option-menu.tsx
@@ -63,7 +63,7 @@ export function OptionMenu<T extends string>({
   error,
   required,
   fullWidth,
-  size = "base",
+  size = "sm",
   "aria-label": ariaLabel,
 }: {
   options: ReadonlyArray<OptionMenuChoice<T>>;

--- a/packages/web/src/components/ui/option-menu.tsx
+++ b/packages/web/src/components/ui/option-menu.tsx
@@ -27,7 +27,7 @@
  */
 import { useId, useState } from "react";
 import { createPortal } from "react-dom";
-import { errorClass, sizeClass } from "./input";
+import { errorClass, sizeClass, sizeTextClass } from "./input";
 import type { ControlSize } from "./input";
 import { Field, controlBase, menuRowClass } from "./field";
 import { CheckIcon, ChevronDown } from "./icons";
@@ -45,10 +45,13 @@ export interface OptionMenuChoice<T extends string> {
 
 const PANEL_WIDTH = 288; // w-72
 
-/** Row-title text follows the control's size tier, so the dropdown reads exactly like an Input of the same tier (review: dropdown text = input text); descriptions stay text-xs secondary. */
-const rowTextClass: Record<ControlSize, string> = { base: "text-base", sm: "text-xs" };
-/** Descriptions keep one step below the row title at every tier, so the title/description hierarchy survives the sm tier's text-xs titles. */
-const rowDescClass: Record<ControlSize, string> = { base: "text-xs", sm: "text-[11px]" };
+/**
+ * Descriptions keep one step below the row title at every tier, so the title/description
+ * hierarchy survives the sm tier's text-xs titles. The sm value is the one `text-[Npx]` the
+ * control family allows: there is no rung below text-xs to step down to. It is a fixed px and
+ * so does not scale with the user's font-size setting — do not copy the shape elsewhere.
+ */
+export const rowDescClass: Record<ControlSize, string> = { base: "text-xs", sm: "text-[11px]" };
 
 export function OptionMenu<T extends string>({
   options,
@@ -146,8 +149,10 @@ export function OptionMenu<T extends string>({
                 }`}
               >
                 <span className="flex items-center justify-between gap-2">
+                  {/* Row title takes the control's own tier, so the menu reads exactly like
+                      an Input of that tier. */}
                   <span
-                    className={`${rowTextClass[size]} ${
+                    className={`${sizeTextClass[size]} ${
                       opt.value === value
                         ? "font-medium text-gray-900 dark:text-gray-100"
                         : "text-gray-700 dark:text-gray-300"

--- a/packages/web/src/components/ui/password-input.tsx
+++ b/packages/web/src/components/ui/password-input.tsx
@@ -25,7 +25,7 @@ export function PasswordInput({
   error,
   invalid,
   required,
-  size = "base",
+  size = "sm",
   className,
   id,
   ...rest

--- a/packages/web/src/components/ui/select.tsx
+++ b/packages/web/src/components/ui/select.tsx
@@ -9,7 +9,7 @@
 import { Children, isValidElement, useId, useState } from "react";
 import type { ChangeEvent, ReactNode, SelectHTMLAttributes } from "react";
 import { createPortal } from "react-dom";
-import { errorClass, sizeClass } from "./input";
+import { errorClass, sizeClass, sizeTextClass } from "./input";
 import type { ControlSize } from "./input";
 import { Field, controlBase, menuRowClass } from "./field";
 import { CheckIcon, ChevronDown } from "./icons";
@@ -46,9 +46,6 @@ function parseOptions(children: ReactNode): Opt[] {
 }
 
 const CONTROL_CLASS = `flex w-full items-center gap-2 text-left ${controlBase} disabled:cursor-not-allowed disabled:opacity-60`;
-
-/** Menu-row text follows the control's size tier, so the dropdown reads exactly like an Input of the same tier (review: dropdown text = input text). */
-const menuTextClass: Record<ControlSize, string> = { base: "text-base", sm: "text-xs" };
 
 export function Select({
   label,
@@ -128,7 +125,9 @@ export function Select({
                 aria-selected={o.value === current}
                 disabled={o.disabled}
                 onClick={() => pick(o.value)}
-                className={`flex items-center ${menuRowClass} ${menuTextClass[size]} disabled:opacity-50 ${
+                // Menu-row text takes the control's own tier, so the dropdown reads exactly
+                // like an Input of that tier.
+                className={`flex items-center ${menuRowClass} ${sizeTextClass[size]} disabled:opacity-50 ${
                   o.value === current
                     ? "bg-gray-100 font-medium text-gray-900 dark:bg-gray-800 dark:text-gray-100"
                     : "text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"

--- a/packages/web/src/components/ui/select.tsx
+++ b/packages/web/src/components/ui/select.tsx
@@ -52,7 +52,7 @@ export function Select({
   hint,
   error,
   required,
-  size = "base",
+  size = "sm",
   className,
   children,
   value,

--- a/packages/web/src/features/admin/admin-users-page.tsx
+++ b/packages/web/src/features/admin/admin-users-page.tsx
@@ -182,10 +182,10 @@ function CreateUserDialog({
       onClose={onClose}
       footer={
         <>
-          <Button onClick={onClose} disabled={busy}>
+          <Button size="sm" onClick={onClose} disabled={busy}>
             {S.common.cancel}
           </Button>
-          <Button variant="primary" disabled={busy} onClick={() => void submit()}>
+          <Button size="sm" variant="primary" disabled={busy} onClick={() => void submit()}>
             {S.common.create}
           </Button>
         </>
@@ -264,10 +264,10 @@ function ResetPasswordDialog({ user, onClose }: { user: UserInfo | null; onClose
       onClose={onClose}
       footer={
         <>
-          <Button onClick={onClose} disabled={busy}>
+          <Button size="sm" onClick={onClose} disabled={busy}>
             {S.common.cancel}
           </Button>
-          <Button variant="primary" disabled={busy} onClick={() => void submit()}>
+          <Button size="sm" variant="primary" disabled={busy} onClick={() => void submit()}>
             {S.common.save}
           </Button>
         </>
@@ -334,15 +334,15 @@ function DeleteUserDialog({
       onClose={onClose}
       footer={
         <>
-          <Button onClick={onClose} disabled={busy}>
+          <Button size="sm" onClick={onClose} disabled={busy}>
             {S.common.cancel}
           </Button>
           {confirmed ? (
-            <Button variant="danger" disabled={busy} onClick={() => void doDelete()}>
+            <Button size="sm" variant="danger" disabled={busy} onClick={() => void doDelete()}>
               {S.common.confirm}
             </Button>
           ) : (
-            <Button variant="danger" onClick={() => setConfirmed(true)}>
+            <Button size="sm" variant="danger" onClick={() => setConfirmed(true)}>
               {S.common.delete}
             </Button>
           )}

--- a/packages/web/src/features/agents/agents-page.tsx
+++ b/packages/web/src/features/agents/agents-page.tsx
@@ -673,8 +673,10 @@ export function AgentsPage() {
         onClose={() => setCreateOpen(false)}
         footer={
           <>
-            <Button onClick={() => setCreateOpen(false)}>{S.common.cancel}</Button>
-            <Button variant="primary" disabled={busy} onClick={() => void create()}>
+            <Button size="sm" onClick={() => setCreateOpen(false)}>
+              {S.common.cancel}
+            </Button>
+            <Button size="sm" variant="primary" disabled={busy} onClick={() => void create()}>
               {S.common.create}
             </Button>
           </>

--- a/packages/web/src/features/agents/agents-page.tsx
+++ b/packages/web/src/features/agents/agents-page.tsx
@@ -755,6 +755,7 @@ export function AgentsPage() {
               <div>
                 <FieldLabel>{S.agent.createPlugins}</FieldLabel>
                 <FormPicker
+                  size="sm"
                   open={pluginsOpen}
                   setOpen={setPluginsOpen}
                   label={
@@ -806,6 +807,7 @@ export function AgentsPage() {
                 {skillsDir && dirSkills !== null && dirSkills.length > 0 && (
                   <div className="mt-2">
                     <FormPicker
+                      size="sm"
                       open={dirSkillsOpen}
                       setOpen={setDirSkillsOpen}
                       label={

--- a/packages/web/src/features/agents/mcp-servers-section.tsx
+++ b/packages/web/src/features/agents/mcp-servers-section.tsx
@@ -382,8 +382,10 @@ export function McpServersSection({
         onClose={closeModal}
         footer={
           <>
-            <Button onClick={closeModal}>{S.common.cancel}</Button>
-            <Button variant="primary" disabled={busy} onClick={() => void submitModal()}>
+            <Button size="sm" onClick={closeModal}>
+              {S.common.cancel}
+            </Button>
+            <Button size="sm" variant="primary" disabled={busy} onClick={() => void submitModal()}>
               {S.common.save}
             </Button>
           </>
@@ -555,8 +557,11 @@ export function McpServersSection({
         onClose={() => setTestAllOpen(false)}
         footer={
           <>
-            <Button onClick={() => setTestAllOpen(false)}>{S.common.cancel}</Button>
+            <Button size="sm" onClick={() => setTestAllOpen(false)}>
+              {S.common.cancel}
+            </Button>
             <Button
+              size="sm"
               variant="primary"
               onClick={() => {
                 setTestAllOpen(false);

--- a/packages/web/src/features/agents/memory-tab.tsx
+++ b/packages/web/src/features/agents/memory-tab.tsx
@@ -44,6 +44,7 @@ import { InfoPopover } from "../../components/ui/info-popover";
 import { HelpFold } from "../../components/ui/help-fold";
 import { Modal } from "../../components/ui/modal";
 import { Textarea } from "../../components/ui/input";
+import { rowDescClass } from "../../components/ui/option-menu";
 import { Switch } from "../../components/ui/switch";
 import { Chevron } from "../../components/ui/chevron";
 import { DownloadIcon, UploadIcon } from "../../components/ui/icons";
@@ -920,7 +921,7 @@ export function MemoryTab({
                   ["replace", S.memory.importModeReplace, S.memory.importModeReplaceHint],
                 ] as [MemoryImportMode, string, string][]
               ).map(([mode, label, hint]) => (
-                <label key={mode} className="flex cursor-pointer items-start gap-2 text-sm">
+                <label key={mode} className="flex cursor-pointer items-start gap-2 text-xs">
                   <input
                     type="radio"
                     name="memory-import-mode"
@@ -930,7 +931,10 @@ export function MemoryTab({
                   />
                   <span className="min-w-0">
                     <span className="text-gray-800 dark:text-gray-200">{label}</span>
-                    <span className="block text-xs text-gray-500 dark:text-gray-400">{hint}</span>
+                    {/* One step below the row title, the same pairing OptionMenu's rows use. */}
+                    <span className={`block ${rowDescClass.sm} text-gray-500 dark:text-gray-400`}>
+                      {hint}
+                    </span>
                   </span>
                 </label>
               ))}

--- a/packages/web/src/features/agents/vault-tab.tsx
+++ b/packages/web/src/features/agents/vault-tab.tsx
@@ -229,8 +229,10 @@ export function VaultTab({
         onClose={() => setAdding(false)}
         footer={
           <>
-            <Button onClick={() => setAdding(false)}>{S.common.cancel}</Button>
-            <Button variant="primary" disabled={busy} onClick={() => void addEntry()}>
+            <Button size="sm" onClick={() => setAdding(false)}>
+              {S.common.cancel}
+            </Button>
+            <Button size="sm" variant="primary" disabled={busy} onClick={() => void addEntry()}>
               {S.vault.add}
             </Button>
           </>

--- a/packages/web/src/features/ai-create/ai-create-modal.tsx
+++ b/packages/web/src/features/ai-create/ai-create-modal.tsx
@@ -81,13 +81,15 @@ function AiCreateDialog({
       widthClass="sm:max-w-xl"
       footer={
         <>
-          <Button onClick={onClose}>{S.common.cancel}</Button>
+          <Button size="sm" onClick={onClose}>
+            {S.common.cancel}
+          </Button>
           {/*
             One exit, and its label says where the prompt goes rather than what happens to it:
             the wand marks it as the AI path, and pressing Send is still the user's own move on
             the next screen. Disabled until there is a prompt and an agent to take it.
           */}
-          <Button variant="primary" disabled={!ready} onClick={go}>
+          <Button size="sm" variant="primary" disabled={!ready} onClick={go}>
             <GlyphIcon d={MAGIC_WAND_ICON} />
             {S.aiCreate.editInChat}
           </Button>

--- a/packages/web/src/features/chat/chat-input.tsx
+++ b/packages/web/src/features/chat/chat-input.tsx
@@ -2414,7 +2414,7 @@ export function ChatInput({
                         title={
                           goalBudgetDraftInvalid ? S.chat.goalBudgetInvalid : S.chat.goalBudgetHint
                         }
-                        className={`min-w-0 flex-1 rounded-md border bg-white px-2 py-1 font-mono text-sm leading-5 placeholder:text-gray-400 focus:outline-none focus:ring-2 dark:bg-gray-950 dark:placeholder:text-gray-500 ${
+                        className={`min-w-0 flex-1 rounded-md border bg-white px-2 py-1 font-mono text-xs leading-5 placeholder:text-gray-400 focus:outline-none focus:ring-2 dark:bg-gray-950 dark:placeholder:text-gray-500 ${
                           goalBudgetDraftInvalid
                             ? "border-red-400 text-red-600 focus:border-red-500 focus:ring-red-400/20 dark:border-red-500 dark:text-red-400"
                             : "border-gray-300 text-gray-800 focus:border-gray-500 focus:ring-gray-400/20 dark:border-gray-700 dark:text-gray-100 dark:focus:border-gray-500"
@@ -2571,6 +2571,9 @@ export function ChatInput({
                   ? S.chat.inputPlaceholderShort
                   : S.chat.inputPlaceholder
           }
+          // text-base, not the sm rung the form controls take: this is a full-height typing
+          // surface for prose the user composes and re-reads, not a field in a form, and the
+          // toolbar under it is already text-xs so the two do not compete.
           className="block max-h-44 min-h-[60px] w-full resize-none bg-transparent px-1 py-0.5 text-base leading-6 placeholder:text-gray-400 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60 dark:placeholder:text-gray-500"
         />
 

--- a/packages/web/src/features/chat/chat-page.tsx
+++ b/packages/web/src/features/chat/chat-page.tsx
@@ -2223,8 +2223,11 @@ export function ChatPage() {
         onClose={() => setCredentialGuide(false)}
         footer={
           <>
-            <Button onClick={() => setCredentialGuide(false)}>{S.project.later}</Button>
+            <Button size="sm" onClick={() => setCredentialGuide(false)}>
+              {S.project.later}
+            </Button>
             <Button
+              size="sm"
               variant="primary"
               onClick={() => {
                 setCredentialGuide(false);

--- a/packages/web/src/features/chat/context-gauge.tsx
+++ b/packages/web/src/features/chat/context-gauge.tsx
@@ -795,6 +795,7 @@ function ThresholdDialog({
       </p>
       <div className="mt-3">
         <Input
+          size="sm"
           label={S.chat.contextThresholdField}
           type="text"
           inputMode="numeric"

--- a/packages/web/src/features/chat/model-select.tsx
+++ b/packages/web/src/features/chat/model-select.tsx
@@ -326,6 +326,7 @@ export function ModelSelect({
   if (variant === "form") {
     return (
       <FormPicker
+        size="sm"
         open={open}
         setOpen={setOpen}
         leading={logo}

--- a/packages/web/src/features/chat/shortcuts-folder.tsx
+++ b/packages/web/src/features/chat/shortcuts-folder.tsx
@@ -221,8 +221,10 @@ export function ShortcutsFolder({
         widthClass="sm:max-w-lg"
         footer={
           <>
-            <Button onClick={() => setDraft(null)}>{S.common.cancel}</Button>
-            <Button variant="primary" disabled={draftError !== null} onClick={saveDraft}>
+            <Button size="sm" onClick={() => setDraft(null)}>
+              {S.common.cancel}
+            </Button>
+            <Button size="sm" variant="primary" disabled={draftError !== null} onClick={saveDraft}>
               {S.common.save}
             </Button>
           </>
@@ -231,6 +233,7 @@ export function ShortcutsFolder({
         {draft !== null && (
           <div className="space-y-3">
             <Input
+              size="sm"
               label={S.chat.shortcuts.titleLabel}
               hint={S.chat.shortcuts.titleHint(SHORTCUT_TITLE_MAX)}
               error={

--- a/packages/web/src/features/chat/workspace-editor.tsx
+++ b/packages/web/src/features/chat/workspace-editor.tsx
@@ -48,6 +48,9 @@ export function WorkspaceFileEditor({
       autoCapitalize="off"
       autoCorrect="off"
       wrap={wrap ? "soft" : "off"}
+      // font-mono text-xs, not the chat composer's text-base: this is a code surface, where
+      // fitting a long line without wrapping and seeing indentation line up matters more than
+      // reading comfort. The two full-height typing surfaces differ because prose and code do.
       className={`h-full w-full resize-none bg-transparent p-3 font-mono text-xs leading-relaxed text-gray-800 outline-none dark:text-gray-100 ${
         wrap ? "whitespace-pre-wrap" : ""
       }`}

--- a/packages/web/src/features/chat/workspace-select.tsx
+++ b/packages/web/src/features/chat/workspace-select.tsx
@@ -335,6 +335,7 @@ export function WorkspaceSelect({
   if (variant === "form") {
     return (
       <FormPicker
+        size="sm"
         open={open}
         setOpen={setFormOpen}
         leading={folderIcon("")}

--- a/packages/web/src/features/machines/machines-page.tsx
+++ b/packages/web/src/features/machines/machines-page.tsx
@@ -43,6 +43,7 @@ import { EmptyState } from "../../components/ui/empty-state";
 import { InfoPopover } from "../../components/ui/info-popover";
 import { Skeleton } from "../../components/ui/skeleton";
 import { GlyphIcon } from "../../components/ui/glyph-icon";
+import { noAutofill } from "../../components/ui/input";
 import { ChevronDown, NAV_ICONS } from "../../components/ui/icons";
 import { installButtonState, installedMachines, verdictOf } from "./machines-view";
 import type { MachineVerdict } from "./machines-view";
@@ -225,7 +226,8 @@ export function MachinesPage() {
                         onChange={(e) => setQuery(e.target.value)}
                         placeholder={S.machines.search}
                         aria-label={S.machines.search}
-                        className="w-full rounded-md border border-gray-200 bg-transparent px-2.5 py-1.5 text-sm transition-colors outline-none placeholder:text-gray-400 focus:border-gray-400 dark:border-gray-700 dark:placeholder:text-gray-500 dark:focus:border-gray-500"
+                        {...noAutofill}
+                        className="w-full rounded-md border border-gray-200 bg-transparent px-2.5 py-1.5 text-xs transition-colors outline-none placeholder:text-gray-400 focus:border-gray-400 dark:border-gray-700 dark:placeholder:text-gray-500 dark:focus:border-gray-500"
                       />
                     </div>
                   )}

--- a/packages/web/src/features/messaging/messaging-binding-modal.tsx
+++ b/packages/web/src/features/messaging/messaging-binding-modal.tsx
@@ -42,8 +42,11 @@ export function MessagingBindingModal({
       onClose={onClose}
       footer={
         <>
-          <Button onClick={onClose}>{S.common.close}</Button>
+          <Button size="sm" onClick={onClose}>
+            {S.common.close}
+          </Button>
           <Button
+            size="sm"
             variant="primary"
             disabled={b.busy || b.form === null}
             onClick={() => void b.save()}

--- a/packages/web/src/features/models/models-page.tsx
+++ b/packages/web/src/features/models/models-page.tsx
@@ -1483,9 +1483,14 @@ export function ModelsPage() {
           <p className="text-sm text-gray-600 dark:text-gray-300">
             {S.models.speedTestConfirm(rows?.filter((r) => r.provider === speedFor).length ?? 0)}
           </p>
+          {/* This dialog builds its action row in the body rather than through Modal's
+              `footer`, so it carries the footer's sm rung itself. */}
           <div className="mt-4 flex justify-end gap-2">
-            <Button onClick={() => setSpeedFor(null)}>{S.common.cancel}</Button>
+            <Button size="sm" onClick={() => setSpeedFor(null)}>
+              {S.common.cancel}
+            </Button>
             <Button
+              size="sm"
               variant="primary"
               onClick={() => {
                 const id = speedFor;
@@ -1733,18 +1738,18 @@ function AddGroupDialog({
       widthClass="sm:max-w-sm"
       footer={
         <>
-          <Button disabled={busy} onClick={onClose}>
+          <Button size="sm" disabled={busy} onClick={onClose}>
             {S.common.cancel}
           </Button>
           {mode === "create" ? (
-            <Button variant="primary" onClick={confirmCreate}>
+            <Button size="sm" variant="primary" onClick={confirmCreate}>
               {S.common.confirm}
             </Button>
           ) : (
             // The import action exists only once the protocol is determined (detected or
             // hand-picked): before that there is nothing meaningful to run.
             clientType !== null && (
-              <Button variant="primary" disabled={busy} onClick={() => void runImport()}>
+              <Button size="sm" variant="primary" disabled={busy} onClick={() => void runImport()}>
                 {S.models.groupImportAll}
               </Button>
             )
@@ -2779,9 +2784,12 @@ function ModelDialog({
       widthClass="sm:max-w-lg"
       footer={
         <>
-          <Button onClick={onClose}>{S.common.cancel}</Button>
+          <Button size="sm" onClick={onClose}>
+            {S.common.cancel}
+          </Button>
           {canEdit && (
             <Button
+              size="sm"
               variant="primary"
               // Saving may have to probe the endpoint first (protocol still unset), which
               // is a network round-trip: the label says so and the button locks, matching
@@ -3407,8 +3415,15 @@ function GroupKeyDialog({
       onClose={onClose}
       footer={
         <>
-          <Button onClick={onClose}>{S.common.cancel}</Button>
-          <Button variant="primary" disabled={!key.trim()} onClick={() => onSubmit(key.trim())}>
+          <Button size="sm" onClick={onClose}>
+            {S.common.cancel}
+          </Button>
+          <Button
+            size="sm"
+            variant="primary"
+            disabled={!key.trim()}
+            onClick={() => onSubmit(key.trim())}
+          >
             {S.common.confirm}
           </Button>
         </>
@@ -3603,11 +3618,12 @@ function ModelOAuthDialog({
 
   const primary =
     phase === "failed" ? (
-      <Button variant="primary" onClick={() => setAttempt((n) => n + 1)}>
+      <Button size="sm" variant="primary" onClick={() => setAttempt((n) => n + 1)}>
         {S.models.oauthRetry}
       </Button>
     ) : manual ? (
       <Button
+        size="sm"
         variant="primary"
         disabled={flow === null || phase === "waiting" || !code.trim()}
         onClick={() => void submitCode()}
@@ -3615,7 +3631,7 @@ function ModelOAuthDialog({
         {S.models.oauthSubmitCode}
       </Button>
     ) : (
-      <Button variant="primary" disabled={flow === null} onClick={openAuthorizePage}>
+      <Button size="sm" variant="primary" disabled={flow === null} onClick={openAuthorizePage}>
         {S.models.oauthAuthorize}
       </Button>
     );
@@ -3629,10 +3645,14 @@ function ModelOAuthDialog({
         // Done is an outcome, not a choice: a "cancel" beside it would offer to undo a key that
         // is already written.
         phase === "done" ? (
-          <Button onClick={onClose}>{S.common.close}</Button>
+          <Button size="sm" onClick={onClose}>
+            {S.common.close}
+          </Button>
         ) : (
           <>
-            <Button onClick={onClose}>{S.common.cancel}</Button>
+            <Button size="sm" onClick={onClose}>
+              {S.common.cancel}
+            </Button>
             {primary}
           </>
         )
@@ -3650,7 +3670,9 @@ function ModelOAuthDialog({
         )}
         {phase !== "done" && manual && (
           <>
-            <Button variant="ghost" disabled={flow === null} onClick={openAuthorizePage}>
+            {/* In the dialog body, directly above the code Input: it takes the same rung the
+                field does, not the page-level md. */}
+            <Button size="sm" variant="ghost" disabled={flow === null} onClick={openAuthorizePage}>
               <GlyphIcon d={SIGN_IN_ICON} size={13} />
               {S.models.oauthAuthorize}
             </Button>

--- a/packages/web/src/features/models/protocol-suffix.tsx
+++ b/packages/web/src/features/models/protocol-suffix.tsx
@@ -33,6 +33,11 @@ import { useState } from "react";
 import { Dropdown } from "../../components/ui/dropdown";
 import { CheckIcon, ChevronDown } from "../../components/ui/icons";
 import { menuRowClass } from "../../components/ui/field";
+// This menu is an OptionMenu by hand (its trigger lives inside the base URL field, which
+// OptionMenu cannot do), so it takes its row typography from OptionMenu's own records rather
+// than re-spelling them — a change to the family reaches it.
+import { rowDescClass } from "../../components/ui/option-menu";
+import { sizeTextClass } from "../../components/ui/input";
 import { S } from "../../lib/strings";
 import { protocolPathForModel } from "./protocol-path";
 import { PROTOCOL_CLIENT_TYPES } from "./protocol-types";
@@ -124,7 +129,7 @@ export function ProtocolSuffixMenu({
             >
               <span className="flex items-center justify-between gap-2">
                 <span
-                  className={`min-w-0 truncate text-xs ${
+                  className={`min-w-0 truncate ${sizeTextClass.sm} ${
                     selected
                       ? "font-medium text-gray-900 dark:text-gray-100"
                       : "text-gray-700 dark:text-gray-300"
@@ -136,7 +141,9 @@ export function ProtocolSuffixMenu({
               </span>
               {/* The path this protocol appends: the same string the trigger shows, so the
                   menu explains what the suffix in the field means. */}
-              <span className="mt-0.5 block font-mono text-[11px] text-gray-500 dark:text-gray-500">
+              <span
+                className={`mt-0.5 block font-mono ${rowDescClass.sm} text-gray-500 dark:text-gray-500`}
+              >
                 {protocolPathForModel("custom", t)}
               </span>
             </button>

--- a/packages/web/src/features/schedules/schedule-ai-modal.tsx
+++ b/packages/web/src/features/schedules/schedule-ai-modal.tsx
@@ -61,13 +61,15 @@ function ScheduleAiDialog({
       widthClass="sm:max-w-xl"
       footer={
         <>
-          <Button onClick={onClose}>{S.common.cancel}</Button>
+          <Button size="sm" onClick={onClose}>
+            {S.common.cancel}
+          </Button>
           {/*
             One exit, and its label says where the prompt goes rather than what happens to it.
             Copying lives on the prompt fold's own CopyButton (AiCreatePanel), which flips its
             glyph in place; a second copy control here would answer with a toast instead.
           */}
-          <Button variant="primary" disabled={!filled} onClick={go}>
+          <Button size="sm" variant="primary" disabled={!filled} onClick={go}>
             <GlyphIcon d={MAGIC_WAND_ICON} />
             {S.schedule.editInSession}
           </Button>

--- a/packages/web/src/features/schedules/schedule-form-modal.tsx
+++ b/packages/web/src/features/schedules/schedule-form-modal.tsx
@@ -347,8 +347,10 @@ function ScheduleFormDialog({
       widthClass="sm:max-w-lg"
       footer={
         <>
-          <Button onClick={onClose}>{S.common.cancel}</Button>
-          <Button variant="primary" disabled={busy} onClick={() => void submit()}>
+          <Button size="sm" onClick={onClose}>
+            {S.common.cancel}
+          </Button>
+          <Button size="sm" variant="primary" disabled={busy} onClick={() => void submit()}>
             {form.editing !== null ? S.common.save : S.common.create}
           </Button>
         </>

--- a/packages/web/src/features/schedules/schedule-form-modal.tsx
+++ b/packages/web/src/features/schedules/schedule-form-modal.tsx
@@ -133,6 +133,7 @@ function SessionSelect({
 
   return (
     <FormPicker
+      size="sm"
       open={open}
       setOpen={setOpen}
       label={label}

--- a/packages/web/src/features/settings/trace-import-row.tsx
+++ b/packages/web/src/features/settings/trace-import-row.tsx
@@ -154,9 +154,10 @@ export function TraceImportRow() {
           </Select>
         </div>
         {/* The file pick doubles as the confirm action (button styling on a label, so the
-            native picker opens without a detour). */}
+            native picker opens without a detour). It sits in a row with the two Selects above,
+            so it carries their sm metrics rather than Button's md ones. */}
         <label
-          className={`inline-flex shrink-0 items-center justify-center gap-1 rounded-md border border-gray-300 px-3 py-1 text-sm font-medium transition-colors duration-150 dark:border-gray-700 ${
+          className={`inline-flex shrink-0 items-center justify-center gap-1 rounded-md border border-gray-300 px-2.5 py-1 text-xs font-medium transition-colors duration-150 dark:border-gray-700 ${
             busy
               ? "pointer-events-none opacity-60"
               : "cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800"

--- a/packages/web/src/pages/login.tsx
+++ b/packages/web/src/pages/login.tsx
@@ -94,7 +94,11 @@ export function LoginPage() {
               void submit();
             }}
           >
+            {/* The two fields ask for the base tier by name, the only place in the app that
+                does. This is a standalone page holding two controls and nothing else, so it is
+                deliberately roomier than the dense forms inside the app, where sm is the rung. */}
             <Input
+              size="base"
               label={S.common.username}
               required
               value={userId}
@@ -107,6 +111,7 @@ export function LoginPage() {
               autoFocus
             />
             <PasswordInput
+              size="base"
               label={S.auth.password}
               required
               value={password}
@@ -125,7 +130,7 @@ export function LoginPage() {
             <Button
               type="submit"
               variant="primary"
-              className="w-full justify-center py-2.5 text-sm font-semibold"
+              className="w-full justify-center py-2.5 font-semibold"
               disabled={busy}
             >
               {S.auth.login}

--- a/packages/web/test/control-size.test.ts
+++ b/packages/web/test/control-size.test.ts
@@ -1,0 +1,236 @@
+/**
+ * The form-control size scale (src/components/ui/input.tsx's `sizeTextClass`).
+ *
+ * A control's font size comes from its `size` prop and nowhere else. A `text-*` in a caller's
+ * `className` does not reliably override the component's own — both are single-class font-size
+ * utilities of equal specificity, so which one wins is decided by the order Tailwind generated
+ * the stylesheet in, not by the order of classes in the string. The built sheet emits `.text-base`
+ * before `.text-sm` before `.text-xs`, which means a caller asking for `text-sm` on an `sm` control
+ * silently loses, while a `text-[13px]` wins and freezes the control against the font-size tier the
+ * user chose in settings.
+ *
+ * That is invisible in review — the class is right there in the diff, and it simply does nothing —
+ * so it is checked rather than remembered. The check parses the real JSX with the TypeScript
+ * parser: whether a class sits on a control or on the `<div>` wrapping it is a question about which
+ * element owns the attribute, and a regex over the file cannot tell those apart.
+ */
+import { describe, expect, it } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+const SRC = fileURLToPath(new URL("../src", import.meta.url));
+
+/** The controls that carry a `size` tier. A `className` on one of these may not set a font size. */
+const CONTROLS = new Set([
+  "Input",
+  "Textarea",
+  "Select",
+  "OptionMenu",
+  "PasswordInput",
+  "FormPicker",
+]);
+
+/**
+ * Font-size utilities only. `text-gray-500`, `text-left` and `text-red-600` are colour and
+ * alignment and stay a caller's business; the bracket form is included because it is the one that
+ * silently opts a control out of the user's font-size setting.
+ */
+const FONT_SIZE_CLASS = /\btext-(?:xs|sm|base|lg|xl|\d?xl|\[[^\]]+])(?![\w-])/;
+
+function tsxFiles(dir = SRC, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const path = join(dir, name);
+    if (statSync(path).isDirectory()) tsxFiles(path, out);
+    else if (name.endsWith(".tsx")) out.push(path);
+  }
+  return out;
+}
+
+const jsxTag = (node: ts.Node): string | null => {
+  if (ts.isJsxSelfClosingElement(node)) return node.tagName.getText();
+  if (ts.isJsxOpeningElement(node)) return node.tagName.getText();
+  return null;
+};
+
+/**
+ * Every literal chunk of a `className` value. A template literal's interpolations are skipped on
+ * purpose: `${sizeTextClass[size]}` is exactly the sanctioned way to reach a rung, so only the text
+ * typed around it is the caller's own spelling.
+ */
+function literalChunks(node: ts.Node, out: string[] = []): string[] {
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) out.push(node.text);
+  else if (ts.isTemplateExpression(node)) {
+    out.push(node.head.text);
+    for (const span of node.templateSpans) out.push(span.literal.text);
+  } else {
+    // The callback must return nothing: forEachChild stops at the first truthy result, so
+    // returning the accumulator here would visit one child and quietly skip the rest.
+    ts.forEachChild(node, (child) => {
+      literalChunks(child, out);
+    });
+  }
+  return out;
+}
+
+/**
+ * `<Button>`s inside a `Modal`'s `footer={…}` that do not ask for the `sm` rung. `Modal` renders
+ * only the footer's wrapper — the buttons come from each caller as an opaque node — so there is no
+ * single place to set this and the rule has to be checked instead.
+ */
+function findLooseFooterButtons(): string[] {
+  const loose: string[] = [];
+  for (const path of tsxFiles()) {
+    const source = ts.createSourceFile(
+      path,
+      readFileSync(path, "utf8"),
+      ts.ScriptTarget.Latest,
+      /* setParentNodes */ true,
+      ts.ScriptKind.TSX,
+    );
+    const visit = (node: ts.Node): void => {
+      if (ts.isJsxAttribute(node) && node.name.getText() === "footer" && node.initializer) {
+        const walk = (inner: ts.Node): void => {
+          if (jsxTag(inner) === "Button") {
+            const attrs = (inner as ts.JsxSelfClosingElement | ts.JsxOpeningElement).attributes
+              .properties;
+            const size = attrs.find(
+              (attr) => ts.isJsxAttribute(attr) && attr.name.getText() === "size",
+            );
+            if (size === undefined) {
+              const line = source.getLineAndCharacterOfPosition(inner.getStart(source)).line + 1;
+              loose.push(`${path.slice(SRC.length + 1).replaceAll(sep, "/")}:${line}`);
+            }
+          }
+          ts.forEachChild(inner, walk);
+        };
+        walk(node.initializer);
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(source);
+  }
+  return loose.sort();
+}
+
+/** Control call sites whose own `className` spells a font size, as "relative/path:line — class". */
+function findSpelledSizes(): string[] {
+  const strays: string[] = [];
+  for (const path of tsxFiles()) {
+    const source = ts.createSourceFile(
+      path,
+      readFileSync(path, "utf8"),
+      ts.ScriptTarget.Latest,
+      /* setParentNodes */ true,
+      ts.ScriptKind.TSX,
+    );
+    const visit = (node: ts.Node): void => {
+      const tag = jsxTag(node);
+      if (tag !== null && CONTROLS.has(tag)) {
+        const attrs = (node as ts.JsxSelfClosingElement | ts.JsxOpeningElement).attributes
+          .properties;
+        for (const attr of attrs) {
+          if (!ts.isJsxAttribute(attr) || attr.name.getText() !== "className") continue;
+          if (attr.initializer === undefined) continue;
+          for (const chunk of literalChunks(attr.initializer)) {
+            const hit = FONT_SIZE_CLASS.exec(chunk);
+            if (hit === null) continue;
+            const line = source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1;
+            strays.push(
+              `${path.slice(SRC.length + 1).replaceAll(sep, "/")}:${line} <${tag}> ${hit[0]}`,
+            );
+          }
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(source);
+  }
+  return strays.sort();
+}
+
+describe("control font size", () => {
+  it("is never spelled on a call site's className", () => {
+    expect(
+      findSpelledSizes(),
+      "A control's font size comes from its `size` prop (sm for a form field, base for a " +
+        "standalone page like login). A text-* class beside it either does nothing or freezes " +
+        "the control against the user's font-size setting — see components/ui/input.tsx.",
+    ).toEqual([]);
+  });
+
+  it("actually reads the control's own attribute — the check is exercised on known shapes", () => {
+    // Guards the guard: without this, the assertion above would pass just as happily on a
+    // `literalChunks` that had stopped seeing template text.
+    const found = (jsx: string): string[] => {
+      const source = ts.createSourceFile(
+        "t.tsx",
+        `const x = ${jsx};`,
+        ts.ScriptTarget.Latest,
+        true,
+        ts.ScriptKind.TSX,
+      );
+      const hits: string[] = [];
+      const visit = (node: ts.Node): void => {
+        const tag = jsxTag(node);
+        if (tag !== null && CONTROLS.has(tag)) {
+          for (const attr of (node as ts.JsxSelfClosingElement).attributes.properties) {
+            if (!ts.isJsxAttribute(attr) || attr.name.getText() !== "className") continue;
+            if (attr.initializer === undefined) continue;
+            for (const chunk of literalChunks(attr.initializer)) {
+              const hit = FONT_SIZE_CLASS.exec(chunk);
+              if (hit !== null) hits.push(hit[0]);
+            }
+          }
+        }
+        ts.forEachChild(node, visit);
+      };
+      visit(source);
+      return hits;
+    };
+    // A plain string, and inside a template around an interpolation.
+    expect(found('<Input className="w-full text-sm" />')).toEqual(["text-sm"]);
+    expect(found("<Textarea className={`w-full ${x} text-[13px]`} />")).toEqual(["text-[13px]"]);
+    // Colour, alignment and a same-prefixed utility are the caller's business, not a font size.
+    expect(found('<Select className="text-left text-gray-500 text-red-600" />')).toEqual([]);
+    // The sanctioned route: the rung arrives as an expression, never as typed text.
+    expect(found("<OptionMenu className={sizeTextClass[size]} />")).toEqual([]);
+    // The class is only a problem on the control itself.
+    expect(found('<div className="text-sm"><Input /></div>')).toEqual([]);
+  });
+
+  it("puts a dialog's buttons on the same rung as its fields", () => {
+    // A Modal footer's Buttons default to md (`text-sm px-3 py-1.5`) while the fields above them
+    // are sm (`text-xs px-2 py-1`), which is how the two dialog families drifted apart —
+    // ConfirmModal already passed sm by hand. `Modal` cannot impose it: it owns the footer's
+    // wrapper, not the buttons in it.
+    expect(
+      findLooseFooterButtons(),
+      'A Button in a Modal footer passes size="sm", so the dialog\'s buttons read at the same ' +
+        "size as its fields (compare components/ui/confirm-modal.tsx).",
+    ).toEqual([]);
+  });
+
+  it("keeps the one grandfathered bracket font size in the record that owns it", () => {
+    // text-[Npx] is fixed px: it ignores the root font size theme.tsx sets per tier, so a control
+    // carrying one stops responding to the user's font-size setting. `rowDescClass.sm` is the sole
+    // exception — an OptionMenu row's description has to sit one step under a text-xs title, and
+    // there is no rung below text-xs to step down to.
+    // String literals only: a comment naming the shape it forbids must not trip its own guard.
+    const homes = ["input.tsx", "select.tsx", "option-menu.tsx", "form-picker.tsx"]
+      .filter((name) => {
+        const path = join(SRC, "components/ui", name);
+        const source = ts.createSourceFile(
+          path,
+          readFileSync(path, "utf8"),
+          ts.ScriptTarget.Latest,
+          true,
+          ts.ScriptKind.TSX,
+        );
+        return literalChunks(source).some((chunk) => /text-\[[^\]]+]/.test(chunk));
+      })
+      .sort();
+    expect(homes).toEqual(["option-menu.tsx"]);
+  });
+});

--- a/packages/web/test/control-size.test.ts
+++ b/packages/web/test/control-size.test.ts
@@ -78,6 +78,10 @@ function literalChunks(node: ts.Node, out: string[] = []): string[] {
  * `<Button>`s inside a `Modal`'s `footer={…}` that do not ask for the `sm` rung. `Modal` renders
  * only the footer's wrapper — the buttons come from each caller as an opaque node — so there is no
  * single place to set this and the rule has to be checked instead.
+ *
+ * The reach is what a parser can see without types: Buttons written inline in the `footer={…}`
+ * attribute. A footer handed over as a component (`footer={<Footer …/>}`) or built in a variable,
+ * and a Button in a dialog *body*, are on the same rule but out of this check's sight.
  */
 function findLooseFooterButtons(): string[] {
   const loose: string[] = [];
@@ -98,9 +102,15 @@ function findLooseFooterButtons(): string[] {
             const size = attrs.find(
               (attr) => ts.isJsxAttribute(attr) && attr.name.getText() === "size",
             );
-            if (size === undefined) {
+            // The rung has to be `sm`, not merely stated: `size="md"` in a footer is the
+            // very drift this check exists for, and a missing prop takes Button's md default.
+            const rung =
+              size !== undefined && ts.isJsxAttribute(size) && size.initializer !== undefined
+                ? size.initializer.getText()
+                : "<none>";
+            if (rung !== '"sm"') {
               const line = source.getLineAndCharacterOfPosition(inner.getStart(source)).line + 1;
-              loose.push(`${path.slice(SRC.length + 1).replaceAll(sep, "/")}:${line}`);
+              loose.push(`${path.slice(SRC.length + 1).replaceAll(sep, "/")}:${line} ${rung}`);
             }
           }
           ts.forEachChild(inner, walk);
@@ -212,25 +222,46 @@ describe("control font size", () => {
     ).toEqual([]);
   });
 
-  it("keeps the one grandfathered bracket font size in the record that owns it", () => {
+  it("spells a font size in the two records and nowhere else in the family", () => {
+    // The point of the refactor, stated as the only thing a reader has to check: every font-size
+    // class the control modules contain belongs to one of two records. `select.tsx` and
+    // `form-picker.tsx` name none at all — before this scale they each kept a private copy of the
+    // same two rungs, which is how they drifted.
+    //
     // text-[Npx] is fixed px: it ignores the root font size theme.tsx sets per tier, so a control
     // carrying one stops responding to the user's font-size setting. `rowDescClass.sm` is the sole
     // exception — an OptionMenu row's description has to sit one step under a text-xs title, and
     // there is no rung below text-xs to step down to.
     // String literals only: a comment naming the shape it forbids must not trip its own guard.
-    const homes = ["input.tsx", "select.tsx", "option-menu.tsx", "form-picker.tsx"]
-      .filter((name) => {
-        const path = join(SRC, "components/ui", name);
-        const source = ts.createSourceFile(
-          path,
-          readFileSync(path, "utf8"),
-          ts.ScriptTarget.Latest,
-          true,
-          ts.ScriptKind.TSX,
-        );
-        return literalChunks(source).some((chunk) => /text-\[[^\]]+]/.test(chunk));
-      })
-      .sort();
-    expect(homes).toEqual(["option-menu.tsx"]);
+    const spelled = (name: string): string[] => {
+      const path = join(SRC, "components/ui", name);
+      const source = ts.createSourceFile(
+        path,
+        readFileSync(path, "utf8"),
+        ts.ScriptTarget.Latest,
+        true,
+        ts.ScriptKind.TSX,
+      );
+      const found = new Set<string>();
+      for (const chunk of literalChunks(source)) {
+        for (const hit of chunk.matchAll(new RegExp(FONT_SIZE_CLASS, "g"))) found.add(hit[0]);
+      }
+      return [...found].sort();
+    };
+    expect(
+      Object.fromEntries(
+        ["input.tsx", "select.tsx", "option-menu.tsx", "form-picker.tsx"].map((name) => [
+          name,
+          spelled(name),
+        ]),
+      ),
+      "A font size inside the control family lives in input.tsx's `sizeTextClass` or " +
+        "option-menu.tsx's `rowDescClass`; a third copy is how the rungs drifted apart before.",
+    ).toEqual({
+      "input.tsx": ["text-base", "text-xs"], // sizeTextClass
+      "option-menu.tsx": ["text-[11px]", "text-xs"], // rowDescClass
+      "select.tsx": [],
+      "form-picker.tsx": [],
+    });
   });
 });


### PR DESCRIPTION
The Web App's form controls spelled their font size in four places that had drifted apart
(`input.tsx`'s `sizeClass`, `select.tsx`'s `menuTextClass`, `option-menu.tsx`'s `rowTextClass`,
and `Textarea`'s own literals), and six dialog fields sat a tier above their neighbours because
no call site had said which tier it wanted. The rung now comes from one record, `sizeTextClass`
in `components/ui/input.tsx`, and every control names the one it takes.

The root font size is **not** 16px: `theme.tsx`'s `FONT_PX` is `{sm:16, md:18, lg:20}` defaulting
to `md`, and `styles.css` overrides no `--text-*`, so `text-xs` is 13.5px at the default tier.
That is why `sm` stays the form rung rather than being widened, and why a `text-[Npx]` anywhere in
a control is a regression — it opts that control out of the user's own font-size setting.

### Census (TypeScript parser, not grep)

112 `Input`/`Textarea`/`Select`/`OptionMenu`/`PasswordInput`/`FormPicker` call sites. Before: 100
explicit `sm`, 5 `FormPicker` (hard-coded `sm`), 6 unopted `base`, 0 explicit `base`. After: 104
explicit `sm`, 5 `FormPicker` (`sm` by default), 2 explicit `base`. No call site passed a `text-*`
class beside a control before or after.

### What changed

- **`sizeClass` split** into `sizeTextClass` (the rung) and its padding. `Select`'s menu rows,
  `OptionMenu`'s row titles and `Textarea` read the rung instead of re-spelling it. `Textarea` had
  its own `text-xs`/`text-base` literals and matched only by coincidence — a change to `sizeClass.sm`
  would have reached none of the app's 21 textareas. It now keeps only `px-3 py-2` as an explicit,
  commented override: a multi-line box wants more room than a one-line input.
- **Four dialogs pass `sm`**: rename chat, rename workspace, context threshold, shortcuts. The
  shortcuts dialog is the sharpest case — an `Input` at `text-base` sat directly above a `Textarea`
  at `text-xs` inside one `space-y-3`.
- **Login keeps `text-base` and now asks for it** (`size="base"`), the only deliberate caller of
  that rung; its submit Button dropped a redundant `text-sm` (it was already `md`/`text-sm`).
- **`FormPicker` gained a `size` prop** defaulting to `sm`, replacing a hard-coded `sizeClass.sm`;
  **`protocol-suffix.tsx`** (a hand-rolled `OptionMenu`) imports the row records instead of
  duplicating `text-xs` / `text-[11px]` by literal.
- **Four raw elements** moved onto the rung: the machines search box (the only one of five at
  `text-sm`, and the only one missing `{...noAutofill}` — both fixed), the goal-budget input, the
  memory-import radio rows, and the trace-import file picker.
- **Two surfaces stay off the scale and now say why**: the chat composer (`text-base`, prose) and
  the Workspace file editor (`font-mono text-xs`, code).

### Dialog footers: unified toward the smaller rung

Per the maintainer's ruling (弹窗之前也大小不一，往小的去统一吧). `Modal` footers passed no `size`,
so their Buttons were `md` (`text-sm px-3 py-1.5`) above fields at `text-xs`, while `ConfirmModal`
(`confirm-modal.tsx:97, 101, 105`) already passed `size="sm"`.

`Modal` owns the footer's **wrapper** (`modal.tsx:207-211`) but the Buttons arrive as an opaque
`ReactNode`, so there is no single place to set this — it was a per-site change, as `ConfirmModal`
itself does it. 21 footers, 56 buttons, plus 3 in dialog bodies that would otherwise have been the
odd ones out (`models-page.tsx` speed-test dialog's hand-built action row, and the OAuth dialog's
authorize link sitting directly above an `sm` `Input`). Two footers build their Buttons outside the
`footer={…}` expression — `update-modal.tsx`'s `Footer()` component and `models-page.tsx`'s
`primary` const — and were handled separately.

`Button` default-`md` call sites went 69 → 10. The 10 that remain are all page-level and keep `md`:
list-header create actions, empty-state actions, an error retry, the machines install button, three
settings rows, and the login submit. Flipping `Button`'s own default was rejected for exactly that
reason — it would have shrunk the login button this PR just made deliberately roomy.

Every dialog was looked at after the change; none reads wrong at the smaller size.

### The default now lands on `sm`

`Input`, `Textarea`, `Select`, `OptionMenu` and `PasswordInput` defaulted to `base`, joining
`FormPicker` at `sm`. That default is how the six outliers happened: a forgotten `size` landed on
the roomiest rung in the densest place it can appear, where it is conspicuous. On `sm` the same
omission lands where its neighbours already are, and `sm` is 94.6% of the app.

This retunes nothing that exists — all 112 call sites name their rung, and none of the open branches
adds a control — and **call sites keep naming it anyway**: the default is the safety net, not
permission to omit. `PasswordInput` carries its own default and forwards it, so it had to flip too
or a bare `<PasswordInput>` would have disagreed with a bare `<Input>`.

`login.tsx` already passes `size="base"`, so the login card is untouched: its screenshot is
byte-identical (`md5 5109aa132e1ccbc1ea0bc709b6663ab0`) across all three rounds — before this PR,
after the normalization, and after the default flip.

### Guard

`packages/web/test/control-size.test.ts` (4 cases) parses the real JSX the way
`test/disclosure-anchor.test.ts` does and fails, naming file and line, on:

1. a font-size class in a `className` passed to a control — the built sheet emits `.text-base`
   before `.text-sm` before `.text-xs` before bracket values, so a caller's `text-sm` silently
   **loses** to a component's `text-xs` while a bracket value beats everything (the same hazard
   `input.tsx`'s `errorClass` forces past with `!`);
2. a `Modal` footer Button that does not ask for `sm`;
3. a second bracket font size inside the control modules — `rowDescClass.sm`'s `text-[11px]` is the
   one grandfathered exception, named as such, the way Icons names `ChevronDown`/`CloseIcon`.

Both scans were verified to fire by injecting a violation and watching the named file:line appear.

`.agents/skills/penguin-harness-frontend/SKILL.md` gained a **Control sizes** section immediately
after Icons, so the codebase's two numeric scales read as a matched pair.

No spec change: `design/specs/` does not describe control typography (checked by grep — its only
hits are historical `08-CHANGELOG.md` entries and the user-facing font-size *setting*).

### Neighbours

Open PRs touch some of these files; every site was re-read immediately before editing.
**#683** (`models-page.tsx`), **#684** (`app-layout.tsx`, `sidebar.tsx`), **#682**
(`workspace-browser.tsx`, `chat-input.tsx`), and `refactor/shared-file-tree` / **#685**
(`workspace-tree-view.tsx`, `components/ui/`). **#685 also edits `SKILL.md`** — its one-sentence
correction to the *bilingual* section's `placeholders-parity` claim. This PR does not touch that
paragraph: the new section is a pure insertion before it, so the two merge cleanly.

## Verification

Node v24.18.0, from `../penguin-harness-wt/fontsize`.

```
$ pnpm --filter @prismshadow/penguin-web typecheck
$ tsc --noEmit -p tsconfig.json          # exit 0, no output

$ pnpm format && pnpm format:check
$ prettier --check .
Checking formatting...
All matched files use Prettier code style!

$ PENGUIN_TEST_HOST=vps3-test .agents/scripts/remote-test.sh <worktree> \
    --build "@prismshadow/penguin-core" -- --filter @prismshadow/penguin-web test
 Test Files  130 passed (130)
      Tests  1820 passed (1820)
   Duration  2.62s
```

The suite ran on the remote host `vps3-test`, and again unchanged after the default flip
(130 / 1820 both times). 130 files / 1820 tests = the baseline 129 / 1816 plus this PR's one new
file and its 4 cases.

CI, both commits, 20 jobs each and all green:
[34583777522](https://github.com/Prism-Shadow/penguin-harness/actions/runs/34583777522) (`720f6e3dc`)
and [34584426231](https://github.com/Prism-Shadow/penguin-harness/actions/runs/34584426231)
(`5d68b272c`).

`packages/web/e2e/` asserts on no control's text size; `chat.spec.mjs`'s rename flow and
`layout.spec.mjs`'s autofill assertion both use label-based selectors scoped to the model dialog,
untouched here. `packages/docs` does not index `.agents/skills/`.

### Looked at, not just typechecked

Built `packages/web`, served it with `PENGUIN_WEB_DIST` + `PENGUIN_SEED_ADMIN_PASSWORD` on a
scratch `PENGUIN_HOME` (port 8977, probed free with `ss -tln`), and drove it with Playwright.

| surface | before | after |
| --- | --- | --- |
| shortcuts dialog | `shots-before/2-shortcuts-dialog.png` | `shots-after/2-shortcuts-dialog.png`, `shots-footer/f1-shortcuts-dialog.png` |
| rename-chat dialog | `shots-before/3-rename-chat-dialog.png` | `shots-after/3-rename-chat-dialog.png` |
| login card | `shots-before/1-login-card.png` | `shots-after/1-login-card.png` (pixel-identical, as intended) |
| machines search row vs the other four | `4-search-inputs.png` (both states, one image) | |
| trace-import row | `5-trace-import-row.png` (both states, one image) | |
| ConfirmModal, model, agent, change-password, schedule dialogs | | `shots-footer/f2…f6` |

Paths are under this session's scratchpad
(`/tmp/claude-1017/-home-cc-dev-penguin-harness/fcdda244-9b29-434b-882a-9b2965d8c4b7/scratchpad/fontsize/`).
The machines page is nav-gated as unreleased and its search box needs >6 registered machines, so
that one comparison is a faithful standalone render against the real built stylesheet at an 18px
root rather than a live page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZVj41ZVxRkykzhyApifDY
