### PR TITLE
fix(web): the login dialog's footer button takes the rung its fields read at

### DIFF
--- a/packages/web/src/pages/login.tsx
+++ b/packages/web/src/pages/login.tsx
@@ -176,7 +176,7 @@ export function LoginPage() {
         title={S.auth.claimFailedTitle}
         onClose={() => setNoticeOpen(false)}
         footer={
-          <Button variant="primary" onClick={() => setNoticeOpen(false)}>
+          <Button size="sm" variant="primary" onClick={() => setNoticeOpen(false)}>
             {S.common.gotIt}
           </Button>
         }


### PR DESCRIPTION
`main` is red on `packages/web/test/control-size.test.ts`.

#689 tightened that file's footer guard to require every `Button` inside a `Modal` `footer={…}` to
pass `size="sm"`, so a dialog's buttons read at the same size as its fields. #690 removed that exact
prop from the claim-failure dialog's button — correctly, against the base it was reviewed on, where
it really was the only small footer button in the app. #689's sweep landed first, and squash-merging
both left `pages/login.tsx:179 <none>` failing the guard.

The guard is the convention `components/ui/confirm-modal.tsx` follows everywhere else, so the button
gets its rung back rather than the guard losing its teeth.

No changelog entry: both PRs are still in `changelog/unreleased/`, so this repairs an interaction
inside the same unreleased batch and nothing user-visible ever differed.

## Verification

```
pnpm --filter @prismshadow/penguin-web typecheck   → exit 0
pnpm lint (oxlint)                                 → exit 0
pnpm format && pnpm format:check                   → clean
```

vitest on `vps3-test` (never locally):

```
web         134 files / 1843 tests passed
pnpm -r test (whole repo, FORCE_COLOR=0)   exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXyqK5bgTH99HuXmroCPYs