### PR TITLE
test(core): sibling background subagents survive a completion notice

### DIFF
--- a/changelog/unreleased/2026-09-12-sibling-subagents-survive-notice.md
+++ b/changelog/unreleased/2026-09-12-sibling-subagents-survive-notice.md
@@ -1,0 +1,15 @@
+# A test pins that a subagent's completion notice ends no sibling
+
+- **Date:** 2026-09-12
+- **Type:** process
+- **Scope:** `core`
+- **Issue:** [#581](https://github.com/Prism-Shadow/penguin-harness/issues/581)
+
+[中文版](2026-09-12-sibling-subagents-survive-notice.zh.md)
+
+The core suite gained one test for the report that a background subagent's completion notice interrupted the other subagents still running: three `run_in_background` children on one Session, one of them settling while the Session is idle and another while a Task runs. On both delivery paths the notice reaches the model as input only, the host is signaled on the idle path alone, and the remaining children keep running until they finish on their own with `completed`.
+
+## Details
+
+- The test drives the real `Environment`, `Session` and subagent tools with a scripted runner whose children answer when released, so the timing of each completion is exact.
+- No runtime code changed: every path that can end a background child's run was read against the report and none is reached by a sibling's notice.

--- a/changelog/unreleased/2026-09-12-sibling-subagents-survive-notice.md
+++ b/changelog/unreleased/2026-09-12-sibling-subagents-survive-notice.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-09-12
 - **Type:** process
 - **Scope:** `core`
+- **PR:** [#708](https://github.com/Prism-Shadow/penguin-harness/pull/708)
 - **Issue:** [#581](https://github.com/Prism-Shadow/penguin-harness/issues/581)
 
 [中文版](2026-09-12-sibling-subagents-survive-notice.zh.md)

--- a/changelog/unreleased/2026-09-12-sibling-subagents-survive-notice.zh.md
+++ b/changelog/unreleased/2026-09-12-sibling-subagents-survive-notice.zh.md
@@ -1,0 +1,15 @@
+# 用测试钉住：子智能体的完成回报不会中断其它子智能体
+
+- **Date:** 2026-09-12
+- **Type:** process
+- **Scope:** `core`
+- **Issue:** [#581](https://github.com/Prism-Shadow/penguin-harness/issues/581)
+
+[English](2026-09-12-sibling-subagents-survive-notice.md)
+
+针对「一个后台子智能体的完成回报导致其它仍在运行的子智能体被中断」的报告，core 测试套件新增一个用例：同一 Session 上三个 `run_in_background` 子智能体，一个在 Session 空闲时结束、另一个在 Task 运行中结束。两条投递路径上，回报都只作为输入送达模型，仅空闲路径会通知宿主，其余子智能体继续运行，直到各自以 `completed` 结束。
+
+## 细节
+
+- 用例驱动真实的 `Environment`、`Session` 与子智能体工具，子智能体由脚本化的 runner 在放行时作答，因此每次结束的时机都精确可控。
+- 没有改动运行时代码：对照报告逐一读过所有能结束后台子智能体运行的路径，没有一条会被同级的完成回报触达。

--- a/changelog/unreleased/2026-09-12-sibling-subagents-survive-notice.zh.md
+++ b/changelog/unreleased/2026-09-12-sibling-subagents-survive-notice.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-09-12
 - **Type:** process
 - **Scope:** `core`
+- **PR:** [#708](https://github.com/Prism-Shadow/penguin-harness/pull/708)
 - **Issue:** [#581](https://github.com/Prism-Shadow/penguin-harness/issues/581)
 
 [English](2026-09-12-sibling-subagents-survive-notice.md)

--- a/packages/core/test/background-execution.test.ts
+++ b/packages/core/test/background-execution.test.ts
@@ -1122,10 +1122,13 @@ function gatedRunner(gates: Map<string, () => void>): SubagentRunner {
             payload: { session_id: hop },
           } as unknown as OmniMessage);
         },
-        async *run({ messages }) {
+        // Typed like the contract: a round's return value is its cutoff, and these rounds
+        // always run to completion.
+        async *run({ messages }): AsyncGenerator<OmniMessage, null> {
           const prompt = promptOf(messages);
           await new Promise<void>((resolve) => gates.set(prompt, resolve));
           yield tag(assistantText(`answer to: ${prompt}`));
+          return null;
         },
         dispose() {},
       };

--- a/packages/core/test/background-execution.test.ts
+++ b/packages/core/test/background-execution.test.ts
@@ -1094,3 +1094,120 @@ describe("Session background notices", () => {
     expect(isSteeredBackgroundNotice(texts[1]!)).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Sibling background subagents survive a completion notice (issue #581)
+// ---------------------------------------------------------------------------
+
+/**
+ * A runner whose every spawn is a distinct child (its own session id, so the registry and
+ * the live index tell three children apart) that answers once its gate is released.
+ */
+function gatedRunner(gates: Map<string, () => void>): SubagentRunner {
+  let spawned = 0;
+  return {
+    async spawn() {
+      spawned += 1;
+      const hop = `session-child-${String(spawned).padStart(8, "0")}`;
+      const tag = <M extends OmniMessage>(msg: M): M => ({ ...msg, origin: [hop] });
+      let metaSent = false;
+      const handle: SubagentHandle = {
+        sessionId: hop,
+        takeMeta() {
+          if (metaSent) return null;
+          metaSent = true;
+          return tag({
+            timestamp: new Date().toISOString(),
+            type: "session_meta",
+            payload: { session_id: hop },
+          } as unknown as OmniMessage);
+        },
+        async *run({ messages }) {
+          const prompt = promptOf(messages);
+          await new Promise<void>((resolve) => gates.set(prompt, resolve));
+          yield tag(assistantText(`answer to: ${prompt}`));
+        },
+        dispose() {},
+      };
+      return handle;
+    },
+  };
+}
+
+describe("sibling background subagents survive a completion notice (issue #581)", () => {
+  it("settling one child ends no sibling, on the idle path or on the steering path", async () => {
+    const gates = new Map<string, () => void>();
+    const dir = await mkdtemp(path.join(tmpdir(), "penguin-bg-"));
+    const env = new Environment({
+      workspaceDir: dir,
+      toolConfig: { customTools: [SUB_DEF], mcpServers: [] },
+      services: { subagentRunner: gatedRunner(gates) },
+    });
+    cleanups.push(async () => {
+      env.dispose();
+      await rm(dir, { recursive: true, force: true });
+    });
+    const llm = new ReplyLLM();
+    const session = new Session({
+      meta: META,
+      ...IMAGES,
+      bootstrap: async () => ({ llm }),
+      environment: env,
+    });
+    let signaled = 0;
+    session.onBackgroundNotice(() => {
+      signaled += 1;
+    });
+    const running = () =>
+      env.listBackgroundSubagents().filter((s) => s.running && s.subagentId !== null);
+    const statusOf = (msg: OmniMessage): string =>
+      parseBackgroundTaskDoneMessage((msg.payload as TextPayload).text)!.done.status;
+
+    for (const prompt of ["alpha", "beta", "gamma"]) {
+      const res = await runTool(env, "run_subagent", { prompt, run_in_background: true });
+      expect(res.stopReason).toBe("completed");
+    }
+    await waitFor(() => gates.size === 3);
+    expect(running()).toHaveLength(3);
+
+    // Idle path: alpha settles while no Task runs — the host takes the notice and submits it
+    // as a Task of its own, the way the server's idle-arrival signal does.
+    gates.get("alpha")!();
+    await waitFor(() => signaled === 1);
+    const notices = session.takeBackgroundNotices();
+    expect(notices).toHaveLength(1);
+    expect(statusOf(notices[0]!)).toBe("completed");
+    for await (const msg of session.run(notices)) void msg;
+    expect(llm.calls).toBe(1);
+    expect(running()).toHaveLength(2);
+    expect(env.hasRunningBackgroundSubagents()).toBe(true);
+
+    // Steering path: beta settles while a Task runs — the engine drains the notice into that
+    // Task at its next boundary, and the host is never signaled.
+    let released = false;
+    for await (const msg of session.run([userText("how are they doing?")])) {
+      void msg;
+      if (!released) {
+        released = true;
+        gates.get("beta")!();
+        await waitFor(() => session.hasPendingBackgroundNotices());
+      }
+    }
+    expect(llm.calls).toBe(3);
+    const steered = llm.inputs[2]!.map((m) => (m.payload as { text?: string }).text ?? "");
+    expect(steered).toHaveLength(1);
+    expect(isSteeredBackgroundNotice(steered[0]!)).toBe(true);
+    expect(parseBackgroundTaskDoneMessage(steered[0]!)!.done.status).toBe("completed");
+    expect(signaled).toBe(1);
+    expect(running()).toHaveLength(1);
+    expect(env.hasRunningBackgroundSubagents()).toBe(true);
+
+    // The last child still ends on its own terms: completed, neither stopped nor failed.
+    gates.get("gamma")!();
+    await waitFor(() => signaled === 2);
+    const last = session.takeBackgroundNotices();
+    expect(last).toHaveLength(1);
+    expect(statusOf(last[0]!)).toBe("completed");
+    expect(running()).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
For #581 (a background subagent's completion notice reportedly interrupts the other subagents still running). No runtime change: this adds the test that pins the contract, after an audit found no path by which a sibling's notice can end a child's run.

## What the test does

Three `run_in_background` children on one real `Environment` + `Session` (scripted runner, per-child gates). One child settles while the Session is idle — the host takes the notice and runs it as a Task, exactly as the server's idle-arrival signal does; another settles while a Task runs — the engine drains the notice into that Task at its next boundary and the host is not signaled. After each delivery the remaining children are still running (`listBackgroundSubagents`, `hasRunningBackgroundSubagents`), and the last one ends `completed` on its own.

## What the audit covered

Every call site that ends a background child's run: the foreground collect window's abort and its `finally` (foreground only), `input_subagent` `abort: true`, the panel's stop, registry eviction (`makeRoom` never evicts a running child), and `Environment.dispose` (session/agent/project deletion, shutdown, and idle eviction — which running children and pending notices pin). Context rotation after a compaction re-equips the same Environment. A parent Task's end denies only the main session's pending approvals (`denyMain`); a child's escalated approval carries its origin and stays pending. The web topology already treats an idle-launched notice as part of the launching Task.

## Verification

Remote test host (Node 24.20): `packages/core/test/background-execution.test.ts` — 34 passed (the new case included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZVj41ZVxRkykzhyApifDY